### PR TITLE
Revert "Bump @editorjs/editorjs from 2.27.2 to 2.28.0 (#4937)"

### DIFF
--- a/packages/prosess-vedtak/package.json
+++ b/packages/prosess-vedtak/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "@editorjs/editorjs": "2.28.0",
+    "@editorjs/editorjs": "2.27.2",
     "@editorjs/header": "2.7.0",
     "@editorjs/list": "1.8.0",
     "@editorjs/paragraph": "2.10.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1846,10 +1846,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@editorjs/editorjs@npm:2.28.0":
-  version: 2.28.0
-  resolution: "@editorjs/editorjs@npm:2.28.0"
-  checksum: 48f19fe090de4fbd45e54b44b80f2269ca33395166ac3537e643ed26417bc894a32c6300494162d9f42bf209074f2d89d96fd1920238e09dcbdf2562f861622e
+"@editorjs/editorjs@npm:2.27.2":
+  version: 2.27.2
+  resolution: "@editorjs/editorjs@npm:2.27.2"
+  checksum: fd484610d8ba8f04aff5ac5331c7a0ec75796af5dc0251e13cf5e64fdbe72d53f91e35b146cb3aca23db7091bd70da8b1abf9bcfc834c07dcc79e1299e010d7a
   languageName: node
   linkType: hard
 
@@ -3246,7 +3246,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@fpsak-frontend/prosess-vedtak@workspace:packages/prosess-vedtak"
   dependencies:
-    "@editorjs/editorjs": 2.28.0
+    "@editorjs/editorjs": 2.27.2
     "@editorjs/header": 2.7.0
     "@editorjs/list": 1.8.0
     "@editorjs/paragraph": 2.10.0


### PR DESCRIPTION
This reverts commit 2b9788b1d6705fa63efc641c69cf579098d38677.