### PR TITLE
Gjør at radene i uttakstabellen ikke er fokuserbare

### DIFF
--- a/packages/prosess-aarskvantum-oms/src/components/AktivitetTabell.tsx
+++ b/packages/prosess-aarskvantum-oms/src/components/AktivitetTabell.tsx
@@ -139,6 +139,7 @@ const AktivitetTabell: FunctionComponent<AktivitetTabellProps> = ({
         </>}
         noHover
         withoutTbody
+        notFocusableHeader
       >
         {uttaksperioder.map(({ periode, delvisFravær, utfall, utbetalingsgrad, vurderteVilkår, hjemler, nøkkeltall }, index) => {
           const erValgt = valgtPeriodeIndex === index;

--- a/packages/shared-components/src/table/TableRow.tsx
+++ b/packages/shared-components/src/table/TableRow.tsx
@@ -81,7 +81,7 @@ const TableRow: FunctionComponent<OwnProps> = ({
     })}
     onMouseDown={createMouseDownHandler(onMouseDown, id, model)}
     onKeyDown={createKeyHandler(onKeyDown, id, model)}
-    tabIndex={notFocusable ? -1 : 0}
+    tabIndex={notFocusable ? null : 0}
   >
     {children}
   </tr>


### PR DESCRIPTION
`tabIndex={-1}` løste ikke problemet med uønsket fokus. Radene får fortsatt fokus ved museklikk. `null` gjør at `tabindex` blir fjernet fra HTML-elementet. Jeg har også lagt til `notFocusableHeader` på uttakstabellen - denne ble ved en feil utelatt fra min forrige pull request.