### PR TITLE
forbedrer  pre-commit hookene

### DIFF
--- a/package.json
+++ b/package.json
@@ -190,9 +190,9 @@
     "workerDirectory": "public"
   },
   "lint-staged": {
-    "*.{ts,tsx,js,jsx}": "eslint --cache --fix",
-    "*.css": "stylelint --fix",
-    "*.{js,css,md}": "prettier --write"
+    "packages/**/*.{ts,tsx,js,jsx}": "eslint --cache --fix",
+    "packages/**/*.css": "stylelint --fix",
+    "packages/**/*.{ts,tsx,js,jsx, css}": "prettier --write"
   },
   "packageManager": "yarn@3.4.1"
 }


### PR DESCRIPTION
Bakgrunn: Pre commit-hookene formaterte ikke typescript-filer.

Løsning: Legg inn at typescript-filer også skal formateres. Snevrer det også inn til at bare koden i packages-mappen skal formateres