### PR TITLE
Legger til bindestrek (hyphen) og bindestrek (Non-breaking hyphen)

### DIFF
--- a/packages/utils/src/validation/validatorsHelper.ts
+++ b/packages/utils/src/validation/validatorsHelper.ts
@@ -7,11 +7,14 @@ export const decimalRegexWithMax = maxNumberOfDecimals => new RegExp(`^\\d+([.,]
 export const decimalRegex = decimalRegexWithMax(2);
 export const saksnummerOrFodselsnummerPattern = /^[a-zA-Z0-9_-]{0,18}$/;
 
-export const textRegex = /^[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'\-–/%§!?@_()#+:;,="&\s<>~*]*$/;
-export const textGyldigRegex = /[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'\-–/%§!?@_()#+:;,="&\s<>~*]*/g;
+export const textRegex =
+  /^[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'\-‐–‑/%§!?@_()#+:;,="&\s<>~*]*$/;
+export const textGyldigRegex =
+  /[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'\-‐–‑/%§!?@_()#+:;,="&\s<>~*]*/g;
 
 export const nameRegex = /^[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'-]*$/;
-export const nameGyldigRegex = /[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'-]*/g;
+export const nameGyldigRegex =
+  /[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'-]*/g;
 
 export const isEmpty = text => text === null || text === undefined || text.toString().trim().length === 0;
 


### PR DESCRIPTION
Legger til bindestrek (hyphen) og bindestrek (Non-breaking hyphen) som ikke bryter teksten. Valideringen godtar fra før bindestrek (dash) og plain `-`.

Word/Pdf oversetter plain `-` til bindestreker, som gjør at kopiering fra mal er mye styr.

Her er resten av unicode-jungelen av bindestreker: https://www.compart.com/en/unicode/category/Pd