### PR TITLE
fjerner /inntekt/ fra A-inntekt lenke

### DIFF
--- a/packages/konstanter/src/eksterneLenker.ts
+++ b/packages/konstanter/src/eksterneLenker.ts
@@ -1,4 +1,4 @@
-export const AINNTEKT_URL = 'https://arbeid-og-inntekt.nais.adeo.no/inntekt/'; // /?0#!empty';
+export const AINNTEKT_URL = 'https://arbeid-og-inntekt.nais.adeo.no/'; // /?0#!empty';
 export const AAREG_URL = 'https://arbeid-og-inntekt.nais.adeo.no/'; // /?4';
 export const RETTSKILDE_URL = 'https://lovdata.no/pro/sso/login/nav';
 export const LINK_TIL_BESTE_BEREGNING_REGNEARK =


### PR DESCRIPTION
må gå til forsiden, kan ikke søke opp person på https://arbeid-og-inntekt.nais.adeo.no/inntekt/