### PR TITLE
Legger til klageinformasjon på ApprovalIndex

### DIFF
--- a/packages/sak-app/src/behandlingsupport/approval/ApprovalIndex.jsx
+++ b/packages/sak-app/src/behandlingsupport/approval/ApprovalIndex.jsx
@@ -2,6 +2,7 @@ import { BehandlingIdentifier, DataFetcher, featureToggle, getPathToFplos } from
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import klageBehandlingArsakType from '@fpsak-frontend/kodeverk/src/behandlingArsakType';
 import BehandlingType from '@fpsak-frontend/kodeverk/src/behandlingType';
+import klageApi from "@fpsak-frontend/behandling-klage/src/data/klageBehandlingApi";
 import kodeverkTyper from '@fpsak-frontend/kodeverk/src/kodeverkTyper';
 import vurderPaNyttArsakType from '@fpsak-frontend/kodeverk/src/vurderPaNyttArsakType';
 import { kodeverkObjektPropType, navAnsattPropType } from '@fpsak-frontend/prop-types';
@@ -29,7 +30,7 @@ import {
   previewMessage,
 } from '../../behandling/duck';
 import { getBehandlingerUuidsMappedById } from '../../behandling/selectors/behandlingerSelectors';
-import fpsakApi from '../../data/fpsakApi';
+import fpsakApi, {reduxRestApi} from '../../data/fpsakApi';
 import { getFagsakYtelseType, isForeldrepengerFagsak } from '../../fagsak/fagsakSelectors';
 import { getAlleKodeverkForBehandlingstype, getKodeverkForBehandlingstype } from '../../kodeverk/duck';
 
@@ -164,6 +165,7 @@ export class ApprovalIndex extends Component {
       behandlingId,
       behandlingTypeKode,
       erTilbakekreving,
+      klagebehandling
     } = this.props;
     const { showBeslutterModal, allAksjonspunktApproved } = this.state;
     const { brukernavn, kanVeilede } = navAnsatt;
@@ -171,6 +173,10 @@ export class ApprovalIndex extends Component {
 
     if (!totrinnskontrollSkjermlenkeContext && !totrinnskontrollReadOnlySkjermlenkeContext) {
       return null;
+    }
+
+    if (klagebehandling?.links) {
+      reduxRestApi.injectPaths(klagebehandling.links);
     }
 
     return (
@@ -256,6 +262,7 @@ ApprovalIndex.propTypes = {
   behandlingsresultat: PropTypes.shape(),
   behandlingId: PropTypes.number,
   behandlingTypeKode: PropTypes.string,
+  klagebehandling: PropTypes.shape()
 };
 
 ApprovalIndex.defaultProps = {
@@ -313,6 +320,7 @@ const mapStateToPropsFactory = initialState => {
       behandlingIdentifier,
       erTilbakekreving,
       behandlingTypeKode,
+      klagebehandling: klageApi.BEHANDLING_KLAGE.getRestApiData()(state)
     };
   };
 };


### PR DESCRIPTION
Per nå får ikke `ApprovalIndex` all informasjonen den trenger om en klagebehandling. Dette er fordi endepunktet `fpsakApi.TOTRINNS_KLAGE_VURDERING` ikke er oppdatert med sti fra klagebehandling når komponenten lastes inn. Jeg har løst dette ved å hente inn endepunktstiene som tilhører behandlingen og oppdatere `reduxRestApi` med disse i `render()`. Ser at liknende metoder er brukt andre steder, f.eks. på [BehandlingIndex](https://github.com/navikt/k9-sak-web/blob/master/packages/sak-app/src/behandling/BehandlingIndex.jsx) og [BehandlingKlageIndex](https://github.com/navikt/k9-sak-web/blob/master/packages/behandling-klage/src/BehandlingKlageIndex.tsx).