### PR TITLE
Fornya tekstvalideringsfunksjon inn i v2/

### DIFF
--- a/packages/utils/src/validation/validators.spec.ts
+++ b/packages/utils/src/validation/validators.spec.ts
@@ -1,5 +1,6 @@
 import moment from 'moment';
 
+import { expect } from 'vitest';
 import { DDMMYYYY_DATE_FORMAT, ISO_DATE_FORMAT } from '../formats';
 import {
   dateAfterOrEqual,
@@ -434,11 +435,26 @@ describe('Validators', () => {
       expect(result).toBeNull();
     });
 
-    it('skal feile når fødselsnummer har ugyldige tegn', () => {
+    it('skal feile når tekst har ugyldige tegn', () => {
       const result = hasValidText('Hei {}*');
       expect(result).toHaveLength(2);
       expect(result[0]).toEqual({ id: 'ValidationMessage.InvalidText' });
       expect(result[1]).toEqual({ text: '{}' });
+    });
+
+    it('skal feile når tekst har [] tegn (brukt til placeholder i maltekst)', () => {
+      const result = hasValidText('Hei [] der');
+      expect(result).toHaveLength(2);
+      expect(result[0]).toEqual({ id: 'ValidationMessage.InvalidText' });
+      expect(result[1]).toEqual({ text: '[]' });
+    });
+
+    it('skal ikke feile når tekst er tom, null eller undefined', () => {
+      const inputs = ['', null, undefined];
+      for (const input of inputs) {
+        const result = hasValidText(input);
+        expect(result).toBeNull();
+      }
     });
   });
 

--- a/packages/utils/src/validation/validators.ts
+++ b/packages/utils/src/validation/validators.ts
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import { validateTextCharacters } from '@k9-sak-web/gui/utils/validation/validateTextCharacters.js';
 import { removeSpacesFromNumber } from '../currencyUtils';
 import { fodselsnummerPattern, isValidFodselsnummer } from '../fodselsnummerUtils';
 import { DDMMYYYY_DATE_FORMAT, ISO_DATE_FORMAT } from '../formats';
@@ -46,8 +47,6 @@ import {
   nameRegex,
   numberRegex,
   saksnummerOrFodselsnummerPattern,
-  textGyldigRegex,
-  textRegex,
   tomorrow,
   yesterday,
 } from './validatorsHelper';
@@ -133,9 +132,15 @@ export const hasValidFodselsnummerFormat = text =>
 export const hasValidFodselsnummer = text => (!isValidFodselsnummer(text) ? invalidFodselsnummerMessage() : null);
 
 export const hasValidText = text => {
-  if (!textRegex.test(text)) {
-    const illegalChars = text.replace(textGyldigRegex, '');
-    return invalidTextMessage(illegalChars.replace(/[\t]/g, 'Tabulatortegn'));
+  if (text === undefined || text === null) {
+    return null;
+  }
+  const { invalidCharacters } = validateTextCharacters(text);
+  if (invalidCharacters?.length > 0) {
+    const invalidCharacterString: string = invalidCharacters
+      .map(invalidChar => invalidChar.replace(/[\t]/, 'Tabulatortegn'))
+      .join('');
+    return invalidTextMessage(invalidCharacterString);
   }
   return null;
 };

--- a/packages/utils/src/validation/validatorsHelper.spec.ts
+++ b/packages/utils/src/validation/validatorsHelper.spec.ts
@@ -8,8 +8,6 @@ import {
   nameGyldigRegex,
   nameRegex,
   saksnummerOrFodselsnummerPattern,
-  textGyldigRegex,
-  textRegex,
   tomorrow,
   yesterday,
 } from './validatorsHelper';
@@ -41,19 +39,6 @@ describe('validatorsHelper', () => {
     it('Skal sjekke om saksnummer er i riktig format', () => {
       expect(saksnummerOrFodselsnummerPattern.test('123456789012345678')).toBe(true);
       expect(saksnummerOrFodselsnummerPattern.test('X123456789012345678')).toBe(false);
-    });
-  });
-
-  describe('textRegex', () => {
-    it('Skal sjekke om input er tekst', () => {
-      expect(textRegex.test('text')).toBe(true);
-      expect(textRegex.test('3434')).toBe(true);
-    });
-  });
-
-  describe('textGyldigRegex', () => {
-    it('Skal sjekke om input er i gyldig tekst format', () => {
-      expect(textGyldigRegex.test('Text')).toBe(true);
     });
   });
 

--- a/packages/utils/src/validation/validatorsHelper.ts
+++ b/packages/utils/src/validation/validatorsHelper.ts
@@ -7,11 +7,6 @@ export const decimalRegexWithMax = maxNumberOfDecimals => new RegExp(`^\\d+([.,]
 export const decimalRegex = decimalRegexWithMax(2);
 export const saksnummerOrFodselsnummerPattern = /^[a-zA-Z0-9_-]{0,18}$/;
 
-export const textRegex =
-  /^[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'\-‐–‑/%§!?@_()#+:;,="&\s<>~*]*$/;
-export const textGyldigRegex =
-  /[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'\-‐–‑/%§!?@_()#+:;,="&\s<>~*]*/g;
-
 export const nameRegex = /^[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'-]*$/;
 export const nameGyldigRegex =
   /[0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'-]*/g;

--- a/packages/v2/gui/src/utils/validation/regexes.ts
+++ b/packages/v2/gui/src/utils/validation/regexes.ts
@@ -1,0 +1,8 @@
+// invalidTextRegex er brukt til validering av fritekst felt.
+// Merk at denne er strengere enn validering i backend i nokre tilfeller.
+// Den kan dermed sannsynlegvis opnast opp ein god del viss ønskelig, men ein ting å tenkje på i såfall er at [] teikn
+// ikkje er tillatt pr no, og viss ein tillater det kan det føre til at saksbehandler utan å få feil kan sende brev der
+// "placeholder" markeringer som bruker [ og ] teikn ikkje er redigert, og dermed kan det føre til at ufullstendige brev
+// blir sendt. Dette bør derfor avklarast nærmare før ein evt tillater [] teikn i denne valideringa.
+export const invalidTextRegex =
+  /[^0-9a-zA-ZæøåÆØÅAaÁáBbCcČčDdĐđEeFfGgHhIiJjKkLlMmNnŊŋOoPpRrSsŠšTtŦŧUuVvZzŽžéôèÉöüäÖÜÄ .'\-‐–‑/%§!?@_()#+:;,="&\s<>~*]/g;

--- a/packages/v2/gui/src/utils/validation/validateTextCharacters.ts
+++ b/packages/v2/gui/src/utils/validation/validateTextCharacters.ts
@@ -1,0 +1,19 @@
+import { invalidTextRegex } from './regexes.js';
+
+export interface InvalidTextResult {
+  readonly ok?: never;
+  readonly invalidCharacters: string[];
+}
+
+export interface ValidTextResult {
+  readonly ok: true;
+  readonly invalidCharacters?: never;
+}
+
+export const validateTextCharacters = (inp: string): ValidTextResult | InvalidTextResult => {
+  const invalidCharacters = inp.match(invalidTextRegex);
+  if (invalidCharacters !== null) {
+    return { invalidCharacters };
+  }
+  return { ok: true };
+};


### PR DESCRIPTION
**Bakgrunn**
Behov for å ha validering av gyldige teikn i fritekst felt i v2/.

**Løysing**
Laga ny kode i v2/ der eg forenkla gammal kode til å berre vere ein regex, og returnerer strukturert valideringsresultat.

Bruker deretter ny kode i gammal funksjon.