### PR TITLE
Fjernat featureToggle i processPanel definitionen

### DIFF
--- a/packages/behandling-frisinn/src/panelDefinisjoner/prosessStegPaneler/BeregningsgrunnlagProsessStegPanelDef.tsx
+++ b/packages/behandling-frisinn/src/panelDefinisjoner/prosessStegPaneler/BeregningsgrunnlagProsessStegPanelDef.tsx
@@ -22,11 +22,10 @@ class PanelDef extends ProsessStegPanelDef {
 
   getOverstyrVisningAvKomponent = () => true;
 
-  getData = ({ fagsak, beregningsgrunnlag, arbeidsgiverOpplysningerPerId, featureToggles }) => ({
+  getData = ({ fagsak, beregningsgrunnlag, arbeidsgiverOpplysningerPerId }) => ({
     fagsak,
     beregningsgrunnlag: beregningsgrunnlag ? [beregningsgrunnlag[0]] : [],
     arbeidsgiverOpplysningerPerId,
-    featureToggles,
   });
 }
 

--- a/packages/behandling-frisinn/src/panelDefinisjoner/prosessStegPaneler/SimuleringProsessStegPanelDef.tsx
+++ b/packages/behandling-frisinn/src/panelDefinisjoner/prosessStegPaneler/SimuleringProsessStegPanelDef.tsx
@@ -20,11 +20,10 @@ class PanelDef extends ProsessStegPanelDef {
   getOverstyrtStatus = ({ simuleringResultat }) =>
     simuleringResultat ? vilkarUtfallType.OPPFYLT : vilkarUtfallType.IKKE_VURDERT;
 
-  getData = ({ fagsak, previewFptilbakeCallback, simuleringResultat, featureToggles }) => ({
+  getData = ({ fagsak, previewFptilbakeCallback, simuleringResultat }) => ({
     fagsak,
     previewFptilbakeCallback,
     simuleringResultat,
-    featureToggles,
   });
 }
 

--- a/packages/behandling-pleiepenger/src/panelDefinisjoner/prosessStegPaneler/BeregningsgrunnlagProsessStegPanelDef.tsx
+++ b/packages/behandling-pleiepenger/src/panelDefinisjoner/prosessStegPaneler/BeregningsgrunnlagProsessStegPanelDef.tsx
@@ -22,11 +22,10 @@ class PanelDef extends ProsessStegPanelDef {
 
   getOverstyrVisningAvKomponent = () => true;
 
-  getData = ({ fagsak, beregningsgrunnlag, arbeidsgiverOpplysningerPerId, featureToggles }) => ({
+  getData = ({ fagsak, beregningsgrunnlag, arbeidsgiverOpplysningerPerId }) => ({
     fagsak,
     beregningsgrunnlag,
     arbeidsgiverOpplysningerPerId,
-    featureToggles,
   });
 }
 

--- a/packages/behandling-pleiepenger/src/panelDefinisjoner/prosessStegPaneler/SimuleringProsessStegPanelDef.tsx
+++ b/packages/behandling-pleiepenger/src/panelDefinisjoner/prosessStegPaneler/SimuleringProsessStegPanelDef.tsx
@@ -20,11 +20,10 @@ class PanelDef extends ProsessStegPanelDef {
   getOverstyrtStatus = ({ simuleringResultat }) =>
     simuleringResultat ? vilkarUtfallType.OPPFYLT : vilkarUtfallType.IKKE_VURDERT;
 
-  getData = ({ fagsak, previewFptilbakeCallback, simuleringResultat, featureToggles }) => ({
+  getData = ({ fagsak, previewFptilbakeCallback, simuleringResultat }) => ({
     fagsak,
     previewFptilbakeCallback,
     simuleringResultat,
-    featureToggles,
   });
 }
 

--- a/packages/behandling-unntak/src/panelDefinisjoner/prosessStegPaneler/SimuleringProsessStegPanelDef.tsx
+++ b/packages/behandling-unntak/src/panelDefinisjoner/prosessStegPaneler/SimuleringProsessStegPanelDef.tsx
@@ -20,11 +20,10 @@ class PanelDef extends ProsessStegPanelDef {
   getOverstyrtStatus = ({ simuleringResultat }) =>
     simuleringResultat ? vilkarUtfallType.OPPFYLT : vilkarUtfallType.IKKE_VURDERT;
 
-  getData = ({ fagsak, previewFptilbakeCallback, simuleringResultat, featureToggles }) => ({
+  getData = ({ fagsak, previewFptilbakeCallback, simuleringResultat }) => ({
     fagsak,
     previewFptilbakeCallback,
     simuleringResultat,
-    featureToggles,
   });
 }
 

--- a/packages/behandling-unntak/src/panelDefinisjoner/prosessStegPaneler/UnntakProsessStegPanelDef.tsx
+++ b/packages/behandling-unntak/src/panelDefinisjoner/prosessStegPaneler/UnntakProsessStegPanelDef.tsx
@@ -12,9 +12,8 @@ class PanelDef extends ProsessStegPanelDef {
 
   getOverstyrVisningAvKomponent = () => true;
 
-  getData = ({ vilkar, featureToggles }) => ({
+  getData = ({ vilkar }) => ({
     vilkar,
-    featureToggles,
   });
 }
 


### PR DESCRIPTION
Ref commit: https://github.com/navikt/k9-sak-web/blob/a5c17e96b96e457ba28523fddcba86e532996610/packages/behandling-felles/src/components/ProsessStegPanel.tsx där vi la till featureToggle i data objektet.