### PR TITLE
Dev-next1 branch deployment til k9-next.dev.intern.nav.no

### DIFF
--- a/.github/workflows/dev-next1-deploy.yml
+++ b/.github/workflows/dev-next1-deploy.yml
@@ -1,0 +1,46 @@
+name: Build and deploy dev-next1
+on:
+  push:
+    paths-ignore:
+      - '**.md'
+      - '.gitignore'
+      - 'CODEOWNERS'
+    branches:
+      - dev-next1
+
+jobs:
+  build-deploy:
+    name: Build and deploy Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    env:
+      CLUSTER: dev-fss
+    steps:
+      - name: Hente kode
+        uses: actions/checkout@v4
+
+      - name: Setup + Install
+        uses: ./.github/actions/setup-install
+        with:
+          npmAuthToken: ${{ secrets.READER_TOKEN }}
+
+      - name: Bygge dist
+        run: yarn build
+
+      - name: Build and push to docker registry
+        uses: nais/docker-build-push@v0
+        id: docker-push
+        with:
+          tag: 'dev-next1'
+          team: k9saksbehandling
+          project_id: ${{ vars.NAIS_MANAGEMENT_PROJECT_ID }}
+          identity_provider: ${{ secrets.NAIS_WORKLOAD_IDENTITY_PROVIDER }}
+      - name: Deploy to nais
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: ${{ env.CLUSTER }}
+          RESOURCE: deploy/${{ env.CLUSTER }}-k9saksbehandling.yml
+          VARS: deploy/dev-next1.yaml
+          VAR: image=${{ steps.docker-push.outputs.image }}

--- a/.github/workflows/promote-command.yml
+++ b/.github/workflows/promote-command.yml
@@ -50,6 +50,7 @@ jobs:
           PRINT_PAYLOAD: true
           CLUSTER: ${{ env.CLUSTER }}
           RESOURCE: deploy/${{ env.CLUSTER }}-k9saksbehandling.yml
+          VARS: deploy/dev.yaml
 
       - name: Oppdater kommentar med deployment status ved feil
         if: failure()

--- a/deploy/dev-fss-k9saksbehandling.yml
+++ b/deploy/dev-fss-k9saksbehandling.yml
@@ -1,7 +1,7 @@
 apiVersion: "nais.io/v1alpha1"
 kind: "Application"
 metadata:
-  name: k9-sak-web
+  name: {{ name }}
   namespace: k9saksbehandling
   labels:
     team: k9saksbehandling
@@ -25,8 +25,8 @@ spec:
     initialDelay: 20
     timeout: 1
   replicas:
-    min: 2
-    max: 3
+    min: {{ replicas.min }}
+    max: {{ replicas.max }}
     cpuThresholdPercentage: 50
   resources:
     limits:
@@ -36,7 +36,7 @@ spec:
       cpu: 200m
       memory: 32Mi
   ingresses:
-    - "https://k9.dev.intern.nav.no/"
+    - "{{ ingress }}"
   env:
     - name: APP_NAME
       value: k9-sak-web

--- a/deploy/dev-next1.yaml
+++ b/deploy/dev-next1.yaml
@@ -1,0 +1,6 @@
+# Verdier for dev-fss.k9saksbehandling.yml ved utrulling frå dev-next1 branch til k9.dev-next1.intern.nav.no
+name: k9-sak-web-dev-next1
+ingress: "https://k9.dev-next1.intern.nav.no/"
+replicas:
+  min: 1
+  max: 2

--- a/deploy/dev-next1.yaml
+++ b/deploy/dev-next1.yaml
@@ -1,6 +1,6 @@
-# Verdier for dev-fss.k9saksbehandling.yml ved utrulling frå dev-next1 branch til k9.dev-next1.intern.nav.no
+# Verdier for dev-fss.k9saksbehandling.yml ved utrulling frå dev-next1 branch til k9-next1.dev.intern.nav.no
 name: k9-sak-web-dev-next1
-ingress: "https://k9.dev-next1.intern.nav.no/"
+ingress: "https://k9-next1.dev.intern.nav.no/"
 replicas:
   min: 1
   max: 2

--- a/deploy/dev.yaml
+++ b/deploy/dev.yaml
@@ -1,0 +1,6 @@
+# Verdier for dev-fss.k9saksbehandling.yml ved utrulling frå master til Q
+name: k9-sak-web
+ingress: "https://k9.dev.intern.nav.no/"
+replicas:
+  min: 2
+  max: 3


### PR DESCRIPTION
**Bakgrunn**
Behov for å kunne ha nokre endringer ute til test over litt tid utan å blokkere for at andre endringer kan leggast ut på master og rullast ut til prod.

**Løsning**
Ny branch **dev-next1** oppretta, med tilhøyrande workflow og branch protection rules.

Ved merge til dev-next1 branch frå ei anna branch vil koden der bli bygd og rulla ut til ein separat frontend instans som ellers går mot dei vanlege test backends på samme måte som ved utrulling frå master.

Denne nye instansen har ingress **https://k9-next1.dev.intern.nav.no**