### PR TITLE
5085

### DIFF
--- a/packages/prosess-vedtak/i18n/nb_NO.json
+++ b/packages/prosess-vedtak/i18n/nb_NO.json
@@ -1,12 +1,6 @@
 {
   "VedtakForm.ForslagTilVedtak": "Vedtak",
   "VedtakForm.BehandlingHenlagt": "Behandlingen er henlagt",
-  "VedtakForm.SjekkTilbakekreving.Overskrift": "Har åpen tilbakekrevingssak som kan bli påvirket", 
-  "VedtakForm.SjekkTilbakekreving.Ja": "Ja", 
-  "VedtakForm.SjekkTilbakekreving.Nei": "Nei", 
-  "VedtakForm.SjekkTilbakekreving.Bekreft": "Bekreft", 
-  "VedtakForm.SjekkTilbakekreving.Beskrivelse": "Vurder om tilbakekrevingssaken skal behandles først.", 
-  "VedtakForm.SjekkTilbakekreving.Advarsel": "Sett behandlingen på vent og behandle tilbakekrevingssaken først",
   "VedtakForm.ResultatKlageYtelsesvedtakOpphevet": "Vedtaket er opphevet",
   "VedtakForm.ResultatKlageAvvist": "Klagen er avvist",
   "VedtakForm.EngangsstonadIkkeInnvilget": "Engangsstønad er avslått",

--- a/packages/prosess-vedtak/src/components/VedtakPanels.jsx
+++ b/packages/prosess-vedtak/src/components/VedtakPanels.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
+import { Alert, Button } from '@navikt/ds-react';
+
 import { kodeverkObjektPropType } from '@fpsak-frontend/prop-types';
 import behandlingType from '@fpsak-frontend/kodeverk/src/behandlingType';
 import fagsakYtelseType from '@fpsak-frontend/kodeverk/src/fagsakYtelseType';
@@ -15,7 +17,6 @@ import { finnSistePeriodeMedAvslagsårsakBeregning } from './VedtakHelper';
 import vedtakBeregningsgrunnlagPropType from '../propTypes/vedtakBeregningsgrunnlagPropType';
 import vedtakVarselPropType from '../propTypes/vedtakVarselPropType';
 import VedtakSjekkTilbakekreving from './VedtakSjekkTilbakekreving';
-import { Alert, Button } from '@navikt/ds-react';
 
 /*
  * VedtakPanels

--- a/packages/prosess-vedtak/src/components/VedtakPanels.jsx
+++ b/packages/prosess-vedtak/src/components/VedtakPanels.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 
 import { kodeverkObjektPropType } from '@fpsak-frontend/prop-types';
@@ -15,6 +15,7 @@ import { finnSistePeriodeMedAvslagsårsakBeregning } from './VedtakHelper';
 import vedtakBeregningsgrunnlagPropType from '../propTypes/vedtakBeregningsgrunnlagPropType';
 import vedtakVarselPropType from '../propTypes/vedtakVarselPropType';
 import VedtakSjekkTilbakekreving from './VedtakSjekkTilbakekreving';
+import { Alert, Button } from '@navikt/ds-react';
 
 /*
  * VedtakPanels
@@ -55,6 +56,7 @@ const VedtakPanels = ({
   lagreDokumentdata,
   overlappendeYtelser,
 }) => {
+  const [redigerSjekkTilbakekreving, setRedigerSjekkTilbakekreving] = useState(false);
   const bg = Array.isArray(beregningsgrunnlag) ? beregningsgrunnlag.filter(Boolean) : [];
   const bgYtelsegrunnlag = bg[0]?.ytelsesspesifiktGrunnlag;
   let bgPeriodeMedAvslagsårsak;
@@ -73,44 +75,61 @@ const VedtakPanels = ({
       ap.status.kode === aksjonspunktStatus.OPPRETTET,
   );
 
-  if (skalViseSjekkTilbakekreving)
-    return <VedtakSjekkTilbakekreving readOnly={readOnly} submitCallback={submitCallback} />;
+  const skalKunneRedigereSjekkTilbakekreving = !!aksjonspunkter.find(
+    ap =>
+      ap.definisjon.kode === aksjonspunktCodes.SJEKK_TILBAKEKREVING &&
+      ap.erAktivt &&
+      ap.kanLoses &&
+      ap.status.kode === aksjonspunktStatus.UTFORT,
+  );
+
+  if (skalViseSjekkTilbakekreving || redigerSjekkTilbakekreving)
+    return <VedtakSjekkTilbakekreving readOnly={readOnly} redigerSjekkTilbakekreving={redigerSjekkTilbakekreving} submitCallback={submitCallback} />;
 
   return (
-    <VedtakForm
-      submitCallback={submitCallback}
-      readOnly={readOnly}
-      previewCallback={previewCallback}
-      hentFritekstbrevHtmlCallback={hentFritekstbrevHtmlCallback}
-      behandlingId={behandlingId}
-      behandlingVersjon={behandlingVersjon}
-      behandlingresultat={behandlingresultat}
-      behandlingStatus={behandlingStatus}
-      sprakkode={sprakkode}
-      behandlingPaaVent={behandlingPaaVent}
-      tilbakekrevingvalg={tilbakekrevingvalg}
-      simuleringResultat={simuleringResultat}
-      resultatstruktur={resultatstruktur}
-      behandlingArsaker={behandlingArsaker}
-      aksjonspunkter={aksjonspunkter}
-      ytelseTypeKode={ytelseTypeKode}
-      kanOverstyre={employeeHasAccess}
-      alleKodeverk={alleKodeverk}
-      personopplysninger={personopplysninger}
-      arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
-      vilkar={vilkar}
-      vedtakVarsel={vedtakVarsel}
-      tilgjengeligeVedtaksbrev={tilgjengeligeVedtaksbrev}
-      informasjonsbehovVedtaksbrev={informasjonsbehovVedtaksbrev}
-      dokumentdata={dokumentdata}
-      fritekstdokumenter={fritekstdokumenter}
-      lagreDokumentdata={lagreDokumentdata}
-      overlappendeYtelser={overlappendeYtelser}
-      resultatstrukturOriginalBehandling={resultatstrukturOriginalBehandling}
-      bgPeriodeMedAvslagsårsak={bgPeriodeMedAvslagsårsak}
-      medlemskapFom={medlemskapFom}
-      erRevurdering={!!(behandlingTypeKode === behandlingType.REVURDERING && bg.length)}
-    />
+    <>
+      {skalKunneRedigereSjekkTilbakekreving && <Alert variant="info" className='mb-2'>
+        Det finnes aksjonspunkt for å sjekke tilbakekreving med status utført. Aksjonspunktet kan fortsatt løses ved å aktivere det igjen.
+        <Button variant="primary" onClick={() => setRedigerSjekkTilbakekreving(true)}>
+          Aktiver aksjonspunkt for å sjekke tilbakekreving
+        </Button>
+      </Alert>}
+
+      <VedtakForm
+        submitCallback={submitCallback}
+        readOnly={readOnly}
+        previewCallback={previewCallback}
+        hentFritekstbrevHtmlCallback={hentFritekstbrevHtmlCallback}
+        behandlingId={behandlingId}
+        behandlingVersjon={behandlingVersjon}
+        behandlingresultat={behandlingresultat}
+        behandlingStatus={behandlingStatus}
+        sprakkode={sprakkode}
+        behandlingPaaVent={behandlingPaaVent}
+        tilbakekrevingvalg={tilbakekrevingvalg}
+        simuleringResultat={simuleringResultat}
+        resultatstruktur={resultatstruktur}
+        behandlingArsaker={behandlingArsaker}
+        aksjonspunkter={aksjonspunkter}
+        ytelseTypeKode={ytelseTypeKode}
+        kanOverstyre={employeeHasAccess}
+        alleKodeverk={alleKodeverk}
+        personopplysninger={personopplysninger}
+        arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
+        vilkar={vilkar}
+        vedtakVarsel={vedtakVarsel}
+        tilgjengeligeVedtaksbrev={tilgjengeligeVedtaksbrev}
+        informasjonsbehovVedtaksbrev={informasjonsbehovVedtaksbrev}
+        dokumentdata={dokumentdata}
+        fritekstdokumenter={fritekstdokumenter}
+        lagreDokumentdata={lagreDokumentdata}
+        overlappendeYtelser={overlappendeYtelser}
+        resultatstrukturOriginalBehandling={resultatstrukturOriginalBehandling}
+        bgPeriodeMedAvslagsårsak={bgPeriodeMedAvslagsårsak}
+        medlemskapFom={medlemskapFom}
+        erRevurdering={!!(behandlingTypeKode === behandlingType.REVURDERING && bg.length)}
+      />
+    </>
   );
 };
 

--- a/packages/prosess-vedtak/src/components/VedtakSjekkTilbakekreving.tsx
+++ b/packages/prosess-vedtak/src/components/VedtakSjekkTilbakekreving.tsx
@@ -2,15 +2,15 @@ import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import { VerticalSpacer } from '@fpsak-frontend/shared-components';
 import { Alert, BodyLong, Button, Heading, Radio, RadioGroup } from '@navikt/ds-react';
 import React from 'react';
-import { FormattedMessage } from 'react-intl';
 import styles from './VedtakSjekkTilbakekreving.module.css';
 
 interface Props {
   readOnly: boolean;
+  redigerSjekkTilbakekreving: boolean;
   submitCallback: (aksjonspunktData: any) => void;
 }
 
-export const VedtakSjekkTilbakekreving: React.FC<Props> = ({ readOnly, submitCallback }: Props) => {
+export const VedtakSjekkTilbakekreving: React.FC<Props> = ({ readOnly, redigerSjekkTilbakekreving = false, submitCallback }: Props) => {
   const [deaktiverBekreftKnapp, setDeaktiverBekreftKnapp] = React.useState<boolean>(true);
   const [visAdvarselTekst, setVisAdvarselTekst] = React.useState<boolean>(false);
 
@@ -39,6 +39,7 @@ export const VedtakSjekkTilbakekreving: React.FC<Props> = ({ readOnly, submitCal
         <Button variant="primary" onClick={handleSubmit} type="button" disabled={deaktiverBekreftKnapp}>
           Bekreft
         </Button>
+        {redigerSjekkTilbakekreving && <Button className='ml-2' variant="secondary">Avbryt</Button>}
       </Alert>
       {deaktiverBekreftKnapp && visAdvarselTekst && (
         <>

--- a/packages/prosess-vedtak/src/components/VedtakSjekkTilbakekreving.tsx
+++ b/packages/prosess-vedtak/src/components/VedtakSjekkTilbakekreving.tsx
@@ -25,23 +25,19 @@ export const VedtakSjekkTilbakekreving: React.FC<Props> = ({ readOnly, submitCal
     <>
       <Alert className={styles.aksjonspunktAlert} variant="warning" size="medium">
         <Heading spacing size="small" level="3">
-          <FormattedMessage id="VedtakForm.SjekkTilbakekreving.Overskrift" />
+          Har åpen tilbakekrevingssak som kan bli påvirket
         </Heading>
         <BodyLong>
-          <FormattedMessage id="VedtakForm.SjekkTilbakekreving.Beskrivelse" />
+          Vurder om tilbakekrevingssaken skal behandles først.
         </BodyLong>
         <VerticalSpacer twentyPx />
         <RadioGroup legend="Behandle tilbakekrevingssaken først?" onChange={handleChange} disabled={readOnly}>
-          <Radio value="ja">
-            <FormattedMessage id="VedtakForm.SjekkTilbakekreving.Ja" />
-          </Radio>
-          <Radio value="nei">
-            <FormattedMessage id="VedtakForm.SjekkTilbakekreving.Nei" />
-          </Radio>
+          <Radio value="ja">Ja</Radio>
+          <Radio value="nei">Nei</Radio>
         </RadioGroup>
         <VerticalSpacer twentyPx />
         <Button variant="primary" onClick={handleSubmit} type="button" disabled={deaktiverBekreftKnapp}>
-          <FormattedMessage id="VedtakForm.SjekkTilbakekreving.Bekreft" />
+          Bekreft
         </Button>
       </Alert>
       {deaktiverBekreftKnapp && visAdvarselTekst && (
@@ -49,7 +45,7 @@ export const VedtakSjekkTilbakekreving: React.FC<Props> = ({ readOnly, submitCal
           <VerticalSpacer twentyPx />
           <Alert className={styles.aksjonspunktAlert} variant="error" size="small">
             <BodyLong>
-              <FormattedMessage id="VedtakForm.SjekkTilbakekreving.Advarsel" />
+              Sett behandlingen på vent og behandle tilbakekrevingssaken først
             </BodyLong>
           </Alert>
         </>


### PR DESCRIPTION
Tester en mulighet for å kunne aktivere redigering av ap 5085 etter det er satt til utført. SB ønsker å kunne gå tilbake og/eller angre valget og løse aksjonspunktet på nytt. 

Lagt til Infoboks med knapp så man kan aktivere ap igjen (redigere)

Har også fjernet intl fra sjekk tilbakekreving, ref. enighet om langsiktige målbilde. 