### PR TITLE
Skiller installering og caching av Playwright ut i egen action

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,0 +1,34 @@
+name: 'Install and cache Playwright'
+description: Run commands needed to install and cache Playwright.
+inputs:
+  cacheOnly:
+    description: Is this for caching purposes only?
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: Finn Playwright versjon
+      shell: bash
+      run: |
+        PLAYWRIGHT_VERSION=$(YARN_ENABLE_COLORS=false yarn info @playwright/test | grep @playwright | sed 's/.*://')
+        echo "Playwright's Version: $PLAYWRIGHT_VERSION"
+        echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
+
+    - name: Cache Playwright Browsers for Playwright versjon
+      shell: bash
+      id: cache-playwright-browsers
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-browsers-${{ env.PLAYWRIGHT_VERSION }}
+
+    - name: Installer Playwright med avhengigheter
+      shell: bash
+      if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
+      run: npx playwright install --with-deps
+
+    - name: Installer Playwrights avhengigheter
+      shell: bash
+      if: inputs.cacheOnly == 'false' && steps.cache-playwright-browsers.outputs.cache-hit == 'true'
+      run: npx playwright install-deps

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -16,7 +16,6 @@ runs:
         echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
 
     - name: Cache Playwright Browsers for Playwright versjon
-      shell: bash
       id: cache-playwright-browsers
       uses: actions/cache@v4
       with:

--- a/.github/workflows/deploy-storybook-to-gh-pages.yml
+++ b/.github/workflows/deploy-storybook-to-gh-pages.yml
@@ -34,3 +34,8 @@ jobs:
           build_command: yarn build-storybook
           path: .static_storybook
           checkout: false
+
+      - name: Oppdater Playwright install cache for Storybook-tester
+        uses: ./.github/actions/setup-playwright
+        with:
+          cacheOnly: 'true'

--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -14,26 +14,8 @@ jobs:
         with:
           npmAuthToken: ${{ secrets.READER_TOKEN }}
 
-      - name: Finn Playwright versjon
-        run: |
-          PLAYWRIGHT_VERSION=$(YARN_ENABLE_COLORS=false yarn info @playwright/test | grep @playwright | sed 's/.*://')
-          echo "Playwright's Version: $PLAYWRIGHT_VERSION"
-          echo "PLAYWRIGHT_VERSION=$PLAYWRIGHT_VERSION" >> $GITHUB_ENV
-
-      - name: Cache Playwright Browsers for Playwright versjon
-        id: cache-playwright-browsers
-        uses: actions/cache@v4
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ env.PLAYWRIGHT_VERSION }}
-
-      - name: Installer Playwright med avhengigheter
-        if: steps.cache-playwright-browsers.outputs.cache-hit != 'true'
-        run: npx playwright install --with-deps
-
-      - name: Installer Playwrights avhengigheter
-        if: steps.cache-playwright-browsers.outputs.cache-hit == 'true'
-        run: npx playwright install-deps
+      - name: Installer Playwright
+        uses: ./.github/actions/setup-playwright
 
       - name: Build Storybook
         run: yarn build-storybook-test --quiet


### PR DESCRIPTION
Bakgrunn: Når Playwright caches på branch lager hver PR sin egen cached versjon fordi de ikke deler cache på tvers.

Løsning: Cache Playwright på master