### PR TITLE
Bruk diagnosekoder for 2024.

### DIFF
--- a/packages/behandling-pleiepenger/package.json
+++ b/packages/behandling-pleiepenger/package.json
@@ -39,7 +39,7 @@
     "@k9-sak-web/rest-api-hooks": "1.0.0",
     "@k9-sak-web/sak-app": "1.0.0",
     "@k9-sak-web/types": "1.0.0",
-    "@navikt/diagnosekoder": "^1.2023.0",
+    "@navikt/diagnosekoder": "^1.2024.0",
     "@navikt/ft-fakta-beregning": "5.0.19",
     "@navikt/ft-fakta-beregning-redesign": "1.0.21",
     "@navikt/ft-fakta-fordel-beregningsgrunnlag": "7.3.22",

--- a/packages/fakta-medisinsk-vilkår/package.json
+++ b/packages/fakta-medisinsk-vilkår/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@fpsak-frontend/form": "1.0.0",
-    "@navikt/diagnosekoder": "^1.2023.0",
+    "@navikt/diagnosekoder": "^1.2024.0",
     "@navikt/ds-css": "5.12.0",
     "@navikt/ds-icons": "3.4.3",
     "@navikt/ds-react": "5.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4747,7 +4747,7 @@ __metadata:
     "@k9-sak-web/rest-api-hooks": 1.0.0
     "@k9-sak-web/sak-app": 1.0.0
     "@k9-sak-web/types": 1.0.0
-    "@navikt/diagnosekoder": ^1.2023.0
+    "@navikt/diagnosekoder": ^1.2024.0
     "@navikt/ft-fakta-beregning": 5.0.19
     "@navikt/ft-fakta-beregning-redesign": 1.0.21
     "@navikt/ft-fakta-fordel-beregningsgrunnlag": 7.3.22
@@ -5153,7 +5153,7 @@ __metadata:
   resolution: "@k9-sak-web/fakta-medisinsk-vilkar@workspace:packages/fakta-medisinsk-vilkår"
   dependencies:
     "@fpsak-frontend/form": 1.0.0
-    "@navikt/diagnosekoder": ^1.2023.0
+    "@navikt/diagnosekoder": ^1.2024.0
     "@navikt/ds-css": 5.12.0
     "@navikt/ds-icons": 3.4.3
     "@navikt/ds-react": 5.12.0
@@ -6046,10 +6046,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/diagnosekoder@npm:^1.2023.0":
-  version: 1.2023.0
-  resolution: "@navikt/diagnosekoder@npm:1.2023.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fdiagnosekoder%2F1.2023.0%2F5a183052f0676e45a88cb9ebb8696d85452f54e6"
-  checksum: 8f98bc41c36801383532e258873e5b1f35eb6e1e45cf332db3178577c97aa77c7bffc18de8ea2c27f4a6b7bc2345a21a9a81b11d207ce543e3d26dce925e9649
+"@navikt/diagnosekoder@npm:^1.2024.0":
+  version: 1.2024.0
+  resolution: "@navikt/diagnosekoder@npm:1.2024.0::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fdiagnosekoder%2F1.2024.0%2F2d990449f3bb8d5231f2e9b583ba30f8bebbeccb"
+  checksum: cb780907d39cdba45826240774e5b8f698606df77b3ec03e32574aa02face22ed90ec8d63b1b3f50ff78a8a8c50ba0dab2037d1a8916b353bbc5ffd0fcd91018
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
**Bakgrunn:**
Nye diagnosekoder er gjeldande frå 1. januar 2024

**Løsning**
Oppdater til versjon 1.2024.0 av @navikt/diagnosekoder