### PR TITLE
Nedgradere checkout action till v1 i promote

### DIFF
--- a/.github/workflows/promote-command.yml
+++ b/.github/workflows/promote-command.yml
@@ -32,7 +32,7 @@ jobs:
           echo "TAG=$(echo ${{ steps.issue_comment.outputs.title }} | awk -F- '{print $NF}')" >> $GITHUB_ENV
 
       - name: Sjekk ut kode
-        uses: actions/checkout@v2
+        uses: actions/checkout@v1
         with:
           ref: ${{ env.TAG }}
 


### PR DESCRIPTION
Ikke støtte før short sha ref i v2 per https://github.com/actions/checkout/issues/265