### PR TITLE
Tilkjent Ytelse fix

### DIFF
--- a/packages/behandling-omsorgspenger/src/panelDefinisjoner/prosessStegOmsorgspengerPanelDefinisjoner.tsx
+++ b/packages/behandling-omsorgspenger/src/panelDefinisjoner/prosessStegOmsorgspengerPanelDefinisjoner.tsx
@@ -196,7 +196,11 @@ const prosessStegPanelDefinisjoner = [
         },
         showComponent: () => true,
         overrideStatus: ({ beregningsresultatUtbetaling }) => {
-          if (!beregningsresultatUtbetaling) {
+          const manglerBeregningsresultatUtbetaling =
+            !beregningsresultatUtbetaling ||
+            !beregningsresultatUtbetaling.perioder ||
+            beregningsresultatUtbetaling.perioder.length === 0;
+          if (manglerBeregningsresultatUtbetaling) {
             return vut.IKKE_VURDERT;
           }
           if (harKunAvslåtteUttak(beregningsresultatUtbetaling)) {


### PR DESCRIPTION
Legger på manglende håndtering av statusen til TilkjentYtelseProsessIndex i prosessmenyen for
tilfellet hvor beregningsresultatUtbetaling.perioder er en tom liste. Resulterte tidligere i
undefined-feil.