### PR TITLE
sender med tomme verdier for brødtekst og overskrift for å trigge rik…

### DIFF
--- a/packages/sak-app/src/behandlingsupport/melding/MeldingIndex.tsx
+++ b/packages/sak-app/src/behandlingsupport/melding/MeldingIndex.tsx
@@ -5,7 +5,11 @@ import BehandlingType, { erTilbakekrevingType } from '@fpsak-frontend/kodeverk/s
 import dokumentMalType from '@fpsak-frontend/kodeverk/src/dokumentMalType';
 import venteArsakType from '@fpsak-frontend/kodeverk/src/venteArsakType';
 import kodeverkTyper from '@fpsak-frontend/kodeverk/src/kodeverkTyper';
-import MeldingerSakIndex, { FormValues, MessagesModalSakIndex, type MeldingerSakIndexBackendApi } from '@k9-sak-web/sak-meldinger';
+import MeldingerSakIndex, {
+  FormValues,
+  MessagesModalSakIndex,
+  type MeldingerSakIndexBackendApi,
+} from '@k9-sak-web/sak-meldinger';
 import { LoadingPanel } from '@fpsak-frontend/shared-components';
 import { RestApiState } from '@k9-sak-web/rest-api-hooks';
 import {
@@ -84,8 +88,9 @@ const getPreviewCallback =
           dokumentMal,
           dokumentdata: {
             fritekst: fritekst || ' ',
-            fritekstbrev:
-              fritekstbrev && Object.values(fritekstbrev).some(x => x === null || x === '') ? null : fritekstbrev,
+            fritekstbrev: fritekstbrev
+              ? { brødtekst: fritekstbrev.brødtekst ?? '', overskrift: fritekstbrev.overskrift ?? '' }
+              : null,
           },
         };
     fetchPreview(false, data);


### PR DESCRIPTION
…tig valideringstekst fra backend. Kan ikke sende null i disse feltene fordi parsing i backend krever at de feltene er satt.