### PR TITLE
Lagt til nytt fritekstbehov for formidling

### DIFF
--- a/packages/prosess-vedtak/src/components/VedtakForm.jsx
+++ b/packages/prosess-vedtak/src/components/VedtakForm.jsx
@@ -93,6 +93,7 @@ export class VedtakForm extends Component {
       UNNTAK_FRA_TILSYNSORDNING,
       BEREGNING_25_PROSENT_AVVIK,
       OVER_18_AAR,
+      REVURDERING_ENDRING,
       fritekstdokumenter,
       lagreDokumentdata,
       ...formProps
@@ -105,6 +106,7 @@ export class VedtakForm extends Component {
       UNNTAK_FRA_TILSYNSORDNING,
       BEREGNING_25_PROSENT_AVVIK,
       OVER_18_AAR,
+      REVURDERING_ENDRING,
     };
 
     return (
@@ -241,6 +243,7 @@ VedtakForm.propTypes = {
   UNNTAK_FRA_TILSYNSORDNING: PropTypes.string,
   BEREGNING_25_PROSENT_AVVIK: PropTypes.string,
   OVER_18_AAR: PropTypes.string,
+  REVURDERING_ENDRING: PropTypes.string,
   fritekstdokumenter: PropTypes.arrayOf(PropTypes.shape()),
   ...formPropTypes,
 };
@@ -258,6 +261,7 @@ VedtakForm.defaultProps = {
   UNNTAK_FRA_TILSYNSORDNING: undefined,
   BEREGNING_25_PROSENT_AVVIK: undefined,
   OVER_18_AAR: undefined,
+  REVURDERING_ENDRING: undefined,
 };
 
 export const buildInitialValues = createSelector(
@@ -302,6 +306,7 @@ export const buildInitialValues = createSelector(
     UNNTAK_FRA_TILSYNSORDNING: dokumentdata?.UNNTAK_FRA_TILSYNSORDNING,
     BEREGNING_25_PROSENT_AVVIK: dokumentdata?.BEREGNING_25_PROSENT_AVVIK,
     OVER_18_AAR: dokumentdata?.OVER_18_AAR,
+    REVURDERING_ENDRING: dokumentdata?.REVURDERING_ENDRING,
   }),
 );
 

--- a/packages/prosess-vedtak/src/components/VedtakForm.spec.jsx
+++ b/packages/prosess-vedtak/src/components/VedtakForm.spec.jsx
@@ -768,6 +768,7 @@ describe('<VedtakForm>', () => {
       KONTINUERLIG_TILSYN: undefined,
       OMSORGEN_FOR: undefined,
       OVER_18_AAR: undefined,
+      REVURDERING_ENDRING: undefined,
       UNNTAK_FRA_TILSYNSORDNING: undefined,
       VILKAR_FOR_TO: undefined,
     });
@@ -842,6 +843,7 @@ describe('<VedtakForm>', () => {
       KONTINUERLIG_TILSYN: undefined,
       OMSORGEN_FOR: undefined,
       OVER_18_AAR: undefined,
+      REVURDERING_ENDRING: undefined,
       UNNTAK_FRA_TILSYNSORDNING: undefined,
       VILKAR_FOR_TO: undefined,
       sprakkode,

--- a/packages/prosess-vedtak/src/components/revurdering/VedtakRevurderingForm.jsx
+++ b/packages/prosess-vedtak/src/components/revurdering/VedtakRevurderingForm.jsx
@@ -108,6 +108,7 @@ export class VedtakRevurderingFormImpl extends Component {
       UNNTAK_FRA_TILSYNSORDNING,
       BEREGNING_25_PROSENT_AVVIK,
       OVER_18_AAR,
+      REVURDERING_ENDRING,
       lagreDokumentdata,
       personopplysninger,
       ...formProps
@@ -120,6 +121,7 @@ export class VedtakRevurderingFormImpl extends Component {
       UNNTAK_FRA_TILSYNSORDNING,
       BEREGNING_25_PROSENT_AVVIK,
       OVER_18_AAR,
+      REVURDERING_ENDRING,
     };
 
     const { erSendtInnUtenArsaker } = this.state;
@@ -279,6 +281,7 @@ VedtakRevurderingFormImpl.propTypes = {
   UNNTAK_FRA_TILSYNSORDNING: PropTypes.string,
   BEREGNING_25_PROSENT_AVVIK: PropTypes.string,
   OVER_18_AAR: PropTypes.string,
+  REVURDERING_ENDRING: PropTypes.string,
   arbeidsgiverOpplysningerPerId: PropTypes.shape().isRequired,
   personopplysninger: PropTypes.shape().isRequired,
   ...formPropTypes,
@@ -301,6 +304,7 @@ VedtakRevurderingFormImpl.defaultProps = {
   UNNTAK_FRA_TILSYNSORDNING: undefined,
   BEREGNING_25_PROSENT_AVVIK: undefined,
   OVER_18_AAR: undefined,
+  REVURDERING_ENDRING: undefined,
 };
 
 const buildInitialValues = createSelector(
@@ -364,6 +368,7 @@ const buildInitialValues = createSelector(
       UNNTAK_FRA_TILSYNSORDNING: dokumentdata?.UNNTAK_FRA_TILSYNSORDNING,
       BEREGNING_25_PROSENT_AVVIK: dokumentdata?.BEREGNING_25_PROSENT_AVVIK,
       OVER_18_AAR: dokumentdata?.OVER_18_AAR,
+      REVURDERING_ENDRING: dokumentdata?.REVURDERING_ENDRING,
     };
   },
 );


### PR DESCRIPTION
Formidling trenger egen fritekst i endringsbrev, og vil legge ved koden `REVURDERING_ENDRING` med beskrivelse, når det er nødvendig.   