### PR TITLE
Slår på bruk av lokale pakker i prod

### DIFF
--- a/deploy/prod-fss-k9saksbehandling.yml
+++ b/deploy/prod-fss-k9saksbehandling.yml
@@ -98,6 +98,6 @@ spec:
     - name: OVERSTYR_BEREGNING
       value: "false"
     - name: LOKALE_PAKKER
-      value: "false"
+      value: "true"
     - name: "OVERSTYRING_UTTAK"
       value: "false"


### PR DESCRIPTION
Bakgrunn: Bruker per nå pakker fra k9-saksbehandling-frontend-repoet.

Løsning: Disse pakkene er kopiert inn i dette repoet. Bytter over til å bruke de lokale