### PR TITLE
Bugfix: VedtakContext differ mot tilgjengligvedtaksbrev før kallet er…

### DIFF
--- a/packages/prosess-vedtak/src/components/VedtakForm.tsx
+++ b/packages/prosess-vedtak/src/components/VedtakForm.tsx
@@ -253,7 +253,10 @@ export const VedtakForm: React.FC<Props> = ({
     // Hvis vi har maler i contexten,
     // sjekk om de er forskjellige fra maler som er tilgjengelige i API
     if (vedtakContext.vedtakFormState?.maler) {
-      if (JSON.stringify(vedtakContext?.vedtakFormState?.maler) !== JSON.stringify(tilgjengeligeVedtaksbrev?.maler)) {
+      if (
+        tilgjengeligeVedtaksbrev &&
+        JSON.stringify(vedtakContext?.vedtakFormState?.maler) !== JSON.stringify(tilgjengeligeVedtaksbrev?.maler)
+      ) {
         // Hvis det er diff tilgjengelige vedtaksbrev og kontekst
         // nullstill valg som har blitt gjort med tidligere tilgjengelige vedtaksbrev
         const nyVedtakState = filtrerVerdierSomSkalNullstilles({


### PR DESCRIPTION
… utført og den er undefined. Resultat er diff når det ikke er det egentlig, og fritekst checkboksen blir resatt og er mulig å redigere. Differ bare når tilgjengligvedtaksbrev har svart.