### PR TITLE
Tsff 230 window reload

### DIFF
--- a/packages/sak-app/src/behandlingsupport/melding/MeldingIndex.spec.tsx
+++ b/packages/sak-app/src/behandlingsupport/melding/MeldingIndex.spec.tsx
@@ -5,8 +5,6 @@ import { Provider } from 'react-redux';
 import { MemoryRouter } from 'react-router-dom';
 import { combineReducers, createStore } from 'redux';
 import { reducer as formReducer } from 'redux-form';
-
-import BehandlingType from '@fpsak-frontend/kodeverk/src/behandlingType';
 import dokumentMalType from '@fpsak-frontend/kodeverk/src/dokumentMalType';
 import kodeverkTyper from '@fpsak-frontend/kodeverk/src/kodeverkTyper';
 import type { BehandlingAppKontekst, Brevmaler, Fagsak, FeatureToggles } from '@k9-sak-web/types';
@@ -16,6 +14,7 @@ import type { ForhåndsvisDto } from '@k9-sak-web/backend/k9formidling/models/Fo
 import type { FritekstbrevDokumentdata } from '@k9-sak-web/backend/k9formidling/models/FritekstbrevDokumentdata.js';
 import type { BestillBrevDto } from '@k9-sak-web/backend/k9sak/generated';
 import { FagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
+import { behandlingType } from '@k9-sak-web/backend/k9sak/kodeverk/behandling/BehandlingType.js';
 import { K9sakApiKeys, requestApi } from '../../data/k9sakApi';
 import MeldingIndex, { type BackendApi } from './MeldingIndex';
 
@@ -84,7 +83,7 @@ describe('<MeldingIndex>', () => {
     {
       id: 1,
       uuid: '1212',
-      type: { kode: BehandlingType.FORSTEGANGSSOKNAD, kodeverk: '' },
+      type: { kode: behandlingType.FØRSTEGANGSSØKNAD, kodeverk: 'BEHANDLING_TYPE' },
       sprakkode: { kode: 'NB', kodeverk: 'SPRAAK_KODE' },
     },
   ];
@@ -298,5 +297,4 @@ describe('<MeldingIndex>', () => {
     expect(reqData).toHaveLength(1);
     expect(reqData[0].params).toEqual({ ...meldingMal, ...melding, ...{ overstyrtMottaker: tredjepartsMottaker } });
   });
-
 });

--- a/packages/sak-app/src/behandlingsupport/melding/MeldingIndex.tsx
+++ b/packages/sak-app/src/behandlingsupport/melding/MeldingIndex.tsx
@@ -96,8 +96,6 @@ const MeldingIndex = ({
   return (
     <MeldingerSakIndex
       onMessageSent={reloadWindow}
-      sprakKode={behandling?.sprakkode}
-      behandlingId={behandlingId}
       behandlingVersjon={behandlingVersjon}
       revurderingVarslingArsak={revurderingVarslingArsak}
       templates={brevmaler}

--- a/packages/sak-app/src/data/useVisForhandsvisningAvMelding.tsx
+++ b/packages/sak-app/src/data/useVisForhandsvisningAvMelding.tsx
@@ -1,4 +1,5 @@
-import { Behandling, Fagsak } from '@k9-sak-web/types';
+import type { Fagsak } from '@k9-sak-web/gui/sak/Fagsak.js';
+import type { BehandlingInfo } from '@k9-sak-web/gui/sak/BehandlingInfo.js';
 
 import { erTilbakekrevingType } from '@fpsak-frontend/kodeverk/src/behandlingType';
 import lagForhåndsvisRequest, { forhandsvis } from '@fpsak-frontend/utils/src/formidlingUtils';
@@ -6,7 +7,7 @@ import { K9sakApiKeys, restApiHooks } from './k9sakApi';
 
 type ForhandsvisFunksjon = (erHenleggelse: boolean, data: any) => void;
 
-export const useVisForhandsvisningAvMelding = (behandling: Behandling, fagsak?: Fagsak): ForhandsvisFunksjon => {
+export const useVisForhandsvisningAvMelding = (behandling: BehandlingInfo, fagsak?: Fagsak): ForhandsvisFunksjon => {
   const erTilbakekreving = erTilbakekrevingType(behandling?.type);
 
   if (!erTilbakekreving && !fagsak) {

--- a/packages/sak-meldinger/src/MeldingerSakIndex.stories.tsx
+++ b/packages/sak-meldinger/src/MeldingerSakIndex.stories.tsx
@@ -87,8 +87,6 @@ const revurderingVarslingArsak = [
 export const SendMeldingPanel: Story = {
   args: {
     templates: mockedBrevmaler,
-    sprakKode: bokmål,
-    behandlingId: 1,
     behandlingVersjon: 1,
     isKontrollerRevurderingApOpen: false,
     personopplysninger,
@@ -132,9 +130,12 @@ export const SendMeldingPanelEnMal: Story = {
 export const SendMeldingPanelEngelsk: Story = {
   args: {
     ...SendMeldingPanel.args,
-    sprakKode: {
-      kode: 'EN',
-      kodeverk: 'Engelsk',
+    behandling: {
+      ...SendMeldingPanel.args.behandling,
+      sprakkode: {
+        kode: 'EN',
+        kodeverk: 'SPRAAK_KODE',
+      },
     },
   },
 };

--- a/packages/sak-meldinger/src/MeldingerSakIndex.stories.tsx
+++ b/packages/sak-meldinger/src/MeldingerSakIndex.stories.tsx
@@ -21,11 +21,8 @@ const meta: Meta<typeof MeldingerSakIndex> = {
   component: MeldingerSakIndex,
   decorators: [withMaxWidth(500)],
   argTypes: {
-    submitCallback: {
-      action: 'submitCallback',
-    },
-    previewCallback: {
-      action: 'previewCallback',
+    onMessageSent: {
+      action: 'onSubmitted',
     },
   },
 };

--- a/packages/sak-meldinger/src/MeldingerSakIndex.tsx
+++ b/packages/sak-meldinger/src/MeldingerSakIndex.tsx
@@ -5,7 +5,6 @@ import {
   ArbeidsgiverOpplysningerPerId,
   Brevmaler,
   FeatureToggles,
-  Kodeverk,
   KodeverkMedNavn,
   Personopplysninger,
 } from '@k9-sak-web/types';
@@ -37,9 +36,7 @@ export interface BackendApi extends MessagesBackendApi, V2MessagesBackendApi {}
 interface OwnProps {
   onMessageSent: () => void;
   templates: Brevmaler;
-  sprakKode: Kodeverk; // TODO Erstatt med behandling
-  behandlingId: number; // TODO Erstatt med behandling
-  behandlingVersjon: number;
+  behandlingVersjon: number; // Er vel berre for å detektere endring, kanskje fjernast etterkvart?
   isKontrollerRevurderingApOpen?: boolean;
   revurderingVarslingArsak: KodeverkMedNavn[];
   personopplysninger?: Personopplysninger;
@@ -54,8 +51,6 @@ interface OwnProps {
 const MeldingerSakIndex = ({
   onMessageSent,
   templates,
-  sprakKode,
-  behandlingId,
   behandlingVersjon,
   isKontrollerRevurderingApOpen = false,
   revurderingVarslingArsak,
@@ -92,7 +87,7 @@ const MeldingerSakIndex = ({
           brevmalkode: values.brevmalkode,
         }
       : {
-          behandlingId,
+          behandlingId: behandling.id,
           overstyrtMottaker: values.overstyrtMottaker,
           brevmalkode: values.brevmalkode,
           fritekst: values.fritekst,
@@ -132,9 +127,9 @@ const MeldingerSakIndex = ({
         <MessagesTilbakekreving
           submitCallback={submitCallback}
           templates={templates}
-          sprakKode={sprakKode}
+          sprakKode={behandling.sprakkode}
           previewCallback={previewCallback}
-          behandlingId={behandlingId}
+          behandlingId={behandling.id}
           behandlingVersjon={behandlingVersjon}
           isKontrollerRevurderingApOpen={isKontrollerRevurderingApOpen}
           revurderingVarslingArsak={revurderingVarslingArsak}
@@ -145,9 +140,9 @@ const MeldingerSakIndex = ({
         <Messages
           submitCallback={submitCallback}
           templates={templates}
-          sprakKode={sprakKode}
+          sprakKode={behandling.sprakkode}
           previewCallback={previewCallback}
-          behandlingId={behandlingId}
+          behandlingId={behandling.id}
           behandlingVersjon={behandlingVersjon}
           isKontrollerRevurderingApOpen={isKontrollerRevurderingApOpen}
           revurderingVarslingArsak={revurderingVarslingArsak}

--- a/packages/utils/src/formidlingUtils.tsx
+++ b/packages/utils/src/formidlingUtils.tsx
@@ -1,4 +1,4 @@
-import { ArbeidsgiverOpplysningerPerId, Behandling, Fagsak, FagsakPerson, Personopplysninger } from '@k9-sak-web/types';
+import { ArbeidsgiverOpplysningerPerId, Behandling, Personopplysninger } from '@k9-sak-web/types';
 import vedtaksbrevtype from '@fpsak-frontend/kodeverk/src/vedtaksbrevtype';
 import ForhåndsvisRequest from '@k9-sak-web/types/src/formidlingTsType';
 import { dokumentdatatype } from '@k9-sak-web/konstanter';
@@ -8,6 +8,8 @@ import {
   lagVisningsnavnForMottaker as v2LagvisningsnavnForMottaker,
 } from '@k9-sak-web/gui/utils/formidling.js';
 import { isBehandlingType } from '@k9-sak-web/backend/combined/kodeverk/behandling/BehandlingType.js';
+import type { BehandlingInfo } from '@k9-sak-web/gui/sak/BehandlingInfo.js';
+import type { Fagsak } from '@k9-sak-web/gui/sak/Fagsak.js';
 
 export interface VedtaksbrevMal {
   dokumentMalType: string;
@@ -126,9 +128,9 @@ export const harMellomlagretRedusertUtbetalingArsak = (key, dokumentdata, vedtak
 };
 
 export const lagForhåndsvisRequest = (
-  behandling: Behandling,
+  behandling: BehandlingInfo,
   fagsak: Fagsak,
-  fagsakPerson: FagsakPerson,
+  fagsakPerson: Fagsak['person'],
   data: any,
 ): ForhåndsvisRequest => ({
   eksternReferanse: behandling.uuid,
@@ -149,7 +151,7 @@ export const getForhandsvisCallback =
   (
     forhandsvisMelding: (data: any) => Promise<any>,
     fagsak: Fagsak,
-    fagsakPerson: FagsakPerson,
+    fagsakPerson: Fagsak['person'],
     behandling: Behandling,
   ) =>
   (parametre: any, aapneINyttVindu = true) => {

--- a/packages/v2/gui/src/sak/meldinger/Messages.tsx
+++ b/packages/v2/gui/src/sak/meldinger/Messages.tsx
@@ -46,6 +46,7 @@ type MessagesProps = {
   readonly personopplysninger?: Personopplysninger;
   readonly arbeidsgiverOpplysningerPerId?: ArbeidsgiverOpplysningerPerId;
   readonly api: BackendApi;
+  readonly onMessageSent: () => void;
 };
 
 type MessagesState = Readonly<{
@@ -55,7 +56,7 @@ type MessagesState = Readonly<{
   valgtMottakerId: string | undefined;
   tredjepartsmottakerAktivert: boolean;
   tredjepartsmottaker: TredjepartsmottakerValue | TredjepartsmottakerError | undefined;
-}>
+}>;
 
 type SetValgtMalkode = Readonly<{
   type: 'SettValgtMal';
@@ -63,105 +64,106 @@ type SetValgtMalkode = Readonly<{
 }>;
 
 type SetFritekstForslag = Readonly<{
-  type: 'SettFritekstForslag',
-  fritekstForslag: FritekstbrevDokumentdata[]
-}>
+  type: 'SettFritekstForslag';
+  fritekstForslag: FritekstbrevDokumentdata[];
+}>;
 
 type SetValgtFritekst = Readonly<{
-  type: 'SettValgtFritekst',
-  valgtFritekst: FritekstbrevDokumentdata | undefined,
-}>
+  type: 'SettValgtFritekst';
+  valgtFritekst: FritekstbrevDokumentdata | undefined;
+}>;
 
 type SetValgtMottakerId = Readonly<{
-  type: 'SettValgtMottakerId',
-  valgtMottakerId: string | undefined,
-}>
+  type: 'SettValgtMottakerId';
+  valgtMottakerId: string | undefined;
+}>;
 
 type SetTredjepartsmottakerAktivert = Readonly<{
-  type: 'SettTredjepartsmottakerAktivert',
-  tredjepartsmottakerAktivert: boolean,
-}>
+  type: 'SettTredjepartsmottakerAktivert';
+  tredjepartsmottakerAktivert: boolean;
+}>;
 
 type SetTredjepartsmottaker = Readonly<{
-  type: "SettTredjepartsmottaker",
-  tredjepartsmottaker: TredjepartsmottakerValue | TredjepartsmottakerError | undefined,
-}>
+  type: 'SettTredjepartsmottaker';
+  tredjepartsmottaker: TredjepartsmottakerValue | TredjepartsmottakerError | undefined;
+}>;
 
 type OnValgtMalChanged = Readonly<{
-  type: "OnValgtMalChanged"
-  valgtMal: Template | undefined
-}>
+  type: 'OnValgtMalChanged';
+  valgtMal: Template | undefined;
+}>;
 
 type MessagesStateActions =
-  SetValgtMalkode |
-  SetFritekstForslag |
-  SetValgtFritekst |
-  SetValgtMottakerId |
-  SetTredjepartsmottakerAktivert |
-  SetTredjepartsmottaker |
-  OnValgtMalChanged;
+  | SetValgtMalkode
+  | SetFritekstForslag
+  | SetValgtFritekst
+  | SetValgtMottakerId
+  | SetTredjepartsmottakerAktivert
+  | SetTredjepartsmottaker
+  | OnValgtMalChanged;
 
 // eslint-disable-next-line consistent-return -- Bevisst deaktivert, ts sjekker at alle mulige typer fører til return.
 const messagesStateReducer = (state: MessagesState, dispatch: MessagesStateActions): MessagesState => {
   // eslint-disable-next-line default-case -- Bevisst deaktivert for å få TS sjekk på at alle dispatch.type verdier er handtert
-  switch(dispatch.type) {
-    case "OnValgtMalChanged": {
+  switch (dispatch.type) {
+    case 'OnValgtMalChanged': {
       // Når valgt mal har blitt endra, endre tredjepartsmottakerAktivert og valgtMottakerId i henhold.
-      const tredjepartsmottakerAktivert = state.tredjepartsmottakerAktivert && (dispatch.valgtMal?.støtterTredjepartsmottaker || false)
-      const valgtMottakerId = dispatch.valgtMal?.mottakere[0]?.id
+      const tredjepartsmottakerAktivert =
+        state.tredjepartsmottakerAktivert && (dispatch.valgtMal?.støtterTredjepartsmottaker || false);
+      const valgtMottakerId = dispatch.valgtMal?.mottakere[0]?.id;
       return {
         ...state,
         tredjepartsmottakerAktivert,
         valgtMottakerId,
-      }
+      };
     }
-    case "SettValgtMal": {
-      const valgtMalkode = dispatch.malkode
+    case 'SettValgtMal': {
+      const valgtMalkode = dispatch.malkode;
       return {
         ...state,
         valgtMalkode,
-      }
+      };
     }
     // Når fritekstForslag blir satt skal valgtFritekst settast til innhald i første forslag
-    case "SettFritekstForslag": {
-      const { fritekstForslag } = dispatch
-      const valgtFritekst = fritekstForslag[0]
+    case 'SettFritekstForslag': {
+      const { fritekstForslag } = dispatch;
+      const valgtFritekst = fritekstForslag[0];
       return {
         ...state,
         fritekstForslag,
         valgtFritekst,
-      }
+      };
     }
-    case "SettValgtFritekst": {
-      const { valgtFritekst } = dispatch
+    case 'SettValgtFritekst': {
+      const { valgtFritekst } = dispatch;
       return {
         ...state,
-        valgtFritekst
-      }
+        valgtFritekst,
+      };
     }
-    case "SettValgtMottakerId": {
-      const { valgtMottakerId } = dispatch
+    case 'SettValgtMottakerId': {
+      const { valgtMottakerId } = dispatch;
       return {
         ...state,
         valgtMottakerId,
-      }
+      };
     }
-    case "SettTredjepartsmottakerAktivert": {
-      const { tredjepartsmottakerAktivert } = dispatch
+    case 'SettTredjepartsmottakerAktivert': {
+      const { tredjepartsmottakerAktivert } = dispatch;
       return {
         ...state,
-        tredjepartsmottakerAktivert
-      }
+        tredjepartsmottakerAktivert,
+      };
     }
-    case "SettTredjepartsmottaker": {
-      const { tredjepartsmottaker } = dispatch
+    case 'SettTredjepartsmottaker': {
+      const { tredjepartsmottaker } = dispatch;
       return {
         ...state,
-        tredjepartsmottaker
-      }
+        tredjepartsmottaker,
+      };
     }
   }
-}
+};
 
 const initMessagesState = (maler: Template[]): MessagesState => ({
   valgtMalkode: maler[0]?.kode,
@@ -170,7 +172,7 @@ const initMessagesState = (maler: Template[]): MessagesState => ({
   valgtMottakerId: undefined,
   tredjepartsmottakerAktivert: false,
   tredjepartsmottaker: undefined,
-})
+});
 
 const Messages = ({
   maler,
@@ -179,27 +181,31 @@ const Messages = ({
   personopplysninger,
   arbeidsgiverOpplysningerPerId,
   api,
+  onMessageSent,
 }: MessagesProps) => {
-  const [{
-    valgtMalkode,
-    fritekstForslag,
-    valgtFritekst,
-    valgtMottakerId,
-    tredjepartsmottakerAktivert,
-    tredjepartsmottaker,
-  }, dispatch] = useReducer(messagesStateReducer, initMessagesState(maler))
+  const [
+    { valgtMalkode, fritekstForslag, valgtFritekst, valgtMottakerId, tredjepartsmottakerAktivert, tredjepartsmottaker },
+    dispatch,
+  ] = useReducer(messagesStateReducer, initMessagesState(maler));
   const fritekstInputRef = useRef<FritekstInputMethods>(null);
   // showValidation is set to true when inputs should display any validation errors, i.e. after the user tries to submit the form without having valid values.
   const [showValidation, setShowValidation] = useState(false);
   const [isBusy, setIsBusy] = useState(false);
 
-  const setValgtMalkode = (malkode: string | undefined) => dispatch({type: 'SettValgtMal', malkode})
-  const setFritekstForslag = (newFritekstForslag: FritekstbrevDokumentdata[]) => dispatch({type: "SettFritekstForslag", fritekstForslag: newFritekstForslag})
-  const setValgtFritekst = (newValgtFritekst: FritekstbrevDokumentdata | undefined) => dispatch({type: "SettValgtFritekst", valgtFritekst: newValgtFritekst})
-  const setValgtMottakerId = (newValgtMottakerId: string | undefined) => dispatch({type: "SettValgtMottakerId", valgtMottakerId: newValgtMottakerId})
-  const setTredjepartsmottakerAktivert = (newTredjepartsmottakerAktivert: boolean) => dispatch({type: "SettTredjepartsmottakerAktivert", tredjepartsmottakerAktivert: newTredjepartsmottakerAktivert})
-  const setTredjepartsmottaker = (newTredjepartsmottaker: TredjepartsmottakerValue | TredjepartsmottakerError | undefined) => dispatch({type: "SettTredjepartsmottaker", tredjepartsmottaker: newTredjepartsmottaker})
-  const onValgtMalChanged = (newValgtMal: Template | undefined) => dispatch({type: "OnValgtMalChanged", valgtMal: newValgtMal})
+  const setValgtMalkode = (malkode: string | undefined) => dispatch({ type: 'SettValgtMal', malkode });
+  const setFritekstForslag = (newFritekstForslag: FritekstbrevDokumentdata[]) =>
+    dispatch({ type: 'SettFritekstForslag', fritekstForslag: newFritekstForslag });
+  const setValgtFritekst = (newValgtFritekst: FritekstbrevDokumentdata | undefined) =>
+    dispatch({ type: 'SettValgtFritekst', valgtFritekst: newValgtFritekst });
+  const setValgtMottakerId = (newValgtMottakerId: string | undefined) =>
+    dispatch({ type: 'SettValgtMottakerId', valgtMottakerId: newValgtMottakerId });
+  const setTredjepartsmottakerAktivert = (newTredjepartsmottakerAktivert: boolean) =>
+    dispatch({ type: 'SettTredjepartsmottakerAktivert', tredjepartsmottakerAktivert: newTredjepartsmottakerAktivert });
+  const setTredjepartsmottaker = (
+    newTredjepartsmottaker: TredjepartsmottakerValue | TredjepartsmottakerError | undefined,
+  ) => dispatch({ type: 'SettTredjepartsmottaker', tredjepartsmottaker: newTredjepartsmottaker });
+  const onValgtMalChanged = (newValgtMal: Template | undefined) =>
+    dispatch({ type: 'OnValgtMalChanged', valgtMal: newValgtMal });
 
   // Konverter valgtFritekst til FritekstInputValue
   const valgtFritekstInputValue: FritekstInputValue = {
@@ -229,7 +235,7 @@ const Messages = ({
 
   const valgtMal = maler.find(mal => mal.kode === valgtMalkode);
   useEffect(() => {
-    onValgtMalChanged(valgtMal)
+    onValgtMalChanged(valgtMal);
   }, [valgtMal]);
 
   const showFritekstInput = (valgtMal?.støtterFritekst || valgtMal?.støtterTittelOgFritekst) ?? false;
@@ -305,8 +311,9 @@ const Messages = ({
         await api.bestillDokument(bestillBrevDto);
         // Reset form to initial default values:
         setShowValidation(false);
-        setValgtMalkode(maler[0]?.kode)
+        setValgtMalkode(maler[0]?.kode);
         fritekstInputRef.current?.reset();
+        onMessageSent();
       } finally {
         setIsBusy(false);
       }
@@ -363,7 +370,9 @@ const Messages = ({
         onChange={() => setTredjepartsmottakerAktivert(!tredjepartsmottakerAktivert)}
         size="small"
         disabled={!valgtMal?.støtterTredjepartsmottaker}
-        >Send til tredjepart</Checkbox>
+      >
+        Send til tredjepart
+      </Checkbox>
       <TredjepartsmottakerInput
         show={tredjepartsmottakerAktivert}
         showValidation={showValidation}


### PR DESCRIPTION
Flytter oppretting av submitCallback og previewCallback ned til MeldingerSakIndex.

Erstatter dei med ein meir generell onMessageSent callback som kan brukast av både ny og gammal meldingskomponent for å signalisere opp til MeldingIndex at melding er sent.

Reduserer og duplikate props litt.