### PR TITLE
Unngå feil når valgtBrevmal er undefined i Messages.tsx

### DIFF
--- a/packages/sak-meldinger/src/components/Messages.tsx
+++ b/packages/sak-meldinger/src/components/Messages.tsx
@@ -153,7 +153,7 @@ export const MessagesImpl = ({
           : JSON.stringify(recipients[0]),
       );
 
-      if (valgtBrevmal.linker.length > 0) {
+      if (valgtBrevmal?.linker?.length > 0) {
         requestMessagesApi.setLinks(valgtBrevmal.linker);
         hentPreutfylteMaler()
           .then(_fritekstForslagTyper => {
@@ -186,7 +186,7 @@ export const MessagesImpl = ({
             ))}
             bredde="xxl"
           />
-          {valgtBrevmal?.linker.length > 0 && fritekstforslagTyper && (
+          {valgtBrevmal?.linker?.length > 0 && fritekstforslagTyper && (
             <>
               <VerticalSpacer eightPx />
               <SelectField


### PR DESCRIPTION
Fekk undefined feil ved opning av komponent i storybook (sak-meldinger).

 ~~Antar det potensielt også kan skje i reell drift ut frå slik koden er skrive.~~  commit log melding tyder på at dette kanskje berre er ei problemstilling i utvikling/test