### PR TITLE
Bruker hooks for å forhindre at rerenders ødelegger bruk av textareas

### DIFF
--- a/packages/fakta-medisinsk-vilkar/src/components/KontinuerligTilsynOgPleie.tsx
+++ b/packages/fakta-medisinsk-vilkar/src/components/KontinuerligTilsynOgPleie.tsx
@@ -119,6 +119,7 @@ const KontinuerligTilsynOgPleie: React.FunctionComponent<KontinuerligTilsynOgPle
           readOnly={readOnly}
         >
           {(periodeMedBehovForKontinuerligTilsynId, index) => {
+            // Finner initial state for radioknappene
             const harBehovForToOmsorgspersonerHelePerioden =
               fields.get(index).behovForToOmsorgspersoner === MedisinskVilkårConsts.JA_HELE;
             const harBehovForToOmsorgspersonerDelerAvPerioden =
@@ -184,7 +185,6 @@ const KontinuerligTilsynOgPleie: React.FunctionComponent<KontinuerligTilsynOgPle
 
       <FieldArray
         name={MedisinskVilkårConsts.PERIODER_MED_KONTINUERLIG_TILSYN_OG_PLEIE}
-        rerenderOnEveryChange
         component={renderTilsynsperiodeFieldArray}
         props={{ readOnly }}
       />

--- a/packages/fakta-medisinsk-vilkar/src/components/Tilsynsperioder.tsx
+++ b/packages/fakta-medisinsk-vilkar/src/components/Tilsynsperioder.tsx
@@ -12,7 +12,7 @@ import MedisinskVilkårConsts from '@k9-sak-web/types/src/medisinsk-vilkår/Medi
 import moment, { Moment } from 'moment';
 import { Knapp } from 'nav-frontend-knapper';
 import { Element } from 'nav-frontend-typografi';
-import React from 'react';
+import React, { useState } from 'react';
 import { FormattedMessage } from 'react-intl';
 import MedisinskVilkårValues from '../types/MedisinskVilkårValues';
 import styles from './tilsynsperioder.less';
@@ -53,189 +53,220 @@ const Tilsynsperioder: React.FunctionComponent<TilsynsperioderProps> = React.mem
     valgtPeriodeMedBehovForKontinuerligTilsynOgPleieTom,
     sammenhengMellomSykdomOgTilsyn,
     brukSoknadsdato,
-  }) => (
-    <div className={styles.tilsynContainer}>
-      <PeriodePolse theme="warn" hideIcon>
-        <div className={styles.periodeContainer}>
-          <FlexRow wrap>
-            <FlexColumn>
-              <HeadingMedHjelpetekst
-                headingId="MedisinskVilkarForm.BehovForKontinuerligTilsynOgPleie"
-                helpTextId={[
-                  'MedisinskVilkarForm.BehovForKontinuerligTilsynOgPleieHjelpetekstOne',
-                  'MedisinskVilkarForm.BehovForKontinuerligTilsynOgPleieHjelpetekstTwo',
-                ]}
-              />
-              <VerticalSpacer eightPx />
-              <TextAreaField
-                name={`${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.BEGRUNNELSE}`}
-                label={{ id: 'MedisinskVilkarForm.Begrunnelse' }}
-                validate={[required, minLength(3), maxLength(2000), hasValidText]}
-                readOnly={readOnly}
-              />
-              <VerticalSpacer eightPx />
-              <RadioGroupField
-                name={`${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårValues.HAR_BEHOV_FOR_KONTINUERLIG_TILSYN_OG_PLEIE}`}
-                bredde="M"
-                validate={[required]}
-                readOnly={readOnly}
-                direction="vertical"
-              >
-                <RadioOption label={{ id: 'MedisinskVilkarForm.RadioknappJaBehovForKontinuerligTilsyn' }} value />
-                <RadioOption
-                  label={{ id: 'MedisinskVilkarForm.RadioknappNeiBehovForKontinuerligTilsyn' }}
-                  value={false}
-                />
-              </RadioGroupField>
-            </FlexColumn>
-          </FlexRow>
-          {harBehovForKontinuerligTilsynOgPleie && (
+  }) => {
+    const [harBehovForKontinuerligTilsynOgPleieState, setHarBehovForKontinuerligTilsynOgPleieState] = useState(
+      harBehovForKontinuerligTilsynOgPleie,
+    );
+    const [
+      harBehovForToOmsorgspersonerDelerAvPeriodenState,
+      setHarBehovForToOmsorgspersonerDelerAvPeriodenState,
+    ] = useState(harBehovForToOmsorgspersonerDelerAvPerioden);
+
+    const [harBehovForToOmsorgspersonerHelePeriodenState, setHarBehovForToOmsorgspersonerHelePeriodenState] = useState(
+      harBehovForToOmsorgspersonerHelePerioden,
+    );
+
+    const [sammenhengMellomSykdomOgTilsynState, setSammenhengMellomSykdomOgTilsynState] = useState(
+      sammenhengMellomSykdomOgTilsyn,
+    );
+
+    const onHarBehovForKontinuerligTilsynOgPleieChange = value => setHarBehovForKontinuerligTilsynOgPleieState(value);
+
+    const onHarBehovForToOmsorgspersonerChange = value => {
+      setHarBehovForToOmsorgspersonerDelerAvPeriodenState(value === MedisinskVilkårConsts.JA_DELER);
+      setHarBehovForToOmsorgspersonerHelePeriodenState(value === MedisinskVilkårConsts.JA_HELE);
+    };
+
+    const onSammenhengMellomSykdomOgTilsynChange = value => setSammenhengMellomSykdomOgTilsynState(value);
+
+    return (
+      <div className={styles.tilsynContainer}>
+        <PeriodePolse theme="warn" hideIcon>
+          <div className={styles.periodeContainer}>
             <FlexRow wrap>
               <FlexColumn>
-                <VerticalSpacer twentyPx />
                 <HeadingMedHjelpetekst
-                  headingId="MedisinskVilkarForm.SammenhengMellomSykdomOgTilsyn"
-                  helpTextId="MedisinskVilkarForm.SammenhengSykdomOgPleieHjelpetekst"
+                  headingId="MedisinskVilkarForm.BehovForKontinuerligTilsynOgPleie"
+                  helpTextId={[
+                    'MedisinskVilkarForm.BehovForKontinuerligTilsynOgPleieHjelpetekstOne',
+                    'MedisinskVilkarForm.BehovForKontinuerligTilsynOgPleieHjelpetekstTwo',
+                  ]}
                 />
                 <VerticalSpacer eightPx />
                 <TextAreaField
-                  name={`${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.SAMMENG_MELLOM_SYKDOM_OG_TILSYN_BEGRUNNELSE}`}
+                  name={`${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.BEGRUNNELSE}`}
                   label={{ id: 'MedisinskVilkarForm.Begrunnelse' }}
                   validate={[required, minLength(3), maxLength(2000), hasValidText]}
                   readOnly={readOnly}
                 />
                 <VerticalSpacer eightPx />
                 <RadioGroupField
-                  name={`${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.SAMMENHENG_MELLOM_SYKDOM_OG_TILSYN}`}
+                  name={`${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårValues.HAR_BEHOV_FOR_KONTINUERLIG_TILSYN_OG_PLEIE}`}
                   bredde="M"
                   validate={[required]}
                   readOnly={readOnly}
                   direction="vertical"
+                  onChange={onHarBehovForKontinuerligTilsynOgPleieChange}
                 >
+                  <RadioOption label={{ id: 'MedisinskVilkarForm.RadioknappJaBehovForKontinuerligTilsyn' }} value />
                   <RadioOption
-                    label={{ id: 'MedisinskVilkarForm.RadioknappJaSammenhengSykdomOgKontinuerligTilsyn' }}
-                    value
-                  />
-                  <RadioOption
-                    label={{ id: 'MedisinskVilkarForm.RadioknappNeiSammenhengSykdomOgKontinuerligTilsyn' }}
+                    label={{ id: 'MedisinskVilkarForm.RadioknappNeiBehovForKontinuerligTilsyn' }}
                     value={false}
                   />
                 </RadioGroupField>
               </FlexColumn>
             </FlexRow>
-          )}
-          {harBehovForKontinuerligTilsynOgPleie && sammenhengMellomSykdomOgTilsyn && (
-            <>
-              <VerticalSpacer twentyPx />
-              <Element>
-                <FormattedMessage id="MedisinskVilkarForm.BehovForKontinuerligTilsynOgPleie.Perioder" />
-              </Element>
+            {harBehovForKontinuerligTilsynOgPleieState && (
               <FlexRow wrap>
                 <FlexColumn>
+                  <VerticalSpacer twentyPx />
+                  <HeadingMedHjelpetekst
+                    headingId="MedisinskVilkarForm.SammenhengMellomSykdomOgTilsyn"
+                    helpTextId="MedisinskVilkarForm.SammenhengSykdomOgPleieHjelpetekst"
+                  />
+                  <VerticalSpacer eightPx />
+                  <TextAreaField
+                    name={`${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.SAMMENG_MELLOM_SYKDOM_OG_TILSYN_BEGRUNNELSE}`}
+                    label={{ id: 'MedisinskVilkarForm.Begrunnelse' }}
+                    validate={[required, minLength(3), maxLength(2000), hasValidText]}
+                    readOnly={readOnly}
+                  />
+                  <VerticalSpacer eightPx />
+                  <RadioGroupField
+                    name={`${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.SAMMENHENG_MELLOM_SYKDOM_OG_TILSYN}`}
+                    bredde="M"
+                    validate={[required]}
+                    readOnly={readOnly}
+                    direction="vertical"
+                    onChange={onSammenhengMellomSykdomOgTilsynChange}
+                  >
+                    <RadioOption
+                      label={{ id: 'MedisinskVilkarForm.RadioknappJaSammenhengSykdomOgKontinuerligTilsyn' }}
+                      value
+                    />
+                    <RadioOption
+                      label={{ id: 'MedisinskVilkarForm.RadioknappNeiSammenhengSykdomOgKontinuerligTilsyn' }}
+                      value={false}
+                    />
+                  </RadioGroupField>
+                </FlexColumn>
+              </FlexRow>
+            )}
+            {harBehovForKontinuerligTilsynOgPleieState && sammenhengMellomSykdomOgTilsynState && (
+              <>
+                <VerticalSpacer twentyPx />
+                <Element>
+                  <FormattedMessage id="MedisinskVilkarForm.BehovForKontinuerligTilsynOgPleie.Perioder" />
+                </Element>
+                <FlexRow wrap>
+                  <FlexColumn>
+                    <PeriodpickerField
+                      names={[
+                        `${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.FOM}`,
+                        `${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.TOM}`,
+                      ]}
+                      validate={[required, hasValidDate, dateRangesNotOverlapping]}
+                      defaultValue={null}
+                      readOnly={readOnly}
+                      label={{ id: 'MedisinskVilkarForm.Periode' }}
+                      disabledDays={{
+                        before: getMomentConvertedDate(datoBegrensningFom),
+                        after: getMomentConvertedDate(datoBegrensningTom),
+                      }}
+                    />
+                  </FlexColumn>
+                  <FlexColumn>
+                    <div className={styles.sokandsperiodeButtonContainer}>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          brukSoknadsdato(
+                            `${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.FOM}`,
+                            `${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.TOM}`,
+                          )
+                        }
+                        className={styles.soknadsperiodeButton}
+                      >
+                        <FormattedMessage id="MedisinskVilkarForm.BrukPeriodenTilVurdering" />
+                      </button>
+                    </div>
+                  </FlexColumn>
+                </FlexRow>
+                <FlexRow>
+                  <FlexColumn>
+                    <VerticalSpacer twentyPx />
+                    <Element>
+                      <FormattedMessage id="MedisinskVilkarForm.BehovForEnEllerToOmsorgspersoner" />
+                    </Element>
+                    <VerticalSpacer eightPx />
+                    <RadioGroupField
+                      name={`${periodeMedBehovForKontinuerligTilsynId}.behovForToOmsorgspersoner`}
+                      bredde="M"
+                      validate={[required]}
+                      readOnly={readOnly}
+                      direction="vertical"
+                      onChange={onHarBehovForToOmsorgspersonerChange}
+                    >
+                      <RadioOption
+                        label={{ id: 'MedisinskVilkarForm.RadioknappNei' }}
+                        value={MedisinskVilkårConsts.NEI}
+                      />
+                      <RadioOption
+                        label={{ id: 'MedisinskVilkarForm.RadioknappJaHele' }}
+                        value={MedisinskVilkårConsts.JA_HELE}
+                      />
+                      <RadioOption
+                        label={{ id: 'MedisinskVilkarForm.RadioknappJaDeler' }}
+                        value={MedisinskVilkårConsts.JA_DELER}
+                      />
+                    </RadioGroupField>
+                    {harBehovForToOmsorgspersonerDelerAvPeriodenState ||
+                    harBehovForToOmsorgspersonerHelePeriodenState ? (
+                      <>
+                        <VerticalSpacer fourPx />
+                        <TextAreaField
+                          name={`${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.BEGRUNNELSE_UTVIDET}`}
+                          label={{ id: 'MedisinskVilkarForm.Begrunnelse' }}
+                          validate={[required, minLength(3), maxLength(2000), hasValidText]}
+                          readOnly={readOnly}
+                        />
+                      </>
+                    ) : null}
+                  </FlexColumn>
+                </FlexRow>
+                {harBehovForToOmsorgspersonerDelerAvPeriodenState && (
                   <PeriodpickerField
                     names={[
-                      `${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.FOM}`,
-                      `${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.TOM}`,
+                      `${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.PERIODER_MED_UTVIDET_KONTINUERLIG_TILSYN_OG_PLEIE}.fom`,
+                      `${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.PERIODER_MED_UTVIDET_KONTINUERLIG_TILSYN_OG_PLEIE}.tom`,
                     ]}
                     validate={[required, hasValidDate, dateRangesNotOverlapping]}
                     defaultValue={null}
                     readOnly={readOnly}
                     label={{ id: 'MedisinskVilkarForm.Periode' }}
                     disabledDays={{
-                      before: getMomentConvertedDate(datoBegrensningFom),
-                      after: getMomentConvertedDate(datoBegrensningTom),
+                      before: moment(valgtPeriodeMedBehovForKontinuerligTilsynOgPleieFom).toDate(),
+                      after: moment(valgtPeriodeMedBehovForKontinuerligTilsynOgPleieTom).toDate(),
                     }}
+                    renderUpwards
                   />
-                </FlexColumn>
-                <FlexColumn>
-                  <div className={styles.sokandsperiodeButtonContainer}>
-                    <button
-                      type="button"
-                      onClick={() =>
-                        brukSoknadsdato(
-                          `${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.FOM}`,
-                          `${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.TOM}`,
-                        )
-                      }
-                      className={styles.soknadsperiodeButton}
-                    >
-                      <FormattedMessage id="MedisinskVilkarForm.BrukPeriodenTilVurdering" />
-                    </button>
-                  </div>
-                </FlexColumn>
-              </FlexRow>
+                )}
+              </>
+            )}
+            {showCancelButton && (
               <FlexRow>
                 <FlexColumn>
-                  <VerticalSpacer twentyPx />
-                  <Element>
-                    <FormattedMessage id="MedisinskVilkarForm.BehovForEnEllerToOmsorgspersoner" />
-                  </Element>
-                  <VerticalSpacer eightPx />
-                  <RadioGroupField
-                    name={`${periodeMedBehovForKontinuerligTilsynId}.behovForToOmsorgspersoner`}
-                    bredde="M"
-                    validate={[required]}
-                    readOnly={readOnly}
-                    direction="vertical"
-                  >
-                    <RadioOption
-                      label={{ id: 'MedisinskVilkarForm.RadioknappNei' }}
-                      value={MedisinskVilkårConsts.NEI}
-                    />
-                    <RadioOption
-                      label={{ id: 'MedisinskVilkarForm.RadioknappJaHele' }}
-                      value={MedisinskVilkårConsts.JA_HELE}
-                    />
-                    <RadioOption
-                      label={{ id: 'MedisinskVilkarForm.RadioknappJaDeler' }}
-                      value={MedisinskVilkårConsts.JA_DELER}
-                    />
-                  </RadioGroupField>
-                  {harBehovForToOmsorgspersonerDelerAvPerioden || harBehovForToOmsorgspersonerHelePerioden ? (
-                    <>
-                      <VerticalSpacer fourPx />
-                      <TextAreaField
-                        name={`${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.BEGRUNNELSE_UTVIDET}`}
-                        label={{ id: 'MedisinskVilkarForm.Begrunnelse' }}
-                        validate={[required, minLength(3), maxLength(2000), hasValidText]}
-                        readOnly={readOnly}
-                      />
-                    </>
-                  ) : null}
+                  <Knapp mini htmlType="button" onClick={() => removeIndex(index)} disabled={false}>
+                    <FormattedMessage id="MedisinskVilkarForm.BehovForTo.Avbryt" />
+                  </Knapp>
                 </FlexColumn>
               </FlexRow>
-              {harBehovForToOmsorgspersonerDelerAvPerioden && (
-                <PeriodpickerField
-                  names={[
-                    `${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.PERIODER_MED_UTVIDET_KONTINUERLIG_TILSYN_OG_PLEIE}.fom`,
-                    `${periodeMedBehovForKontinuerligTilsynId}.${MedisinskVilkårConsts.PERIODER_MED_UTVIDET_KONTINUERLIG_TILSYN_OG_PLEIE}.tom`,
-                  ]}
-                  validate={[required, hasValidDate, dateRangesNotOverlapping]}
-                  defaultValue={null}
-                  readOnly={readOnly}
-                  label={{ id: 'MedisinskVilkarForm.Periode' }}
-                  disabledDays={{
-                    before: moment(valgtPeriodeMedBehovForKontinuerligTilsynOgPleieFom).toDate(),
-                    after: moment(valgtPeriodeMedBehovForKontinuerligTilsynOgPleieTom).toDate(),
-                  }}
-                  renderUpwards
-                />
-              )}
-            </>
-          )}
-          {showCancelButton && (
-            <FlexRow>
-              <FlexColumn>
-                <Knapp mini htmlType="button" onClick={() => removeIndex(index)} disabled={false}>
-                  <FormattedMessage id="MedisinskVilkarForm.BehovForTo.Avbryt" />
-                </Knapp>
-              </FlexColumn>
-            </FlexRow>
-          )}
-        </div>
-      </PeriodePolse>
-    </div>
-  ),
+            )}
+          </div>
+        </PeriodePolse>
+      </div>
+    );
+  },
 );
 
 export default Tilsynsperioder;

--- a/packages/form/src/RadioGroupField.tsx
+++ b/packages/form/src/RadioGroupField.tsx
@@ -24,6 +24,7 @@ interface RadioGroupFieldProps {
   DOMName?: string;
   validate?: ((value: string) => boolean | undefined)[] | ((value: string) => boolean | undefined);
   readOnly?: boolean;
+  onChange?: (value: string) => void;
 }
 
 const classNames = classnames.bind(styles);


### PR DESCRIPTION
Dersom man bruker rerenderOnEveryChange på FieldArray og props fra KontinuerligTilsyn  i TilsynsPerioder blir textareas "umulig" å redigere pga konstante renders. Dersom man fjerner rerenderOnEveryChange blir ikke ting vist/skjult riktig fordi radioknappene ikke trigger rerender. Dette har blitt løst med hooks