### PR TITLE
Forhåndsvisning brev: Send ugyldig orgnr til backend.

### DIFF
--- a/packages/sak-meldinger/src/components/Messages.tsx
+++ b/packages/sak-meldinger/src/components/Messages.tsx
@@ -96,12 +96,10 @@ const createValidateRecipient = recipients => value =>
     ? undefined
     : [{ id: 'ValidationMessage.InvalidRecipient' }];
 
-const createTredjepartsmottaker = (orgnr: string): Mottaker => {
-  return {
+const createTredjepartsmottaker = (orgnr: string): Mottaker => ({
     id: orgnr,
     type: 'ORGNR',
-  };
-};
+  });
 
 const resolveOverstyrtMottaker = (
   overstyrtMottaker: string,
@@ -119,7 +117,8 @@ const resolveOverstyrtMottaker = (
       eregLookupResponse.name !== undefined
     ) {
       return createTredjepartsmottaker(tredjepartsmottakerOrgnr);
-    } else if(
+    }
+    if(
       typeof tredjepartsmottakerOrgnr === 'string' &&
       tredjepartsmottakerOrgnr.length > 0 &&
       forPreview


### PR DESCRIPTION
Ved forhåndsvisning får pr no ikkje trigga validering i frontend. Så for at bruker skal få fornuftig feilmelding må vi sende ugyldig (tredjeparts)mottaker-orgnr til backend når det er snakk om kall for forhåndsvisning.