### PR TITLE
Bytter fra anchor til knapp i historikkinnslag

### DIFF
--- a/packages/sak-historikk/src/components/maler/felles/bubbleText.module.css
+++ b/packages/sak-historikk/src/components/maler/felles/bubbleText.module.css
@@ -1,4 +1,8 @@
 .clickableArea {
+  background: none;
+  border: none;
+  color: rgb(0, 103, 197);
+  cursor: pointer;
   float: right;
   margin-bottom: 4px;
   margin-top: 4px;

--- a/packages/sak-historikk/src/components/maler/felles/bubbleText.spec.tsx
+++ b/packages/sak-historikk/src/components/maler/felles/bubbleText.spec.tsx
@@ -31,7 +31,7 @@ describe('<BubbleText>', () => {
     const wrapper = shallowWithIntl(
       <BubbleText.WrappedComponent intl={intlMock} bodyText={bodyText} cutOffLength={cutOffLength} />,
     );
-    const x = wrapper.find('a');
+    const x = wrapper.find('button');
     x.simulate('click');
     const oppChevron = wrapper.find(OppChevron);
     expect(oppChevron).toHaveLength(1);

--- a/packages/sak-historikk/src/components/maler/felles/bubbleText.tsx
+++ b/packages/sak-historikk/src/components/maler/felles/bubbleText.tsx
@@ -39,15 +39,16 @@ const BubbleText = ({ intl, cutOffLength = 83, bodyText = '' }: OwnProps & Wrapp
     <>
       {expanded && <div>{bodyText}</div>}
       {!expanded && <div className={styles.breakWord}>{truncateText(bodyText, cutOffLength)}</div>}
-      <a
-        href="#"
+      <button
+        type="button"
         onClick={handleOnClick}
         onKeyDown={handleKeyDown}
         className={styles.clickableArea}
-        title={intl.formatMessage({ id: expanded ? 'BubbleText.LukkeTekstfelt' : 'BubbleText.ApneTekstfelt' })}
+        aria-label={intl.formatMessage({ id: expanded ? 'BubbleText.LukkeTekstfelt' : 'BubbleText.ApneTekstfelt' })}
+        aria-expanded={expanded}
       >
         {expanded ? <OppChevron /> : <NedChevron />}
-      </a>
+      </button>
     </>
   );
 };


### PR DESCRIPTION
Bakgrunn: Lenke scrollet hele vinduet til toppen ved klikk.

Løsning: Knapp er mer egnet her, og scroller ikke vinduet til toppen