### PR TITLE
Fletter sammen kodeverk fra k9-sak og k9-klage

### DIFF
--- a/packages/sak-app/src/kodeverk/duck.jsx
+++ b/packages/sak-app/src/kodeverk/duck.jsx
@@ -10,7 +10,7 @@ export const getAlleFpSakKodeverk = createSelector(
 
       const sammenflettedeKodeverk = {};
 
-      // Går igjennom kodeverkene fra k9-sak og for å flette de sammen med tilsvarende kodeverk i k9-klage
+      // Går igjennom kodeverkene fra k9-sak for å flette dem sammen med tilsvarende kodeverk i k9-klage
       Object.keys(kodeverk_sak).forEach((kv) => {
 
         if (!!kodeverk_klage[kv] && Array.isArray(kodeverk_klage[kv]) && Array.isArray(kodeverk_sak[kv])) {

--- a/packages/sak-app/src/kodeverk/duck.jsx
+++ b/packages/sak-app/src/kodeverk/duck.jsx
@@ -5,16 +5,26 @@ import fpsakApi from '../data/fpsakApi';
 export const getAlleFpSakKodeverk = createSelector(
   [fpsakApi.KODEVERK.getRestApiData(), fpsakApi.KODEVERK_KLAGE.getRestApiData()],
   (kodeverk_sak = {}, kodeverk_klage = {}) => {
+
     if (Object.keys(kodeverk_klage).length) {
+
       const sammenflettedeKodeverk = {};
+
+      // Går igjennom kodeverkene fra k9-sak og for å flette de sammen med tilsvarende kodeverk i k9-klage
       Object.keys(kodeverk_sak).forEach((kv) => {
+
         if (!!kodeverk_klage[kv] && Array.isArray(kodeverk_klage[kv]) && Array.isArray(kodeverk_sak[kv])) {
+
+          // Fletter sammen kodeverk som heter det samme i k9-sak og k9-klage
           const koder = new Set(kodeverk_sak[kv].map(k => k.kode));
           sammenflettedeKodeverk[kv] = [...kodeverk_sak[kv], ...kodeverk_klage[kv].filter(k => !koder.has(k.kode))];
         } else {
+
+          // Tar k9-sak sin versjon hvis det ikke finnes noe kodeverk med samme navn i klage
           sammenflettedeKodeverk[kv] = kodeverk_sak[kv];
         }
       });
+
       return {...kodeverk_klage, ...sammenflettedeKodeverk};
     }
     return kodeverk_sak;

--- a/packages/sak-app/src/kodeverk/duck.jsx
+++ b/packages/sak-app/src/kodeverk/duck.jsx
@@ -4,7 +4,21 @@ import fpsakApi from '../data/fpsakApi';
 /* Selectors */
 export const getAlleFpSakKodeverk = createSelector(
   [fpsakApi.KODEVERK.getRestApiData(), fpsakApi.KODEVERK_KLAGE.getRestApiData()],
-  (kodeverk_sak = {}, kodeverk_klage = {}) => ({...kodeverk_klage, ...kodeverk_sak})
+  (kodeverk_sak = {}, kodeverk_klage = {}) => {
+    if (Object.keys(kodeverk_klage).length) {
+      const sammenflettedeKodeverk = {};
+      Object.keys(kodeverk_sak).forEach((kv) => {
+        if (!!kodeverk_klage[kv] && Array.isArray(kodeverk_klage[kv]) && Array.isArray(kodeverk_sak[kv])) {
+          const koder = new Set(kodeverk_sak[kv].map(k => k.kode));
+          sammenflettedeKodeverk[kv] = [...kodeverk_sak[kv], ...kodeverk_klage[kv].filter(k => !koder.has(k.kode))];
+        } else {
+          sammenflettedeKodeverk[kv] = kodeverk_sak[kv];
+        }
+      });
+      return {...kodeverk_klage, ...sammenflettedeKodeverk};
+    }
+    return kodeverk_sak;
+  }
 );
 export const getAlleFpTilbakeKodeverk = createSelector(
   [fpsakApi.KODEVERK_FPTILBAKE.getRestApiData()],


### PR DESCRIPTION
Kodeverkene må flettes dypere sammen, slik at man f.eks. får med alle behandlingstyper.