### PR TITLE
Tsff 641/storbritannia skal ikke vises som eos land

### DIFF
--- a/packages/fakta-medlemskap/src/components/oppholdInntektOgPerioder/OppholdINorgeOgAdresserFaktaPanel.jsx
+++ b/packages/fakta-medlemskap/src/components/oppholdInntektOgPerioder/OppholdINorgeOgAdresserFaktaPanel.jsx
@@ -23,6 +23,9 @@ const capitalizeFirstLetter = landNavn => {
 
 const formatLandNavn = landNavn => {
   if (landNavn.length === 2 || landNavn.length === 3) {
+    if (landNavn === 'XXK') {
+      return 'Kosovo';
+    }
     return countries.getName(landNavn, 'no');
   }
   return landNavn;

--- a/packages/fakta-utenlandsopphold/src/Utenlandsopphold.spec.tsx
+++ b/packages/fakta-utenlandsopphold/src/Utenlandsopphold.spec.tsx
@@ -41,4 +41,69 @@ describe('Utenlandsopphold', () => {
     expect(screen.getByText('Merknad til utenlandsopphold')).toBeVisible();
     expect(screen.getByText('Periode telles ikke.')).toBeVisible();
   });
+
+  test('land utenfor EØS vises med merknad', () => {
+    renderWithIntl(
+      <Utenlandsopphold
+        utenlandsopphold={{ perioder: [utenlandsoppholdMock.perioder[1]] }}
+        kodeverk={utenlandsoppholdÅrsakMock}
+      />,
+    );
+
+    expect(screen.getByText('Land')).toBeVisible();
+    expect(screen.getByText('Kina')).toBeVisible();
+    expect(screen.getByText('EØS')).toBeVisible();
+    expect(screen.getByText('Nei')).toBeVisible();
+    expect(screen.getByText('Merknad til utenlandsopphold')).toBeVisible();
+    expect(screen.getByText('Ingen av årsakene over (kan motta pleiepenger i 8 uker)')).toBeVisible();
+  });
+  // Egen test da det har mismatch mellom kodeverk og i18n-iso-countries
+  test('Kosovo vises korrekt', () => {
+    renderWithIntl(
+      <Utenlandsopphold
+        utenlandsopphold={{ perioder: [utenlandsoppholdMock.perioder[6]] }}
+        kodeverk={utenlandsoppholdÅrsakMock}
+      />,
+    );
+
+    expect(screen.getByText('Land')).toBeVisible();
+    expect(screen.getByText('Kosovo')).toBeVisible();
+    expect(screen.getByText('EØS')).toBeVisible();
+    expect(screen.getByText('Nei')).toBeVisible();
+  });
+
+  // spesialhåndtering for Storbritannia da det ligger som EØS-land i kodeverket
+  test('Storbritannia er ikke i EØS', () => {
+    renderWithIntl(
+      <Utenlandsopphold
+        utenlandsopphold={{ perioder: [utenlandsoppholdMock.perioder[7]] }}
+        kodeverk={utenlandsoppholdÅrsakMock}
+      />,
+    );
+
+    expect(screen.getByText('Land')).toBeVisible();
+    expect(screen.getByText('Storbritannia')).toBeVisible();
+    expect(screen.getByText('EØS')).toBeVisible();
+    expect(screen.getByText('Nei')).toBeVisible();
+    expect(screen.getByText('Merknad til utenlandsopphold')).toBeVisible();
+    expect(screen.getByText('Ingen av årsakene over (kan motta pleiepenger i 8 uker)')).toBeVisible();
+  });
+
+  // Sveits vurderes på lik linje med EØS-land
+  test('Sveits vises med ekstra informasjon', () => {
+    renderWithIntl(
+      <Utenlandsopphold
+        utenlandsopphold={{ perioder: [utenlandsoppholdMock.perioder[5]] }}
+        kodeverk={utenlandsoppholdÅrsakMock}
+      />,
+    );
+
+    expect(screen.getByText('Land')).toBeVisible();
+    expect(screen.getByText('Sveits')).toBeVisible();
+    expect(screen.getByText('EØS')).toBeVisible();
+    expect(screen.getByText('Nei*')).toBeVisible();
+    expect(screen.getByText('Merknad til utenlandsopphold')).toBeVisible();
+    expect(screen.getByText('Periode telles ikke.')).toBeVisible();
+    expect(screen.getByText('*) Ikke en del av EØS, men vurderes mot EØS-regelverk')).toBeVisible();
+  });
 });

--- a/packages/fakta-utenlandsopphold/src/Utenlandsopphold.tsx
+++ b/packages/fakta-utenlandsopphold/src/Utenlandsopphold.tsx
@@ -21,7 +21,6 @@ const Utenlandsopphold = ({
   fagsakYtelseType?: string;
 }) => {
   const finnÅrsaker = (periode: UtenlandsoppholdType, erEØS: boolean) => {
-    // EØS eller Sveits
     if (erEØS || periode.landkode.kode === 'CHE') {
       return 'Periode telles ikke.';
     }
@@ -39,6 +38,7 @@ const Utenlandsopphold = ({
   };
 
   const mapItems = (periode: UtenlandsoppholdType) => {
+    // Storbritannia ligger som EØS-land i kodeverket. Frem til det er fjernet derfra må det spesialhåndteres her.
     const erEØS = () =>
       periode.region.kode === 'NORDEN' || (periode.region.kode === 'EOS' && periode.landkode.kode !== 'GBR');
 

--- a/packages/mocks/mockdata/utenlandsoppholdMock.js
+++ b/packages/mocks/mockdata/utenlandsoppholdMock.js
@@ -88,6 +88,36 @@ const utenlandsopphold = {
       },
       årsak: 'INGEN',
     },
+    {
+      periode: `${dayjs().subtract(52, 'day').format('YYYY-MM-DD')}/${dayjs()
+        .subtract(31, 'day')
+        .format('YYYY-MM-DD')}`,
+      landkode: {
+        kode: 'XXK',
+        navn: 'XXK',
+        kodeverk: 'LANDKODER',
+      },
+      region: {
+        kode: 'ANNET',
+        kodeverk: 'REGION',
+      },
+      årsak: 'INGEN',
+    },
+    {
+      periode: `${dayjs().subtract(59, 'day').format('YYYY-MM-DD')}/${dayjs()
+        .subtract(31, 'day')
+        .format('YYYY-MM-DD')}`,
+      landkode: {
+        kode: 'GBR',
+        navn: 'GBR',
+        kodeverk: 'LANDKODER',
+      },
+      region: {
+        kode: 'EOS',
+        kodeverk: 'REGION',
+      },
+      årsak: 'INGEN',
+    },
   ],
 };
 

--- a/packages/mocks/mockdata/utenlandsoppholdMock.js
+++ b/packages/mocks/mockdata/utenlandsoppholdMock.js
@@ -75,7 +75,7 @@ const utenlandsopphold = {
     },
     {
       periode: `${dayjs().subtract(45, 'day').format('YYYY-MM-DD')}/${dayjs()
-        .subtract(31, 'day')
+        .subtract(39, 'day')
         .format('YYYY-MM-DD')}`,
       landkode: {
         kode: 'CHE',
@@ -90,7 +90,7 @@ const utenlandsopphold = {
     },
     {
       periode: `${dayjs().subtract(52, 'day').format('YYYY-MM-DD')}/${dayjs()
-        .subtract(31, 'day')
+        .subtract(47, 'day')
         .format('YYYY-MM-DD')}`,
       landkode: {
         kode: 'XXK',
@@ -105,7 +105,7 @@ const utenlandsopphold = {
     },
     {
       periode: `${dayjs().subtract(59, 'day').format('YYYY-MM-DD')}/${dayjs()
-        .subtract(31, 'day')
+        .subtract(55, 'day')
         .format('YYYY-MM-DD')}`,
       landkode: {
         kode: 'GBR',

--- a/packages/sak-aktor/src/AktorSakIndex.stories.tsx
+++ b/packages/sak-aktor/src/AktorSakIndex.stories.tsx
@@ -57,10 +57,7 @@ export const visSakerOpprettetPaAktor = () => (
       },
     }}
     alleKodeverk={alleKodeverk as any}
-    finnPathToFagsak={() => 'path'}
   />
 );
 
-export const visningAvUgyldigAktorId = () => (
-  <AktorSakIndex valgtAktorId="123" alleKodeverk={alleKodeverk as any} finnPathToFagsak={() => 'path'} />
-);
+export const visningAvUgyldigAktorId = () => <AktorSakIndex valgtAktorId="123" alleKodeverk={alleKodeverk as any} />;


### PR DESCRIPTION
Midlertidig løsning mens Storbritannia ligger som EØS-land i kodeverk. Ina har undersøkt og sakene behandles riktig til tross for dette.