### PR TITLE
Endre logikk for om endringslogg skal rendres

### DIFF
--- a/packages/sak-dekorator/src/HeaderWithErrorPanel.spec.tsx
+++ b/packages/sak-dekorator/src/HeaderWithErrorPanel.spec.tsx
@@ -1,23 +1,23 @@
+import { render, screen } from '@testing-library/react';
 import React from 'react';
-import { shallow } from 'enzyme';
-import { Header } from '@navikt/ft-plattform-komponenter';
-
+import { MemoryRouter } from 'react-router';
 import HeaderWithErrorPanel from './HeaderWithErrorPanel';
 
 describe('<HeaderWithErrorPanel>', () => {
   it('skal sjekke at navn blir vist', () => {
-    const wrapper = shallow(
-      <HeaderWithErrorPanel
-        navAnsattName="Per"
-        removeErrorMessage={() => undefined}
-        setSiteHeight={() => undefined}
-        getPathToFplos={() => undefined}
-        getPathToK9Punsj={() => undefined}
-        ainntektPath="test"
-        aaregPath="test"
-      />,
+    render(
+      <MemoryRouter>
+        <HeaderWithErrorPanel
+          navAnsattName="Per"
+          removeErrorMessage={() => undefined}
+          setSiteHeight={() => undefined}
+          getPathToFplos={() => undefined}
+          getPathToK9Punsj={() => undefined}
+          ainntektPath="test"
+          aaregPath="test"
+        />
+      </MemoryRouter>,
     );
-    const header = wrapper.find(Header);
-    expect(header.prop('title')).toBe('Pleiepenger, omsorgspenger og frisinn');
+    expect(screen.getByText('Pleiepenger, omsorgspenger og frisinn')).toBeInTheDocument();
   });
 });

--- a/packages/sak-dekorator/src/HeaderWithErrorPanel.tsx
+++ b/packages/sak-dekorator/src/HeaderWithErrorPanel.tsx
@@ -3,6 +3,7 @@ import Endringslogg from '@navikt/familie-endringslogg';
 import { BoxedListWithLinks, Header, Popover, SystemButton, UserPanel } from '@navikt/ft-plattform-komponenter';
 import React, { RefObject, useCallback, useEffect, useRef, useState } from 'react';
 import { RawIntlProvider, createIntl, createIntlCache } from 'react-intl';
+import { useLocation } from 'react-router';
 import messages from '../i18n/nb_NO.json';
 import ErrorMessagePanel from './ErrorMessagePanel';
 import Feilmelding from './feilmeldingTsType';
@@ -90,6 +91,7 @@ const HeaderWithErrorPanel = ({
 }: OwnProps) => {
   const [erLenkepanelApent, setLenkePanelApent] = useState(false);
   const wrapperRef = useOutsideClickEvent(erLenkepanelApent, setLenkePanelApent);
+  const location = useLocation();
 
   const fixedHeaderRef = useRef<any>();
   useEffect(() => {
@@ -149,6 +151,8 @@ const HeaderWithErrorPanel = ({
     [erLenkepanelApent],
   );
 
+  const skalViseEndringslogg = !location.pathname.includes('/close') && !!navBrukernavn;
+
   return (
     <div
       ref={fixedHeaderRef}
@@ -165,7 +169,7 @@ const HeaderWithErrorPanel = ({
             https://github.com/navikt/familie-endringslogg
             For å nå backend lokalt må man være tilkoblet naisdevice og kjøre opp k9-sak-web på port 8000 pga CORS
             */}
-            {navBrukernavn && (
+            {skalViseEndringslogg && (
               <div className={styles['endringslogg-container']}>
                 <Endringslogg
                   userId={navBrukernavn}


### PR DESCRIPTION
Bakgrunn: Endringsloggen rendres i popupen som dukker opp for innlogging, og fører alltid til feilende kall mot endringslogg backend som støyer i Sentry-loggene.

Løsning: Ikke rendre endringslogg dersom url er den som brukes i popup