### PR TITLE
Rydder kode og henter klageresultat fra riktig sted

### DIFF
--- a/packages/prosess-vedtak-klage/src/components/VedtakKlageForm.jsx
+++ b/packages/prosess-vedtak-klage/src/components/VedtakKlageForm.jsx
@@ -10,7 +10,6 @@ import kodeverkTyper from '@fpsak-frontend/kodeverk/src/kodeverkTyper';
 import { ElementWrapper, FadingPanel, VerticalSpacer } from '@fpsak-frontend/shared-components';
 import { getKodeverknavnFn } from '@fpsak-frontend/fp-felles';
 import { behandlingForm, behandlingFormValueSelector } from '@fpsak-frontend/form';
-import behandlingResultatType from '@fpsak-frontend/kodeverk/src/behandlingResultatType';
 import klageVurderingCodes from '@fpsak-frontend/kodeverk/src/klageVurdering';
 
 import VedtakKlageSubmitPanel from './VedtakKlageSubmitPanel';
@@ -38,7 +37,7 @@ export const VedtakKlageFormImpl = ({
   isOpphevOgHjemsend,
   avvistArsaker,
   behandlingsResultatTekst,
-  klageVurdering,
+  klageresultat,
   behandlingPaaVent,
   alleKodeverk,
   ...formProps
@@ -77,20 +76,20 @@ export const VedtakKlageFormImpl = ({
           <VerticalSpacer sixteenPx />
         </div>
         )}
-        {klageVurdering.klageVurdertAv === 'NK' && (
+        {klageresultat.klageVurdertAv === 'NK' && (
         <VedtakKlageKaSubmitPanel
           begrunnelse={fritekstTilBrev}
-          klageResultat={klageVurdering}
+          klageResultat={klageresultat}
           previewVedtakCallback={getPreviewVedtakCallback(previewVedtakCallback)}
           formProps={formProps}
           readOnly={readOnly}
           behandlingPaaVent={behandlingPaaVent}
         />
         )}
-        {klageVurdering.klageVurdertAv === 'NFP' && (
+        {klageresultat.klageVurdertAv === 'NFP' && (
         <VedtakKlageSubmitPanel
           begrunnelse={fritekstTilBrev}
-          klageResultat={klageVurdering}
+          klageResultat={klageresultat}
           previewVedtakCallback={getPreviewVedtakCallback(previewVedtakCallback)}
           formProps={formProps}
           readOnly={readOnly}
@@ -113,7 +112,7 @@ VedtakKlageFormImpl.propTypes = {
   avvistArsaker: PropTypes.arrayOf(PropTypes.object),
   omgjortAarsak: PropTypes.string,
   fritekstTilBrev: PropTypes.string,
-  behandlingsresultat: PropTypes.shape().isRequired,
+  behandlingsresultat: PropTypes.shape(),
   ...formPropTypes,
 };
 
@@ -146,18 +145,15 @@ const omgjoerTekstMap = {
   DELVIS_MEDHOLD_I_KLAGE: 'VedtakKlageForm.KlageOmgjortDelvis',
 };
 
-const getKlageResultat = createSelector(
-  [(ownProps) => ownProps.klageVurdering],
-  (behandlingKlageVurdering) => (behandlingKlageVurdering.klageVurderingResultatNK
-    ? behandlingKlageVurdering.klageVurderingResultatNK : behandlingKlageVurdering.klageVurderingResultatNFP),
+export const getKlageresultat = createSelector(
+  [ownProps => ownProps.klageVurdering],
+  kv => kv.klageVurderingResultatNK || kv.klageVurderingResultatNFP
 );
 
 const getResultatText = createSelector(
-  [(ownProps) => ownProps.klageVurdering],
-  (behandlingKlageVurdering) => {
-    const klageResultat = behandlingKlageVurdering.klageVurderingResultatNK
-      ? behandlingKlageVurdering.klageVurderingResultatNK : behandlingKlageVurdering.klageVurderingResultatNFP;
-    switch (klageResultat.klageVurdering) {
+  [getKlageresultat],
+  klageresultat => {
+    switch (klageresultat.klageVurdering) {
       case klageVurderingCodes.AVVIS_KLAGE:
         return 'VedtakKlageForm.KlageAvvist';
       case klageVurderingCodes.STADFESTE_YTELSESVEDTAK:
@@ -167,7 +163,7 @@ const getResultatText = createSelector(
       case klageVurderingCodes.HJEMSENDE_UTEN_Å_OPPHEVE:
         return 'VedtakKlageForm.HjemmsendUtenOpphev';
       case klageVurderingCodes.MEDHOLD_I_KLAGE:
-        return omgjoerTekstMap[klageResultat.klageVurderingOmgjoer];
+        return omgjoerTekstMap[klageresultat.klageVurderingOmgjoer];
       default:
         return null;
     }
@@ -190,27 +186,23 @@ const getOmgjortAarsak = createSelector(
 );
 
 const getIsOmgjort = createSelector(
-  [(ownProps) => ownProps.behandlingsresultat],
-  (behandlingsresultat) => behandlingsresultat?.type.kode === behandlingResultatType.KLAGE_MEDHOLD,
+  [getKlageresultat],
+  klageresultat => klageresultat.klageVurdering === klageVurderingCodes.MEDHOLD_I_KLAGE
 );
 
 export const getIsAvvist = createSelector(
-  [(ownProps) => ownProps.behandlingsresultat],
-  (behandlingsresultat) => behandlingsresultat?.type.kode === behandlingResultatType.KLAGE_AVVIST,
+  [getKlageresultat],
+  klageresultat => klageresultat.klageVurdering === klageVurderingCodes.AVVIS_KLAGE
 );
 
 export const getIsOpphevOgHjemsend = createSelector(
-  [(ownProps) => ownProps.behandlingsresultat],
-  (behandlingsresultat) => behandlingsresultat?.type.kode === behandlingResultatType.KLAGE_YTELSESVEDTAK_OPPHEVET,
+  [getKlageresultat],
+  klageresultat => klageresultat.klageVurdering === klageVurderingCodes.OPPHEVE_YTELSESVEDTAK
 );
 
 export const getFritekstTilBrev = createSelector(
-  [(ownProps) => ownProps.klageVurdering],
-  (behandlingKlageVurdering) => {
-    const klageResultat = behandlingKlageVurdering.klageVurderingResultatNK
-      ? behandlingKlageVurdering.klageVurderingResultatNK : behandlingKlageVurdering.klageVurderingResultatNFP;
-    return klageResultat.fritekstTilBrev;
-  },
+  [getKlageresultat],
+  klageresultat => klageresultat.frtekstTilBrev
 );
 
 export const buildInitialValues = createSelector([(ownProps) => ownProps.aksjonspunkter], (aksjonspunkter) => {
@@ -232,7 +224,7 @@ const mapStateToPropsFactory = (initialState, initialOwnProps) => {
     omgjortAarsak: getOmgjortAarsak(ownProps),
     fritekstTilBrev: getFritekstTilBrev(ownProps),
     behandlingsResultatTekst: getResultatText(ownProps),
-    klageVurdering: getKlageResultat(ownProps),
+    klageresultat: getKlageresultat(ownProps),
     ...behandlingFormValueSelector(VEDTAK_KLAGE_FORM_NAME, ownProps.behandlingId, ownProps.behandlingVersjon)(
       state,
       'begrunnelse',

--- a/packages/prosess-vedtak-klage/src/components/VedtakKlageForm.jsx
+++ b/packages/prosess-vedtak-klage/src/components/VedtakKlageForm.jsx
@@ -202,7 +202,7 @@ export const getIsOpphevOgHjemsend = createSelector(
 
 export const getFritekstTilBrev = createSelector(
   [getKlageresultat],
-  klageresultat => klageresultat.frtekstTilBrev
+  klageresultat => klageresultat.fritekstTilBrev
 );
 
 export const buildInitialValues = createSelector([(ownProps) => ownProps.aksjonspunkter], (aksjonspunkter) => {

--- a/packages/prosess-vedtak-klage/src/components/VedtakKlageForm.spec.jsx
+++ b/packages/prosess-vedtak-klage/src/components/VedtakKlageForm.spec.jsx
@@ -4,8 +4,7 @@ import sinon from 'sinon';
 import { intlMock } from '@fpsak-frontend/utils-test/src/intl-enzyme-test-helper';
 import { reduxFormPropsMock } from '@fpsak-frontend/utils-test/src/redux-form-test-helper';
 import { Normaltekst, Undertekst } from 'nav-frontend-typografi';
-import behandlingResultatType from '@fpsak-frontend/kodeverk/src/behandlingResultatType';
-import { getAvvisningsAarsaker, getIsAvvist, VedtakKlageFormImpl } from './VedtakKlageForm';
+import {getAvvisningsAarsaker, getIsAvvist, getKlageresultat, VedtakKlageFormImpl} from './VedtakKlageForm';
 import shallowWithIntl from '../../i18n/intl-enzyme-test-helper-proses-vedtak-klage';
 
 const KLAGE_OMGJORT_TEKST = 'VedtakKlageForm.KlageOmgjortGunst';
@@ -16,12 +15,9 @@ describe('<VedtakKlageForm>', () => {
     const avvistArsaker = [{ kode: 'KLAGET_FOR_SENT', kodeverk: 'KLAGE_AVVIST_AARSAK' },
       { kode: 'KLAGER_IKKE_PART', kodeverk: 'KLAGE_AVVIST_AARSAK' }];
     const forhandsvisVedtaksbrevFunc = sinon.spy();
-    const br = {
-      id: 1,
-      type: {
-        kode: behandlingResultatType.KLAGE_AVVIST,
-        navn: 'avvist',
-      },
+    const klageVurderingResultatNFP = {
+      klageVurdertAv: "NFP",
+      klageVurdering: "AVVIS_KLAGE"
     };
     const wrapper = shallowWithIntl(<VedtakKlageFormImpl
       {...reduxFormPropsMock}
@@ -36,11 +32,11 @@ describe('<VedtakKlageForm>', () => {
       avvisningsAarsakerForFeature={[null]}
       behandlingPaaVent={false}
       behandlingStatusKode="UTRED"
-      behandlingsresultat={br}
       previewVedtakCallback={forhandsvisVedtaksbrevFunc}
       finishKlageCallback={forhandsvisVedtaksbrevFunc}
       aksjonspunktKoder={[]}
-      klageVurdering={{}}
+      klageVurdering={{klageVurderingResultatNFP}}
+      klageresultat={klageVurderingResultatNFP}
       isBehandlingReadOnly
       alleKodeverk={{
         KlageAvvistÅrsak: [{
@@ -58,7 +54,7 @@ describe('<VedtakKlageForm>', () => {
   describe('Klage vedtak Selectors', () => {
     describe('getIsAvvist', () => {
       it('should return true', () => {
-        const brt = { type: { kode: behandlingResultatType.KLAGE_AVVIST } };
+        const brt = {klageVurdering: "AVVIS_KLAGE"};
         const selected = getIsAvvist.resultFunc(brt);
         expect(selected).equal(true);
       });
@@ -72,6 +68,24 @@ describe('<VedtakKlageForm>', () => {
         };
         const selected = getAvvisningsAarsaker.resultFunc(klageVurdering);
         expect(selected).to.have.length(2);
+      });
+    });
+
+    describe('getKlageresultat', () => {
+
+      it('Skal returnere klageVurderingResultatNFP hvis klagen ikke har blitt vurdert av klageinstans', () => {
+        const klageVurderingResultatNFP = {klageVurdertAv: "NFP"};
+        const klageresultater = {klageVurderingResultatNFP};
+        const resultat = getKlageresultat.resultFunc(klageresultater);
+        expect(resultat).equal(klageVurderingResultatNFP);
+      });
+
+      it('Skal returnere klageVurderingResultatNK hvis klagen har blitt vurdert av klageinstans', () => {
+        const klageVurderingResultatNFP = {klageVurdertAv: "NFP"};
+        const klageVurderingResultatNK = {klageVurdertAv: "NK"};
+        const klageresultater = {klageVurderingResultatNFP, klageVurderingResultatNK};
+        const resultat = getKlageresultat.resultFunc(klageresultater);
+        expect(resultat).equal(klageVurderingResultatNK);
       });
     });
   });


### PR DESCRIPTION
`behandlingsresultat` finnes ikke på klage sin `BehandlingDto`. Resultatet må derfor hentes fra `klageVurdering`.

Koden her var forøvrig ganske rotete og forvirrende, blant annet med tre forskjellige ting som het `klageVurdering` og en selector som endret innholdet i sin egen kilde. Jeg har prøvd å rydde litt i dette, bl.a. ved å legge til en ny prop som heter `klageresultat`.