### PR TITLE
Overstyr uttak fix 2

### DIFF
--- a/packages/prosess-uttak/src/ui/components/overstyrUttakForm/OverstyrUttakForm.tsx
+++ b/packages/prosess-uttak/src/ui/components/overstyrUttakForm/OverstyrUttakForm.tsx
@@ -106,9 +106,7 @@ const OverstyrUttakForm: React.FC = () => {
 
       {bekreftSlettId && (
         <Modal ref={ref} width="small" header={{ heading: "Er du sikker på at du vil slette en overstyring?", size: "small", closeButton: false }}>
-          <Modal.Body>
-            {bekreftSlettId}
-          </Modal.Body>
+          
           <Modal.Footer>
             <Button variant='danger' onClick={() => handleSlett(bekreftSlettId)}>Slett</Button>
             <Button variant='primary' onClick={() => ref.current?.close()}>Avbryt</Button>

--- a/packages/prosess-uttak/src/ui/components/overstyrUttakForm/OverstyrUttakForm.tsx
+++ b/packages/prosess-uttak/src/ui/components/overstyrUttakForm/OverstyrUttakForm.tsx
@@ -129,7 +129,7 @@ const OverstyrUttakForm: React.FC = () => {
         </div>
       )}
 
-      {!visOverstyringSkjema && overstyrte?.length > 0 && (
+      {!visOverstyringSkjema && (
         <div className={styles.overstyrUttakFormFooter}>
           <Button variant="primary" size="small" type="submit" onClick={handleSubmit} loading={loading}>
             Bekreft og fortsett


### PR DESCRIPTION
- Fikk med en unødvendig ID som ble skrevet ut i modalen
- If sjekken gjorde at man ikke fikk bekreftet aksjonspunktet hvis man ønsket å fjerne overstyringene og gå videre