### PR TITLE
Oms/uttak fixes

### DIFF
--- a/packages/assets/images/information-circle.svg
+++ b/packages/assets/images/information-circle.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 16.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Filled_Version" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink"
+     x="0px" fill="#0067C5"
+     y="0px" width="24px" height="24px" viewBox="0 0 24 24" enable-background="new 0 0 24 24" xml:space="preserve">
+  <path d="M11.5,1C5.158,1,0,6.158,0,12.5S5.158,24,11.5,24C17.841,24,23,18.842,23,12.5S17.841,1,11.5,1z M11,6c0.551,0,1,0.448,1,1
+    c0,0.553-0.449,1-1,1c-0.553,0-1-0.447-1-1C10,6.448,10.447,6,11,6z M14.5,20h-6C8.224,20,8,19.776,8,19.5S8.224,19,8.5,19H11v-8
+    H9.5C9.224,11,9,10.776,9,10.5S9.224,10,9.5,10h2c0.275,0,0.5,0.224,0.5,0.5V19h2.5c0.275,0,0.5,0.224,0.5,0.5S14.775,20,14.5,20z"
+  />
+</svg>

--- a/packages/prosess-aarskvantum-oms/i18n/nb_NO.json
+++ b/packages/prosess-aarskvantum-oms/i18n/nb_NO.json
@@ -1,9 +1,12 @@
 {
   "Årskvantum.Heading": "Årskvantum nøkkeltall",
   "Årskvantum.Rammemelding": "Det er benyttet rammemelding for behandlingen",
+  "Årskvantum.Timer": "{timer}t",
   "Årskvantum.TotaleDager": "Totale dager",
   "Årskvantum.ForbrukteDager": "Forbrukte dager",
   "Årskvantum.Restdager": "Restdager",
+  "Årskvantum.Smittevernsdager": "Smittevernsdager",
+  "Årskvantum.Smittevernsdager.EkstraTekst": "Kommer i tillegg til totale dager",
   "Årskvantum.TotaldagerInfo": "{totaltAntallDager} dager, {antallDagerArbeidsgiverDekker} dekket av arbeidsgiver",
   "Årskvantum.DagerFraInfotrygd": "{dager} dager utbetalt fra Infotrygd",
   "Årskvantum.DagerOgTimerFraInfotrygd": "{dager} dager, {timer}t utbetalt fra Infotrygd",

--- a/packages/prosess-aarskvantum-oms/i18n/nb_NO.json
+++ b/packages/prosess-aarskvantum-oms/i18n/nb_NO.json
@@ -1,5 +1,6 @@
 {
   "Årskvantum.Heading": "Årskvantum nøkkeltall",
+  "Årskvantum.Rammemelding": "Det er benyttet rammemelding for behandlingen",
   "Årskvantum.TotaleDager": "Totale dager",
   "Årskvantum.ForbrukteDager": "Forbrukte dager",
   "Årskvantum.Restdager": "Restdager",

--- a/packages/prosess-aarskvantum-oms/src/components/AktivitetTabell.tsx
+++ b/packages/prosess-aarskvantum-oms/src/components/AktivitetTabell.tsx
@@ -115,13 +115,24 @@ const AktivitetTabell: FunctionComponent<AktivitetTabellProps> = ({
           arbeidsforhold.type}
       </Element>
       <Table
-        headerTextCodes={[
-          'Uttaksplan.Periode',
-          'Uttaksplan.Fravær',
-          'Uttaksplan.Utfall',
-          'Uttaksplan.Utbetalingsgrad',
-          'EMPTY',
-        ]}
+        suppliedHeaders={
+          <>
+            <StyledColumn width="30%">
+              <FormattedMessage id="Uttaksplan.Periode" />
+            </StyledColumn>
+            <StyledColumn width="30%">
+              <FormattedMessage id="Uttaksplan.Fravær" />
+            </StyledColumn>
+            <StyledColumn width="20%">
+              <FormattedMessage id="Uttaksplan.Utfall" />
+            </StyledColumn>
+            <StyledColumn width="15%">
+              <FormattedMessage id="Uttaksplan.Utbetalingsgrad" />
+            </StyledColumn>
+            <StyledColumn width="5%" />
+          </>
+        }
+        allowFormattedHeader
         stripet
         noHover
       >

--- a/packages/prosess-aarskvantum-oms/src/components/CounterBox.tsx
+++ b/packages/prosess-aarskvantum-oms/src/components/CounterBox.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode } from 'react';
 import styled from 'styled-components';
 
-type Theme = 'standard' | 'rød' | 'grønn';
+type Theme = 'standard' | 'rød' | 'grønn' | 'lyseblå' | 'oransje';
 
 const farger = {
   rød: {
@@ -12,6 +12,14 @@ const farger = {
     border: '#06893A',
     background: '#CDE7D8',
   },
+  lyseblå: {
+    border: '#66CBEC',
+    background: '#E0F5FB',
+  },
+  oransje: {
+    border: '#FFA733',
+    background: '#FFE9CC',
+  },
   standard: {
     border: '#78706A',
     background: 'inherit',
@@ -20,7 +28,7 @@ const farger = {
 
 interface CounterBoxProps {
   bigCount: string | number;
-  smallCount?: string | number;
+  smallCount?: string | number | ReactNode;
   label: string | ReactNode;
   theme: Theme;
   bottomText?: string | ReactNode;

--- a/packages/prosess-aarskvantum-oms/src/components/StyledColumn.tsx
+++ b/packages/prosess-aarskvantum-oms/src/components/StyledColumn.tsx
@@ -1,12 +1,17 @@
 import styled from 'styled-components';
 
-const StyledColumn = styled.td<{ koronaperiode?: boolean; first?: boolean }>`
+const StyledColumn = styled.td<{ koronaperiode?: boolean; first?: boolean; width?: string }>`
   border-bottom: 1px solid ${({ koronaperiode }) => (koronaperiode ? '#FFA733' : '#b7b1a9')};
   line-height: 1.42857143;
   padding: 8px;
   text-align: left;
   vertical-align: top;
   position: relative;
+  ${({ width }) =>
+    width &&
+    `
+    width: ${width};
+  `}
 
   ${({ koronaperiode, first }) =>
     koronaperiode &&

--- a/packages/prosess-aarskvantum-oms/src/components/Årskvantum.spec.tsx
+++ b/packages/prosess-aarskvantum-oms/src/components/Årskvantum.spec.tsx
@@ -9,19 +9,24 @@ const sjekkKonvertering = ({ dager, timer }, expectedDager, expectedTimer) => {
   expect(timer).to.equal(expectedTimer);
 };
 
-it('rendrer 3 Counterbox med riktig info', () => {
-  const wrapper = shallow(
-    <Årskvantum
-      totaltAntallDager={20}
-      antallDagerArbeidsgiverDekker={3}
-      forbrukteDager={4.4}
-      restdager={12.6}
-      benyttetRammemelding
-      antallDagerInfotrygd={0}
-    />,
-  );
-  const bokser = wrapper.find(CounterBox);
-  expect(bokser).to.have.length(3);
+it('rendrer smittevern hvis restdager er nagativt, ellers ikke', () => {
+  const wrapper = restdager =>
+    shallow(
+      <Årskvantum
+        totaltAntallDager={20}
+        antallDagerArbeidsgiverDekker={3}
+        forbrukteDager={4.4}
+        restdager={restdager}
+        benyttetRammemelding
+        antallDagerInfotrygd={0}
+      />,
+    );
+
+  const bokserUtenSmittevern = wrapper(12).find(CounterBox);
+  expect(bokserUtenSmittevern).to.have.length(3);
+
+  const bokserMedSmittevern = wrapper(-12).find(CounterBox);
+  expect(bokserMedSmittevern).to.have.length(4);
 });
 
 it('konverterer desimaltall til hele dager og timer med max 1 desimal', () => {

--- a/packages/prosess-aarskvantum-oms/src/components/Årskvantum.spec.tsx
+++ b/packages/prosess-aarskvantum-oms/src/components/Årskvantum.spec.tsx
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import React from 'react';
+import { shallow } from 'enzyme';
 import Årskvantum, { konverterDesimalTilDagerOgTimer } from './Årskvantum';
-import { shallowWithIntl } from '../../i18n/intl-enzyme-test-helper-uttaksplan';
 import CounterBox from './CounterBox';
 
 const sjekkKonvertering = ({ dager, timer }, expectedDager, expectedTimer) => {
@@ -10,8 +10,15 @@ const sjekkKonvertering = ({ dager, timer }, expectedDager, expectedTimer) => {
 };
 
 it('rendrer 3 Counterbox med riktig info', () => {
-  const wrapper = shallowWithIntl(
-    <Årskvantum totaltAntallDager={20} antallDagerArbeidsgiverDekker={3} forbrukteDager={4.4} restdager={12.6} />,
+  const wrapper = shallow(
+    <Årskvantum
+      totaltAntallDager={20}
+      antallDagerArbeidsgiverDekker={3}
+      forbrukteDager={4.4}
+      restdager={12.6}
+      benyttetRammemelding
+      antallDagerInfotrygd={0}
+    />,
   );
   const bokser = wrapper.find(CounterBox);
   expect(bokser).to.have.length(3);

--- a/packages/prosess-aarskvantum-oms/src/components/Årskvantum.tsx
+++ b/packages/prosess-aarskvantum-oms/src/components/Årskvantum.tsx
@@ -25,7 +25,7 @@ const CounterContainer = styled.div`
   }
 `;
 
-export const InfoRammemelding = styled.span`
+const InfoRammemelding = styled.span`
   font-size: 17px;
   font-weight: 400;
   display: flex;
@@ -55,9 +55,12 @@ const Årskvantum: FunctionComponent<ÅrskvantumProps> = ({
   antallDagerInfotrygd,
   benyttetRammemelding,
 }) => {
+  const restdagerErSmittevernsdager = restdager < 0;
+
   const forbrukt = konverterDesimalTilDagerOgTimer(forbrukteDager);
-  const rest = konverterDesimalTilDagerOgTimer(restdager);
+  const rest = restdagerErSmittevernsdager ? { dager: 0, timer: 0 } : konverterDesimalTilDagerOgTimer(restdager);
   const dagerInfotrygd = konverterDesimalTilDagerOgTimer(antallDagerInfotrygd);
+  const smittevernsdager = restdagerErSmittevernsdager && konverterDesimalTilDagerOgTimer(Math.abs(restdager));
 
   return (
     <BorderedContainer
@@ -90,9 +93,24 @@ const Årskvantum: FunctionComponent<ÅrskvantumProps> = ({
             />
           }
         />
+        {restdagerErSmittevernsdager && (
+          <CounterBox
+            bigCount={smittevernsdager.dager}
+            smallCount={
+              smittevernsdager.timer ? (
+                <FormattedMessage id="Årskvantum.Timer" values={{ timer: smittevernsdager.timer }} />
+              ) : null
+            }
+            label={<FormattedMessage id="Årskvantum.Smittevernsdager" />}
+            theme="lyseblå"
+            bottomText={<FormattedMessage id="Årskvantum.Smittevernsdager.EkstraTekst" />}
+          />
+        )}
         <CounterBox
           bigCount={forbrukt.dager}
-          smallCount={forbrukt.timer ? `${forbrukt.timer}t` : null}
+          smallCount={
+            forbrukt.timer ? <FormattedMessage id="Årskvantum.Timer" values={{ timer: forbrukt.timer }} /> : null
+          }
           label={<FormattedMessage id="Årskvantum.ForbrukteDager" />}
           theme="rød"
           bottomText={
@@ -108,7 +126,7 @@ const Årskvantum: FunctionComponent<ÅrskvantumProps> = ({
         />
         <CounterBox
           bigCount={rest.dager}
-          smallCount={rest.timer ? `${rest.timer}t` : null}
+          smallCount={rest.timer ? <FormattedMessage id="Årskvantum.Timer" values={{ timer: rest.timer }} /> : null}
           label={<FormattedMessage id="Årskvantum.Restdager" />}
           theme="grønn"
         />

--- a/packages/prosess-aarskvantum-oms/src/components/Årskvantum.tsx
+++ b/packages/prosess-aarskvantum-oms/src/components/Årskvantum.tsx
@@ -2,8 +2,9 @@ import React, { FunctionComponent } from 'react';
 import { FormattedMessage } from 'react-intl';
 import styled from 'styled-components';
 import Undertittel from 'nav-frontend-typografi/lib/undertittel';
-import { Image } from '@fpsak-frontend/shared-components/index';
+import { FlexRow, Image } from '@fpsak-frontend/shared-components/index';
 import pieChart from '@fpsak-frontend/assets/images/pie_chart.svg';
+import info from '@fpsak-frontend/assets/images/information-circle.svg';
 import CounterBox from './CounterBox';
 import BorderedContainer from './BorderedContainer';
 
@@ -13,6 +14,7 @@ interface ÅrskvantumProps {
   forbrukteDager: number;
   restdager: number;
   antallDagerInfotrygd: number;
+  benyttetRammemelding: boolean;
 }
 
 const CounterContainer = styled.div`
@@ -20,6 +22,18 @@ const CounterContainer = styled.div`
   flex-wrap: wrap;
   & > * {
     margin: 0.5em;
+  }
+`;
+
+export const InfoRammemelding = styled.span`
+  font-size: 17px;
+  font-weight: 400;
+  display: flex;
+  align-items: center;
+
+  & img {
+    width: 20px;
+    height: 20px;
   }
 `;
 
@@ -39,6 +53,7 @@ const Årskvantum: FunctionComponent<ÅrskvantumProps> = ({
   forbrukteDager,
   antallDagerArbeidsgiverDekker,
   antallDagerInfotrygd,
+  benyttetRammemelding,
 }) => {
   const forbrukt = konverterDesimalTilDagerOgTimer(forbrukteDager);
   const rest = konverterDesimalTilDagerOgTimer(restdager);
@@ -48,8 +63,18 @@ const Årskvantum: FunctionComponent<ÅrskvantumProps> = ({
     <BorderedContainer
       heading={
         <Undertittel tag="h3">
-          <Image src={pieChart} />
-          <FormattedMessage id="Årskvantum.Heading" />
+          <FlexRow spaceBetween>
+            <span>
+              <Image src={pieChart} />
+              <FormattedMessage id="Årskvantum.Heading" />
+            </span>
+            {benyttetRammemelding && (
+              <InfoRammemelding>
+                <Image src={info} />
+                <FormattedMessage id="Årskvantum.Rammemelding" />
+              </InfoRammemelding>
+            )}
+          </FlexRow>
         </Undertittel>
       }
     >

--- a/packages/prosess-aarskvantum-oms/src/dto/UttaksplanType.ts
+++ b/packages/prosess-aarskvantum-oms/src/dto/UttaksplanType.ts
@@ -5,6 +5,7 @@ interface UttaksplanType {
   behandlingUUID: string;
   innsendingstidspunkt: string;
   aktiviteter: Aktivitet[];
+  benyttetRammemelding: boolean;
 }
 
 export default UttaksplanType;

--- a/packages/prosess-aarskvantum-oms/src/dto/ÅrskvantumForbrukteDager.ts
+++ b/packages/prosess-aarskvantum-oms/src/dto/ÅrskvantumForbrukteDager.ts
@@ -5,7 +5,6 @@ interface ÅrskvantumForbrukteDager {
   antallDagerArbeidsgiverDekker: number;
   forbrukteDager: number;
   restdager: number;
-  benyttetRammemelding: boolean;
   antallDagerInfotrygd?: number;
   sisteUttaksplan: UttaksplanType;
 }

--- a/packages/prosess-aarskvantum-oms/src/dto/ÅrskvantumForbrukteDager.ts
+++ b/packages/prosess-aarskvantum-oms/src/dto/ÅrskvantumForbrukteDager.ts
@@ -5,6 +5,7 @@ interface ÅrskvantumForbrukteDager {
   antallDagerArbeidsgiverDekker: number;
   forbrukteDager: number;
   restdager: number;
+  benyttetRammemelding: boolean;
   antallDagerInfotrygd?: number;
   sisteUttaksplan: UttaksplanType;
 }

--- a/packages/prosess-aarskvantum-oms/src/ÅrskvantumIndex.tsx
+++ b/packages/prosess-aarskvantum-oms/src/ÅrskvantumIndex.tsx
@@ -31,7 +31,6 @@ const ÅrskvantumIndex: FunctionComponent<ÅrsakvantumIndexProps> = ({ årskvant
     antallDagerArbeidsgiverDekker,
     antallDagerInfotrygd = 0,
     sisteUttaksplan,
-    benyttetRammemelding,
   } = årskvantum;
   const aktivitetsstatuser = alleKodeverk[kodeverkTyper.AKTIVITET_STATUS];
 
@@ -43,7 +42,7 @@ const ÅrskvantumIndex: FunctionComponent<ÅrsakvantumIndexProps> = ({ årskvant
         forbrukteDager={forbrukteDager}
         antallDagerArbeidsgiverDekker={antallDagerArbeidsgiverDekker}
         antallDagerInfotrygd={antallDagerInfotrygd}
-        benyttetRammemelding={benyttetRammemelding}
+        benyttetRammemelding={sisteUttaksplan.benyttetRammemelding}
       />
       <VerticalSpacer sixteenPx />
       <Uttaksplan aktiviteter={sisteUttaksplan.aktiviteter} aktivitetsstatuser={aktivitetsstatuser} />

--- a/packages/prosess-aarskvantum-oms/src/ÅrskvantumIndex.tsx
+++ b/packages/prosess-aarskvantum-oms/src/ÅrskvantumIndex.tsx
@@ -31,6 +31,7 @@ const ÅrskvantumIndex: FunctionComponent<ÅrsakvantumIndexProps> = ({ årskvant
     antallDagerArbeidsgiverDekker,
     antallDagerInfotrygd = 0,
     sisteUttaksplan,
+    benyttetRammemelding,
   } = årskvantum;
   const aktivitetsstatuser = alleKodeverk[kodeverkTyper.AKTIVITET_STATUS];
 
@@ -42,6 +43,7 @@ const ÅrskvantumIndex: FunctionComponent<ÅrsakvantumIndexProps> = ({ årskvant
         forbrukteDager={forbrukteDager}
         antallDagerArbeidsgiverDekker={antallDagerArbeidsgiverDekker}
         antallDagerInfotrygd={antallDagerInfotrygd}
+        benyttetRammemelding={benyttetRammemelding}
       />
       <VerticalSpacer sixteenPx />
       <Uttaksplan aktiviteter={sisteUttaksplan.aktiviteter} aktivitetsstatuser={aktivitetsstatuser} />

--- a/packages/shared-components/src/table/Table.jsx
+++ b/packages/shared-components/src/table/Table.jsx
@@ -19,21 +19,38 @@ const isString = value => typeof value === 'string';
  *
  * Presentasjonskomponent. Definerer en tabell med rader og kolonner.
  */
-const Table = ({ headerTextCodes, allowFormattedHeader, classNameTable, children, noHover, stripet }) => (
+
+const headers = (headerTextCodes, allowFormattedHeader, suppliedHeaders) => {
+  if (suppliedHeaders) {
+    return suppliedHeaders;
+  }
+
+  return headerTextCodes.map(headerElement => {
+    if (isString(headerElement) && headerElement.startsWith(EMPTY_STRING)) {
+      return <TableColumn key={headerElement}>&nbsp;</TableColumn>;
+    }
+    return (
+      <TableColumn key={headerElement.key ? headerElement.key : headerElement}>
+        {allowFormattedHeader && headerElement}
+        {!allowFormattedHeader && <FormattedHTMLMessage id={headerElement} />}
+      </TableColumn>
+    );
+  });
+};
+
+const Table = ({
+  headerTextCodes,
+  allowFormattedHeader,
+  classNameTable,
+  children,
+  noHover,
+  stripet,
+  suppliedHeaders,
+}) => (
   <table className={classNames('table', { [classNameTable]: classNameTable, noHover, stripet })}>
     <thead>
       <TableRow isHeader noHover={noHover}>
-        {headerTextCodes.map(headerElement => {
-          if (isString(headerElement) && headerElement.startsWith(EMPTY_STRING)) {
-            return <TableColumn key={headerElement}>&nbsp;</TableColumn>;
-          }
-          return (
-            <TableColumn key={headerElement.key ? headerElement.key : headerElement}>
-              {allowFormattedHeader && headerElement}
-              {!allowFormattedHeader && <FormattedHTMLMessage id={headerElement} />}
-            </TableColumn>
-          );
-        })}
+        {headers(headerTextCodes, allowFormattedHeader, suppliedHeaders)}
       </TableRow>
     </thead>
     <tbody>
@@ -63,6 +80,7 @@ Table.propTypes = {
   noHover: PropTypes.bool,
   allowFormattedHeader: PropTypes.bool,
   stripet: PropTypes.bool,
+  suppliedHeaders: PropTypes.element,
 };
 
 Table.defaultProps = {

--- a/packages/storybook/stories/omsorgspenger/Uttaksplan.stories.tsx
+++ b/packages/storybook/stories/omsorgspenger/Uttaksplan.stories.tsx
@@ -22,6 +22,7 @@ const årskvantumDto: ÅrskvantumForbrukteDager = {
   forbrukteDager: 10.4,
   restdager: 9.6,
   antallDagerInfotrygd: 2.4,
+  benyttetRammemelding: true,
   sisteUttaksplan: {
     aktiviteter: [
       {

--- a/packages/storybook/stories/omsorgspenger/Uttaksplan.stories.tsx
+++ b/packages/storybook/stories/omsorgspenger/Uttaksplan.stories.tsx
@@ -22,7 +22,6 @@ const årskvantumDto: ÅrskvantumForbrukteDager = {
   forbrukteDager: 10.4,
   restdager: 9.6,
   antallDagerInfotrygd: 2.4,
-  benyttetRammemelding: true,
   sisteUttaksplan: {
     aktiviteter: [
       {
@@ -78,6 +77,7 @@ const årskvantumDto: ÅrskvantumForbrukteDager = {
     behandlingUUID: '1',
     saksnummer: '2',
     innsendingstidspunkt: '123',
+    benyttetRammemelding: true,
   },
 };
 

--- a/packages/storybook/stories/omsorgspenger/Uttaksplan.stories.tsx
+++ b/packages/storybook/stories/omsorgspenger/Uttaksplan.stories.tsx
@@ -82,4 +82,15 @@ const årskvantumDto: ÅrskvantumForbrukteDager = {
 };
 
 // @ts-ignore
-export const årskvantum = () => <ÅrskvantumIndex årskvantum={årskvantumDto} alleKodeverk={alleKodeverk} />;
+export const standard = () => <ÅrskvantumIndex årskvantum={årskvantumDto} alleKodeverk={alleKodeverk} />;
+
+export const smittevernsdager = () => (
+  <ÅrskvantumIndex
+    årskvantum={{
+      ...årskvantumDto,
+      restdager: -3.4,
+    }}
+    // @ts-ignore
+    alleKodeverk={alleKodeverk}
+  />
+);


### PR DESCRIPTION
- Negative restdager betyr smittevernsdager
- Viser info om benyttet rammemelding hvis det finnes
- Setter fast bredde på tabellkolonner - måtte da utvide Table-komponent