### PR TITLE
Henter inn behandlingsid til nedtrekksmeny for påklagd vedtak

### DIFF
--- a/packages/prosess-formkrav/src/components/FormkravKlageForm.jsx
+++ b/packages/prosess-formkrav/src/components/FormkravKlageForm.jsx
@@ -25,14 +25,15 @@ import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 
 import styles from './formkravKlageForm.less';
 
-export const IKKE_PA_KLAGD_VEDTAK = 'ikkePaklagdVedtak';
+export const IKKE_PAKLAGD_VEDTAK = 'ikkePaklagdVedtak';
 
-export const getPaKlagdVedtak = (klageFormkavResultat) => (
-  klageFormkavResultat.paKlagdBehandlingId ? `${klageFormkavResultat.paKlagdBehandlingId}` : IKKE_PA_KLAGD_VEDTAK
-);
+export const getPaklagdVedtak = (klageFormkravResultat, avsluttedeBehandlinger) => {
+  const behandlingid = avsluttedeBehandlinger.find(b => b.uuid === klageFormkravResultat.påklagdBehandlingRef)?.id;
+  return behandlingid ? `${behandlingid}` : IKKE_PAKLAGD_VEDTAK;
+};
 
 const getKlagBareVedtak = (avsluttedeBehandlinger, intl, getKodeverknavn) => {
-  const klagBareVedtak = [<option key="formkrav" value={IKKE_PA_KLAGD_VEDTAK}>{intl.formatMessage({ id: 'Klage.Formkrav.IkkePåklagdVedtak' })}</option>];
+  const klagBareVedtak = [<option key="formkrav" value={IKKE_PAKLAGD_VEDTAK}>{intl.formatMessage({ id: 'Klage.Formkrav.IkkePåklagdVedtak' })}</option>];
   return klagBareVedtak.concat(avsluttedeBehandlinger.map((behandling) => (
     <option key={behandling.id} value={`${behandling.id}`}>
       {`${getKodeverknavn(behandling.type)} ${moment(behandling.avsluttet).format(DDMMYYYY_DATE_FORMAT)}`}

--- a/packages/prosess-formkrav/src/components/FormkravKlageFormKa.jsx
+++ b/packages/prosess-formkrav/src/components/FormkravKlageFormKa.jsx
@@ -7,7 +7,7 @@ import PropTypes from 'prop-types';
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import { behandlingForm } from '@fpsak-frontend/form';
 
-import FormkravKlageForm, { getPaKlagdVedtak, IKKE_PA_KLAGD_VEDTAK } from './FormkravKlageForm';
+import FormkravKlageForm, { getPaklagdVedtak, IKKE_PAKLAGD_VEDTAK } from './FormkravKlageForm';
 import { erTilbakekreving, påklagdTilbakekrevingInfo } from './FormkravKlageFormNfp';
 
 /**
@@ -59,24 +59,27 @@ export const transformValues = (values, avsluttedeBehandlinger) => ({
   erSignert: values.erSignert,
   begrunnelse: values.begrunnelse,
   kode: aksjonspunktCodes.VURDERING_AV_FORMKRAV_KLAGE_KA,
-  vedtak: values.vedtak === IKKE_PA_KLAGD_VEDTAK ? null : values.vedtak,
+  vedtak: values.vedtak === IKKE_PAKLAGD_VEDTAK ? null : values.vedtak,
   erTilbakekreving: erTilbakekreving(avsluttedeBehandlinger, values.vedtak),
   tilbakekrevingInfo: påklagdTilbakekrevingInfo(avsluttedeBehandlinger, values.vedtak),
 });
 
 const formName = 'FormkravKlageFormKa';
 
-const buildInitialValues = createSelector([(ownProps) => ownProps.klageVurdering], (klageVurdering) => {
-  const klageFormkavResultatKa = klageVurdering ? klageVurdering.klageFormkravResultatKA : null;
-  return {
-    vedtak: klageFormkavResultatKa ? getPaKlagdVedtak(klageFormkavResultatKa) : null,
-    begrunnelse: klageFormkavResultatKa ? klageFormkavResultatKa.begrunnelse : null,
-    erKlagerPart: klageFormkavResultatKa ? klageFormkavResultatKa.erKlagerPart : null,
-    erKonkret: klageFormkavResultatKa ? klageFormkavResultatKa.erKlageKonkret : null,
-    erFristOverholdt: klageFormkavResultatKa ? klageFormkavResultatKa.erKlagefirstOverholdt : null,
-    erSignert: klageFormkavResultatKa ? klageFormkavResultatKa.erSignert : null,
-  };
-});
+const buildInitialValues = createSelector(
+  [ownProps => ownProps.klageVurdering, ownProps => ownProps.avsluttedeBehandlinger],
+  (klageVurdering, avsluttedeBehandlinger) => {
+    const klageFormkavResultatKa = klageVurdering ? klageVurdering.klageFormkravResultatKA : null;
+    return {
+      vedtak: klageFormkavResultatKa ? getPaklagdVedtak(klageFormkavResultatKa, avsluttedeBehandlinger) : null,
+      begrunnelse: klageFormkavResultatKa ? klageFormkavResultatKa.begrunnelse : null,
+      erKlagerPart: klageFormkavResultatKa ? klageFormkavResultatKa.erKlagerPart : null,
+      erKonkret: klageFormkavResultatKa ? klageFormkavResultatKa.erKlageKonkret : null,
+      erFristOverholdt: klageFormkavResultatKa ? klageFormkavResultatKa.erKlagefirstOverholdt : null,
+      erSignert: klageFormkavResultatKa ? klageFormkavResultatKa.erSignert : null,
+    };
+  }
+);
 
 const mapStateToPropsFactory = (initialState, initialOwnProps) => {
   const onSubmit = (values) => initialOwnProps.submitCallback([transformValues(values, initialOwnProps.avsluttedeBehandlinger)]);

--- a/packages/prosess-formkrav/src/components/FormkravKlageFormNfp.jsx
+++ b/packages/prosess-formkrav/src/components/FormkravKlageFormNfp.jsx
@@ -8,7 +8,7 @@ import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import { behandlingForm } from '@fpsak-frontend/form';
 
 import BehandlingType from '@fpsak-frontend/kodeverk/src/behandlingType';
-import FormkravKlageForm, { getPaKlagdVedtak, IKKE_PA_KLAGD_VEDTAK } from './FormkravKlageForm';
+import FormkravKlageForm, { getPaklagdVedtak, IKKE_PAKLAGD_VEDTAK } from './FormkravKlageForm';
 
 /**
  * FormkravklageformNfp
@@ -81,24 +81,27 @@ const transformValues = (values, avsluttedeBehandlinger) => ({
   erSignert: values.erSignert,
   begrunnelse: values.begrunnelse,
   kode: aksjonspunktCodes.VURDERING_AV_FORMKRAV_KLAGE_NFP,
-  vedtak: values.vedtak === IKKE_PA_KLAGD_VEDTAK ? null : values.vedtak,
+  vedtak: values.vedtak === IKKE_PAKLAGD_VEDTAK ? null : values.vedtak,
   erTilbakekreving: erTilbakekreving(avsluttedeBehandlinger, values.vedtak),
   tilbakekrevingInfo: påklagdTilbakekrevingInfo(avsluttedeBehandlinger, values.vedtak),
 });
 
 const formName = 'FormkravKlageFormNfp';
 
-const buildInitialValues = createSelector([ownProps => ownProps.klageVurdering], klageVurdering => {
-  const klageFormkavResultatNfp = klageVurdering ? klageVurdering.klageFormkravResultatNFP : null;
-  return {
-    vedtak: klageFormkavResultatNfp ? getPaKlagdVedtak(klageFormkavResultatNfp) : null,
-    begrunnelse: klageFormkavResultatNfp ? klageFormkavResultatNfp.begrunnelse : null,
-    erKlagerPart: klageFormkavResultatNfp ? klageFormkavResultatNfp.erKlagerPart : null,
-    erKonkret: klageFormkavResultatNfp ? klageFormkavResultatNfp.erKlageKonkret : null,
-    erFristOverholdt: klageFormkavResultatNfp ? klageFormkavResultatNfp.erKlagefirstOverholdt : null,
-    erSignert: klageFormkavResultatNfp ? klageFormkavResultatNfp.erSignert : null,
-  };
-});
+const buildInitialValues = createSelector(
+  [ownProps => ownProps.klageVurdering, ownProps => ownProps.avsluttedeBehandlinger],
+  (klageVurdering, avsluttedeBehandlinger) => {
+    const klageFormkavResultatNfp = klageVurdering ? klageVurdering.klageFormkravResultatNFP : null;
+    return {
+      vedtak: klageFormkavResultatNfp ? getPaklagdVedtak(klageFormkavResultatNfp, avsluttedeBehandlinger) : null,
+      begrunnelse: klageFormkavResultatNfp ? klageFormkavResultatNfp.begrunnelse : null,
+      erKlagerPart: klageFormkavResultatNfp ? klageFormkavResultatNfp.erKlagerPart : null,
+      erKonkret: klageFormkavResultatNfp ? klageFormkavResultatNfp.erKlageKonkret : null,
+      erFristOverholdt: klageFormkavResultatNfp ? klageFormkavResultatNfp.erKlagefirstOverholdt : null,
+      erSignert: klageFormkavResultatNfp ? klageFormkavResultatNfp.erSignert : null
+    };
+  }
+);
 
 const mapStateToPropsFactory = (initialState, initialOwnProps) => {
   const onSubmit = values =>


### PR DESCRIPTION
Behandlings-ID finnes ikke i `klageFormkravResulat` - denne må derfor hentes fra lista over avsluttede behandlinger. Refaktorerer også `IKKE_PA_KLAGD_VEDTAK` -> `IKKE_PAKLAGD_VEDTAK`.