### PR TITLE
Tsff 100 v2/ tsconfig og gui package

### DIFF
--- a/eslint/eslintrc.common.cjs
+++ b/eslint/eslintrc.common.cjs
@@ -45,7 +45,10 @@ const config = {
     // import/no-cycle rule apparently started working when import/resolver was changed to typescript. It found lots of
     // existing problems, so disabled it for now.
     'import/no-cycle': OFF,
-    'import/extensions': ['error', 'ignorePackages', { js: 'never', jsx: 'never', ts: 'never', tsx: 'never' }],
+    // Disabled since we want to start using .js extensions when importing. Because that makes importing from packages
+    // using a simple wildcard (/*) "exports" clause possible, and gives a better dx. Especially in VS Code, path lookup
+    // from such packages works well then.
+    'import/extensions': OFF,
     'linebreak-style': OFF,
     'import/no-named-as-default': OFF,
     'max-len': [1, 160],

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:watch:all": "vitest --watchAll",
     "test:coverage": "vitest --coverage --selectProjects test",
     "test:e2e": "lerna run test:e2e --stream",
-    "ts-check": "tsc  --pretty",
+    "ts-check": "tsc  --pretty && tsc --pretty --project packages/v2/tsconfig.json",
     "lint": "eslint --cache packages --ext .ts,.tsx,.js,.jsx",
     "lint:fix": "eslint --fix --cache packages --ext .ts,.tsx,.js,.jsx",
     "css:lint": "stylelint \"packages/**/*.css\"",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "sentry-release": "(SENTRY_RELEASE=$(git rev-parse --short HEAD); node ./scripts/sentry-release)"
   },
   "workspaces": [
-    "packages/*"
+    "packages/*",
+    "packages/v2/*"
   ],
   "dependencies": {
     "@babel/runtime": "7.23.8",

--- a/packages/sak-app/package.json
+++ b/packages/sak-app/package.json
@@ -40,6 +40,7 @@
     "@k9-sak-web/fakta-medisinsk-vilkar": "1.0.0",
     "@k9-sak-web/fakta-om-barnet": "1.0.0",
     "@k9-sak-web/fakta-omsorgen-for": "1.0.0",
+    "@k9-sak-web/gui": "1.0.0",
     "@k9-sak-web/konstanter": "1.0.0",
     "@k9-sak-web/modal-sett-pa-vent": "1.0.0",
     "@k9-sak-web/prosess-omsorgsdager": "1.0.0",

--- a/packages/v2/gui/README.md
+++ b/packages/v2/gui/README.md
@@ -1,0 +1,9 @@
+k9-sak-web/gui
+==============
+
+Denne pakken er meint å innehalde kode som utgjere brukergrensesnittet til k9-sak.
+
+Stort sett skal all kode som er avhengig av React og som ikkje brukast i andre system leggast inn her.
+
+For å eksportere moduler ut frå denne pakken, juster `"exports"` klausulen i `package.json` viss nødvendig. På den måten
+kan ein bygge opp ein hierarkisk pakkestruktur som ekstern kode kan importere frå.

--- a/packages/v2/gui/package.json
+++ b/packages/v2/gui/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@k9-sak-web/gui",
+  "private": true,
+  "license": "MIT",
+  "type": "module",
+  "version": "1.0.0",
+  "exports": {
+    "./meldinger/*": "./src/meldinger/*.js"
+  },
+  "dependencies": {
+    "react": "18.2.0"
+  }
+}

--- a/packages/v2/gui/package.json
+++ b/packages/v2/gui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "version": "1.0.0",
   "exports": {
-    "./meldinger/*": "./src/meldinger/*.js"
+    "./sak/meldinger/*": "./src/sak/meldinger/*.js"
   },
   "dependencies": {
     "react": "18.2.0"

--- a/packages/v2/gui/package.json
+++ b/packages/v2/gui/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "version": "1.0.0",
   "exports": {
-    "./sak/meldinger/*": "./src/sak/meldinger/*.js"
+    "./sak/meldinger/*": "./src/sak/meldinger/*"
   },
   "dependencies": {
     "react": "18.2.0"

--- a/packages/v2/gui/src/sak/meldinger/Messages.tsx
+++ b/packages/v2/gui/src/sak/meldinger/Messages.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const Messages = () => <div>TODO</div>;
+
+export default Messages;

--- a/packages/v2/tsconfig.json
+++ b/packages/v2/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  // Basert på https://github.com/tsconfig/bases/blob/main/bases/vite-react.json og
+  // https://github.com/tsconfig/bases/blob/main/bases/strictest.json.
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "es2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "moduleResolution": "bundler",
+    "allowJs": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
+    "allowUnusedLabels": false,
+    "allowUnreachableCode": false,
+    "exactOptionalPropertyTypes": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noUncheckedIndexedAccess": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "sourceMap": true,
+    "jsx": "react",
+    "types": ["vite/client", "vitest/globals", "@testing-library/jest-dom"],
+    "baseUrl": "packages/v2/",
+    "skipLibCheck": true
+  },
+  "include": ["./**/*"],
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -5174,6 +5174,14 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@k9-sak-web/gui@1.0.0, @k9-sak-web/gui@workspace:packages/v2/gui":
+  version: 0.0.0-use.local
+  resolution: "@k9-sak-web/gui@workspace:packages/v2/gui"
+  dependencies:
+    react: 18.2.0
+  languageName: unknown
+  linkType: soft
+
 "@k9-sak-web/konstanter@1.0.0, @k9-sak-web/konstanter@workspace:packages/konstanter":
   version: 0.0.0-use.local
   resolution: "@k9-sak-web/konstanter@workspace:packages/konstanter"
@@ -5569,6 +5577,7 @@ __metadata:
     "@k9-sak-web/fakta-medisinsk-vilkar": 1.0.0
     "@k9-sak-web/fakta-om-barnet": 1.0.0
     "@k9-sak-web/fakta-omsorgen-for": 1.0.0
+    "@k9-sak-web/gui": 1.0.0
     "@k9-sak-web/konstanter": 1.0.0
     "@k9-sak-web/modal-sett-pa-vent": 1.0.0
     "@k9-sak-web/prosess-omsorgsdager": 1.0.0


### PR DESCRIPTION
**Bakgrunn**
- Ønske om å gradvis kunne skrive om gammal kode til å bli validert med strict typescript sjekking. Så vi får kontroll på null/undefined/any osv.
- Ønske om å kunne skrive ny kode  slik at den blir validert med strict typescript sjekk.
- Ønske om å redusere tal separate, teknisk sett like pakker i prosjektet.

**Resultat**
- Introduserer ny _tsconfig.json_ under _packages/v2/_. Denne vil få effekt på all kode som plasserast under _packages/v2/_ i kjeldekodetreet.
- Introduserer ein ny pakke _@k9-sak-web/gui_. Denne ligger under _packages/v2/gui_. Denne pakken definerer "rå ESM eksporter" i package.json, slik at ein kan styre fleksibelt kva som skal vere tilgjengeleg utanfrå, og konsumenter kan importere direkte frå dei kataloger/moduler det skal vere mulig å importere frå, utan å ha nokon index.ts i pakken.

Tanken er at vi gradvis kan skrive om kode frå gamle pakker inn i denne eine v2/gui pakken, og fjerne dei gamle pakkane når dei ikkje er i bruk lenger.

Eksempel på slik direkte import:
`import Messages from '@k9-sak-web/gui/sak/meldinger/Messages.js';`