### PR TITLE
Forhindre at validering mot backend gjøres for tidlig

### DIFF
--- a/packages/fakta-medisinsk-vilkår/src/ui/components/innleggelsesperiodeFormModal/InnleggelsesperiodeFormModal.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/innleggelsesperiodeFormModal/InnleggelsesperiodeFormModal.tsx
@@ -92,7 +92,9 @@ const InnleggelsesperiodeFormModal = ({
                   const initialiserteInnleggelsesperioder = getValues().innleggelsesperioder.map(
                     ({ period }: AnyType) => new Period(period.fom, period.tom),
                   );
-                  const erAllePerioderGyldige = initialiserteInnleggelsesperioder.every(periode => periode.isValid());
+                  const erAllePerioderGyldige = initialiserteInnleggelsesperioder.every(
+                    periode => periode.isValid() && periode.fomIsBeforeOrSameAsTom(),
+                  );
                   if (erAllePerioderGyldige) {
                     endringerPåvirkerAndreBehandlinger(initialiserteInnleggelsesperioder).then(
                       ({ førerTilRevurdering }) => setShowWarningMessage(førerTilRevurdering),


### PR DESCRIPTION
Bakgrunn: Dersom bruker taster innleggelsesdatoer på følgende måte `10062024` vil validering mot backend starte før man får tastet `24` i `2024` for til og med dato, altså blir det `100620`, og da vil vi få 400-feil fra backend fordi fra og med dato er i 2024 og til og med blir i 2020.

Løsning: Validerer mot backend i det perioden er ferdig utfylt og fom-dato er samme eller før tom-dato