### PR TITLE
Lagt til støtte for npm-registry i dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,10 +1,17 @@
 version: 2
+registries:
+  npm-github:
+    type: npm-registry
+    url: https://npm.pkg.github.com
+    token: ${{secrets.DEPENDABOT_TOKEN}}
 updates:
   - package-ecosystem: npm
     directory: "/"
     schedule:
       interval: daily
-    open-pull-requests-limit: 10
+    open-pull-requests-limit: 20
+    registries:
+      - npm-github
   - package-ecosystem: github-actions
     directory: "/"
     schedule:


### PR DESCRIPTION
Trenger en PAT med repo read/write under Settings > Secrets > Dependabot > Repository secrets