### PR TITLE
Tillrettelegger for flere muligheter av fnr og fødselsdato

### DIFF
--- a/packages/fakta-barn-oms/src/FaktaBarnIndex.tsx
+++ b/packages/fakta-barn-oms/src/FaktaBarnIndex.tsx
@@ -121,7 +121,12 @@ const FaktaBarnIndex = ({ barn = [], rammevedtak = [], fagsaksType }: FaktaBarnI
     };
 
     rammevedtakGruppertPerBarn.forEach(barnMedRV => {
-      if (barnMedRV.personIdent === b.personIdent) {
+      const BarnRVFodselsnummer = barnMedRV.personIdent.substr(0, 6);
+      const BarnFodselsnummer = b.personIdent.substr(0, 6);
+      if (barnMedRV.personIdent === b.personIdent
+        || BarnRVFodselsnummer === b.personIdent
+        || barnMedRV.personIdent === BarnFodselsnummer
+      ) {
         kombinertBarnOgRammevedtak.rammevedtak = barnMedRV;
       }
     });


### PR DESCRIPTION
Hade tidigare kun fødelsdato når det kom till rammevedtak men må nå støtte att flere kombinasjoner av fnr og fødselsdato