### PR TITLE
Legger til klasse for håndtering av spørringer relatert til behandling

### DIFF
--- a/packages/sak-app/src/behandlingmenu/duck.spec.jsx
+++ b/packages/sak-app/src/behandlingmenu/duck.spec.jsx
@@ -58,9 +58,8 @@ describe('BehandlingMenu-reducer', () => {
 
     const push = sinon.spy();
     const params = { behandlingType: 'revurdering' };
-    const isTilbakekreving = false;
 
-    return store.dispatch(createNewBehandling(push, fagsak.saksnummer, true, isTilbakekreving, params))
+    return store.dispatch(createNewBehandling(push, fagsak.saksnummer, true, params))
       .then(() => {
         expect(store.getActions()).to.have.length(7);
         const [requestStartedAction, requestStatusStartedAction, requestStatusFinishedAction, requestFinishedAction] = store.getActions();
@@ -109,9 +108,8 @@ describe('BehandlingMenu-reducer', () => {
 
     const push = sinon.spy();
     const params = { behandlingType: 'revurdering' };
-    const isTilbakekreving = false;
 
-    return store.dispatch(createNewBehandling(push, 1, true, isTilbakekreving, params))
+    return store.dispatch(createNewBehandling(push, 1, true, params))
       .then(() => {
         expect(store.getActions()).to.have.length(4);
         const [requestStartedAction, requestFinishedAction] = store.getActions();

--- a/packages/sak-meny/src/components/createNewBehandling/CreateNewBehandlingMenuItem.jsx
+++ b/packages/sak-meny/src/components/createNewBehandling/CreateNewBehandlingMenuItem.jsx
@@ -44,7 +44,7 @@ class CreateNewBehandlingMenuItem extends Component {
     };
 
     const erBehandlingValgt = behandlingIdentifier !== undefined && behandlingIdentifier.behandlingId;
-    submitNyBehandling(push, saksnummer, erBehandlingValgt, isTilbakekreving, data);
+    submitNyBehandling(push, saksnummer, erBehandlingValgt, data);
     this.hideModal();
   }
 

--- a/packages/utils/src/behandlingstypeUtils.jsx
+++ b/packages/utils/src/behandlingstypeUtils.jsx
@@ -1,0 +1,31 @@
+import fpsakApi from "@fpsak-frontend/sak-app/src/data/fpsakApi";
+import behandlingstype from '@fpsak-frontend/kodeverk/src/behandlingType';
+
+class ApiForBehandlingstype {
+
+  behandlingstypekode;
+
+  constructor(behandlingstypekode) {
+    this.behandlingstypekode = behandlingstypekode;
+  }
+
+  behandlingerApi() {
+    switch (this.behandlingstypekode) {
+      case behandlingstype.TILBAKEKREVING:
+      case behandlingstype.TILBAKEKREVING_REVURDERING: return fpsakApi.BEHANDLINGER_FPTILBAKE;
+      case behandlingstype.KLAGE: return fpsakApi.BEHANDLINGER_KLAGE;
+      default: return fpsakApi.BEHANDLINGER_FPSAK;
+    }
+  }
+
+  newBehandlingApi() {
+    switch (this.behandlingstypekode) {
+      case behandlingstype.TILBAKEKREVING:
+      case behandlingstype.TILBAKEKREVING_REVURDERING: return fpsakApi.NEW_BEHANDLING_FPTILBAKE;
+      case behandlingstype.KLAGE: return fpsakApi.NEW_BEHANDLING_KLAGE;
+      default: return fpsakApi.NEW_BEHANDLING_FPSAK;
+    }
+  }
+}
+
+export default ApiForBehandlingstype;

--- a/packages/utils/src/behandlingstypeUtils.spec.jsx
+++ b/packages/utils/src/behandlingstypeUtils.spec.jsx
@@ -1,0 +1,47 @@
+import behandlingstype from '@fpsak-frontend/kodeverk/src/behandlingType';
+import fpsakApi from '@fpsak-frontend/sak-app/src/data/fpsakApi';
+import { expect } from 'chai';
+import ApiForBehandlingstype from './behandlingstypeUtils';
+
+describe('behandlingstypeUtils', () => {
+
+  describe('behandlingerApi', () => {
+
+    const inputToOutputMap = new Map([
+      [behandlingstype.KLAGE, fpsakApi.BEHANDLINGER_KLAGE],
+      [behandlingstype.TILBAKEKREVING, fpsakApi.BEHANDLINGER_FPTILBAKE],
+      [behandlingstype.TILBAKEKREVING_REVURDERING, fpsakApi.BEHANDLINGER_FPTILBAKE],
+      [behandlingstype.FORSTEGANGSSOKNAD, fpsakApi.BEHANDLINGER_FPSAK],
+      [behandlingstype.SOKNAD, fpsakApi.BEHANDLINGER_FPSAK],
+      [behandlingstype.REVURDERING, fpsakApi.BEHANDLINGER_FPSAK]
+    ]);
+
+    inputToOutputMap.forEach((expectedOutput, input) => it(
+      `Returnerer ${expectedOutput.name} når behandlingstype er ${input}`,
+      () => {
+        const behandlingstypeapi = new ApiForBehandlingstype(input);
+        expect(behandlingstypeapi.behandlingerApi()).to.equal(expectedOutput);
+      }
+    ));
+  });
+
+  describe('newBehandlingApi', () => {
+
+    const inputToOutputMap = new Map([
+      [behandlingstype.KLAGE, fpsakApi.NEW_BEHANDLING_KLAGE],
+      [behandlingstype.TILBAKEKREVING, fpsakApi.NEW_BEHANDLING_FPTILBAKE],
+      [behandlingstype.TILBAKEKREVING_REVURDERING, fpsakApi.NEW_BEHANDLING_FPTILBAKE],
+      [behandlingstype.FORSTEGANGSSOKNAD, fpsakApi.NEW_BEHANDLING_FPSAK],
+      [behandlingstype.SOKNAD, fpsakApi.NEW_BEHANDLING_FPSAK],
+      [behandlingstype.REVURDERING, fpsakApi.NEW_BEHANDLING_FPSAK]
+    ]);
+
+    inputToOutputMap.forEach((expectedOutput, input) => it(
+      `Returnerer ${expectedOutput.name} når behandlingstype er ${input}`,
+      () => {
+        const behandlingstypeapi = new ApiForBehandlingstype(input);
+        expect(behandlingstypeapi.newBehandlingApi()).to.equal(expectedOutput);
+      }
+    ));
+  });
+});


### PR DESCRIPTION
Legger til en klasse men funksjoner som returnerer hvilket endepunkt som skal kalles basert på behandlingstypen. Hensikten er å rydde opp i eksisterende kode, hvor det flere steder gjøres sjekker av denne typen:
```
let updateBehandlinger;
if (isTilbakekreving) updateBehandlinger = fpsakApi.BEHANDLINGER_FPTILBAKE;
else if (params.behandlingType === behandlingType.KLAGE) updateBehandlinger = fpsakApi.BEHANDLINGER_KLAGE;
else updateBehandlinger = fpsakApi.BEHANDLINGER_FPSAK;
```
Med denne klassen kan man i stedet skrive:
```
const apiForBehandlingstype = new ApiForBehandlingstype(params.behandlingType);
const updateBehandlinger = apiForBehandlingstype.behandlingerApi();
```
Jeg vil gjerne ha tilbakemeldinger på hvorvidt det finnes bedre måter å løse dette på og om klassen er plassert på et passende sted i filsystemet.