### PR TITLE
Viser alltid aksjonspunktvisning for overlappende ytelser

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -160,16 +160,6 @@ module.exports = {
       }),
     );
 
-    config.plugins.push(new ESLintPlugin({
-      context: PACKAGES_DIR,
-      extensions: ['.js', '.jsx', '.ts', '.tsx'],
-      failOnWarning: false,
-      failOnError: !(configType === 'DEVELOPMENT'),
-      fix: (configType === 'DEVELOPMENT'),
-      overrideConfigFile: path.resolve(__dirname, (configType === 'DEVELOPMENT') ? '../eslint/eslintrc.dev.js' : '../eslint/eslintrc.prod.js'),
-      cache: true,
-    }));
-
     config.resolve.extensions.push('.ts', '.tsx', '.less');
 
     // Return the altered config

--- a/packages/prosess-vedtak/src/components/FritekstBrevPanel.tsx
+++ b/packages/prosess-vedtak/src/components/FritekstBrevPanel.tsx
@@ -66,7 +66,7 @@ const FritekstBrevPanel = ({
       {!readOnly && !harAutomatiskVedtaksbrev && (
         <div className={styles.brevAlertContainer}>
           <Alert variant="info" size="small">
-            Denne type behandling har ingen automatisk brev.
+            Denne type behandling er det ikke utviklet automatisk brev for enda.
           </Alert>
         </div>
       )}

--- a/packages/prosess-vedtak/src/components/VedtakAksjonspunktPanel.tsx
+++ b/packages/prosess-vedtak/src/components/VedtakAksjonspunktPanel.tsx
@@ -50,7 +50,6 @@ export const VedtakAksjonspunktPanelImpl: React.FC<Props> = ({
       />
       {overlappendeYtelser && overlappendeYtelser.length > 0 && (
         <VedtakOverlappendeYtelsePanel
-          aksjonspunktKoder={aksjonspunktKoder}
           alleKodeverk={alleKodeverk}
           overlappendeYtelser={overlappendeYtelser}
           harVurdertOverlappendeYtelse={harVurdertOverlappendeYtelse}

--- a/packages/prosess-vedtak/src/components/VedtakForm.tsx
+++ b/packages/prosess-vedtak/src/components/VedtakForm.tsx
@@ -138,18 +138,13 @@ export const VedtakForm: React.FC<Props> = ({
   const [erSendtInnUtenArsaker, setErSendtInnUtenArsaker] = useState(false);
   const [harVurdertOverlappendeYtelse, setHarVurdertOverlappendeYtelse] = useState(false);
   const [visSakGårIkkeTilBeslutterModal, setVisSakGårIkkeTilBeslutterModal] = useState(false);
-  const måVurdereOverlappendeYtelse = aksjonspunkter.some(
-    aksjonspunkt => aksjonspunkt.definisjon.kode === aksjonspunktCodes.VURDERE_OVERLAPPENDE_YTELSER_FØR_VEDTAK,
-  );
+  const harOverlappendeYtelser = overlappendeYtelser && overlappendeYtelser.length > 0;
   const vedtakContext = useContext(VedtakFormContext);
   const onToggleOverstyring = (e, setFieldValue) => {
     const isChecked = e.target.checked;
     setFieldValue(fieldnames.SKAL_BRUKE_OVERSTYRENDE_FRITEKST_BREV, isChecked);
     if (isChecked) {
       setFieldValue(fieldnames.SKAL_HINDRE_UTSENDING_AV_BREV, false);
-    } else {
-      setFieldValue(fieldnames.BRØDTEKST, '');
-      setFieldValue(fieldnames.OVERSKRIFT, '');
     }
   };
 
@@ -159,8 +154,6 @@ export const VedtakForm: React.FC<Props> = ({
 
     if (isChecked) {
       setFieldValue(fieldnames.SKAL_BRUKE_OVERSTYRENDE_FRITEKST_BREV, false);
-      setFieldValue(fieldnames.BRØDTEKST, '');
-      setFieldValue(fieldnames.OVERSKRIFT, '');
     }
   };
 
@@ -285,7 +278,7 @@ export const VedtakForm: React.FC<Props> = ({
     <Formik
       initialValues={{ ...initialValues, ...vedtakContext?.vedtakFormState }}
       onSubmit={(values, actions) => {
-        if ((måVurdereOverlappendeYtelse && harVurdertOverlappendeYtelse) || !måVurdereOverlappendeYtelse) {
+        if ((harOverlappendeYtelser && harVurdertOverlappendeYtelse) || !harOverlappendeYtelser) {
           submitCallback(createPayload(values));
         } else {
           actions.setSubmitting(false);
@@ -443,7 +436,7 @@ export const VedtakForm: React.FC<Props> = ({
                   formikValues={formikProps.values}
                   isSubmitting={formikProps.isSubmitting}
                   skalBrukeOverstyrendeFritekstBrev={formikProps.values.skalBrukeOverstyrendeFritekstBrev}
-                  handleSubmit={erToTrinn ? formikProps.handleSubmit : () => setVisSakGårIkkeTilBeslutterModal(true)}
+                  handleSubmit={erToTrinn ? formikProps.handleSubmit : handleErToTrinnSubmit}
                   ytelseTypeKode={ytelseTypeKode}
                   readOnly={readOnly}
                   behandlingStatusKode={behandlingStatus?.kode}

--- a/packages/prosess-vedtak/src/components/VedtakOverlappendeYtelsePanel.tsx
+++ b/packages/prosess-vedtak/src/components/VedtakOverlappendeYtelsePanel.tsx
@@ -1,4 +1,3 @@
-import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import { BorderBox, VerticalSpacer } from '@fpsak-frontend/shared-components';
 import Tidslinje from '@fpsak-frontend/tidslinje/src/components/pleiepenger/Tidslinje';
 import Periode from '@fpsak-frontend/tidslinje/src/components/pleiepenger/types/Periode';
@@ -15,7 +14,6 @@ import styles from './VedtakOverlappendeYtelsePanel.less';
 interface Props {
   overlappendeYtelser: any;
   alleKodeverk: { [key: string]: KodeverkMedNavn[] };
-  aksjonspunktKoder: string[];
   harVurdertOverlappendeYtelse: boolean;
   setHarVurdertOverlappendeYtelse: (harVurdertOverlappendeYtelse: boolean) => void;
 }
@@ -24,7 +22,6 @@ const VedtakOverlappendeYtelsePanel: React.FC<Props & WrappedComponentProps> = (
   overlappendeYtelser,
   alleKodeverk,
   intl,
-  aksjonspunktKoder,
   harVurdertOverlappendeYtelse,
   setHarVurdertOverlappendeYtelse,
 }) => {
@@ -98,55 +95,46 @@ const VedtakOverlappendeYtelsePanel: React.FC<Props & WrappedComponentProps> = (
       />
     );
 
-  const harAksjonspunkt =
-    aksjonspunktKoder && aksjonspunktKoder.includes(aksjonspunktCodes.VURDERE_OVERLAPPENDE_YTELSER_FØR_VEDTAK);
-
   return (
     <>
-      {harAksjonspunkt && (
-        <>
-          <Alert className={styles.aksjonspunktAlert} variant="warning" size="medium">
-            <Heading spacing size="small" level="3">
-              Søker har overlappende ytelser
-            </Heading>
-            <BodyLong>Vurder om overlappende ytelser gir konsekvens for vedtak</BodyLong>
-            <VerticalSpacer twentyPx />
-            {getTidslinje()}
-            <VerticalSpacer twentyPx />
-            <CheckboxGroup
-              legend="Bekreft at overlappende ytelser er sjekket og fulgt opp"
-              hideLegend
-              error={submitCount > 0 && !harVurdertOverlappendeYtelse ? 'Du må bekrefte for å gå videre' : ''}
-            >
-              <Checkbox
-                checked={harVurdertOverlappendeYtelse}
-                onChange={() => setHarVurdertOverlappendeYtelse(!harVurdertOverlappendeYtelse)}
-                size="small"
-                error={submitCount > 0 && !harVurdertOverlappendeYtelse}
-                value="harVurdertOverlappendeYtelse"
-              >
-                Jeg bekrefter å ha sjekket og fulgt opp overlappende ytelser
-              </Checkbox>
-            </CheckboxGroup>
-          </Alert>
-          <Alert variant="info" size="medium">
-            <Accordion className={styles.accordion}>
-              <Accordion.Item>
-                <Accordion.Header type="button">
-                  <Heading spacing size="small" level="3">
-                    Hvilke ytelser går det automatisk melding?
-                  </Heading>
-                </Accordion.Header>
-                <Accordion.Content>
-                  <BodyLong>Nå kan du sende inn søknaden.</BodyLong>
-                </Accordion.Content>
-              </Accordion.Item>
-            </Accordion>
-          </Alert>
-        </>
-      )}
-
-      {!harAksjonspunkt && getTidslinje()}
+      <Alert className={styles.aksjonspunktAlert} variant="warning" size="medium">
+        <Heading spacing size="small" level="3">
+          Søker har overlappende ytelser
+        </Heading>
+        <BodyLong>Vurder om overlappende ytelser gir konsekvens for vedtak</BodyLong>
+        <VerticalSpacer twentyPx />
+        {getTidslinje()}
+        <VerticalSpacer twentyPx />
+        <CheckboxGroup
+          legend="Bekreft at overlappende ytelser er sjekket og fulgt opp"
+          hideLegend
+          error={submitCount > 0 && !harVurdertOverlappendeYtelse ? 'Du må bekrefte for å gå videre' : ''}
+        >
+          <Checkbox
+            checked={harVurdertOverlappendeYtelse}
+            onChange={() => setHarVurdertOverlappendeYtelse(!harVurdertOverlappendeYtelse)}
+            size="small"
+            error={submitCount > 0 && !harVurdertOverlappendeYtelse}
+            value="harVurdertOverlappendeYtelse"
+          >
+            Jeg bekrefter å ha sjekket og fulgt opp overlappende ytelser
+          </Checkbox>
+        </CheckboxGroup>
+      </Alert>
+      <Alert variant="info" size="medium">
+        <Accordion className={styles.accordion}>
+          <Accordion.Item>
+            <Accordion.Header type="button">
+              <Heading spacing size="small" level="3">
+                Hvilke ytelser går det automatisk melding?
+              </Heading>
+            </Accordion.Header>
+            <Accordion.Content>
+              <BodyLong>Nå kan du sende inn søknaden.</BodyLong>
+            </Accordion.Content>
+          </Accordion.Item>
+        </Accordion>
+      </Alert>
 
       {valgtPeriode && (
         <BorderBox>

--- a/packages/prosess-vedtak/src/components/brev/MellomLagreBrev.tsx
+++ b/packages/prosess-vedtak/src/components/brev/MellomLagreBrev.tsx
@@ -5,6 +5,8 @@ import { Button } from '@navikt/ds-react';
 import { Column, Row } from 'nav-frontend-grid';
 import { VerticalSpacer } from '@fpsak-frontend/shared-components';
 import { DokumentDataType, LagreDokumentdataType } from '@k9-sak-web/types/src/dokumentdata';
+import { useFormikContext } from 'formik';
+import { fieldnames } from '../../konstanter';
 
 /**
  * Noen typer brukt i denne komponenten, burde flyttes når fler av komponentene blir refaktorert til typescript
@@ -55,6 +57,7 @@ const MellomLagreBrev = ({
   const [originalBrev, setOriginalBrev] = useState(undefined);
   const [erTekstLik, setErTekstLik] = useState(false);
   const [erTekstEndret, setErTekstEndret] = useState(false);
+  const { values } = useFormikContext();
 
   /**
    * @param {string} overskriftStreng
@@ -104,6 +107,8 @@ const MellomLagreBrev = ({
     }
   }, [originalBrev, overskrift, brødtekst, inkluderKalender]);
 
+  const visningForBrevIkkeLagret = values[fieldnames.SKAL_BRUKE_OVERSTYRENDE_FRITEKST_BREV] === true;
+
   if (erTekstEndret && (overskrift || brødtekst || inkluderKalender)) {
     return (
       <Row>
@@ -111,14 +116,26 @@ const MellomLagreBrev = ({
           {!erTekstLik && (
             <>
               <VerticalSpacer sixteenPx />
-              <AlertStripe type="advarsel" form="inline">
-                {intl.formatMessage({ id: 'VedtakForm.FritekstBrevIkkeLagret' })}
-              </AlertStripe>
-              <VerticalSpacer sixteenPx />
+              {visningForBrevIkkeLagret && (
+                <>
+                  <AlertStripe type="advarsel" form="inline">
+                    {intl.formatMessage({ id: 'VedtakForm.FritekstBrevIkkeLagret' })}
+                  </AlertStripe>
+                  <VerticalSpacer sixteenPx />
+                </>
+              )}
               {submitKnapp}
-              <Button type="button" variant="secondary" size="small" onClick={onMellomlagreClick} disabled={erTekstLik}>
-                {intl.formatMessage({ id: 'VedtakForm.FritekstBrevLagre' })}
-              </Button>
+              {visningForBrevIkkeLagret && (
+                <Button
+                  type="button"
+                  variant="secondary"
+                  size="small"
+                  onClick={onMellomlagreClick}
+                  disabled={erTekstLik}
+                >
+                  {intl.formatMessage({ id: 'VedtakForm.FritekstBrevLagre' })}
+                </Button>
+              )}
               <VerticalSpacer sixteenPx />
             </>
           )}

--- a/packages/storybook/stories/prosess/VedtakProsessIndex.stories.js
+++ b/packages/storybook/stories/prosess/VedtakProsessIndex.stories.js
@@ -595,6 +595,7 @@ export const visOverlappendeYtelser = () => {
       submitCallback={action('button-click')}
       alleKodeverk={alleKodeverk}
       overlappendeYtelser={overlappendeYtelser}
+      featureToggles={{ NY_PROSESS_VEDTAK_ENABLED: true }}
     />
   );
 };


### PR DESCRIPTION
Tekst og designendringer
Fjernet eslint fra storybook-bygg som gjorde oppstart latterlig tregt