### PR TITLE
Korrigere skrivefeil i variabelnavn

### DIFF
--- a/packages/behandling-pleiepenger/src/panelDefinisjoner/prosessStegPaneler/UttakProsessStegPanelDef.tsx
+++ b/packages/behandling-pleiepenger/src/panelDefinisjoner/prosessStegPaneler/UttakProsessStegPanelDef.tsx
@@ -17,7 +17,7 @@ class PanelDef extends ProsessStegPanelDef {
     alleKodeverk,
     submitCallback,
     lagreOverstyringUttak,
-    virkningsDatoUttakNyeRegler,
+    virkningsdatoUttakNyeRegler,
     relevanteAksjonspunkter,
     erOverstyrer,
   }) => (
@@ -32,7 +32,7 @@ class PanelDef extends ProsessStegPanelDef {
       alleKodeverk={alleKodeverk}
       submitCallback={submitCallback}
       lagreOverstyringUttak={lagreOverstyringUttak}
-      virkningsdatoUttakNyeRegler={virkningsDatoUttakNyeRegler}
+      virkningsdatoUttakNyeRegler={virkningsdatoUttakNyeRegler}
       relevanteAksjonspunkter={relevanteAksjonspunkter}
       erOverstyrer={erOverstyrer}
     />


### PR DESCRIPTION
En liten d ble til en stor D i overføringen fra microfrontend, og som de fleste vet (foruten meg) så er ikke `virkningsdatoUttakNyeRegler` det samme som `virkningsDatoUttakNyeRegler` ...