### PR TITLE
Unngå CORS feil i utviklingsmiljø.

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -20,6 +20,12 @@ const createProxy = (target, pathRewrite) => ({
         // eslint-disable-next-line no-param-reassign
         proxyRes.headers.location = `/k9/sak/resource/login?original=${req.originalUrl}`;
       }
+      // Viss respons frå proxied server inneheld location header med server adresse, fjern server addressa slik at redirect
+      // går til dev server istadenfor proxied server. Dette for å unngå CORS feil når request går direkte til proxied server.
+      if (proxyRes.headers.location?.startsWith(target)) {
+        // eslint-disable-next-line no-param-reassign
+        proxyRes.headers.location = proxyRes.headers.location.replace(target, "")
+      }
     });
   },
 });


### PR DESCRIPTION
Når server som er proxied for frontend returnere redirect i location header inneheld den av og til server adressa til proxied server. Dermed sende frontend forespørsel direkte til denne utan å gå via devserver proxy. Dette førte til CORS feil.

Fikser dette ved å i vite dev server omskrive header location returnert frå proxied backend server til å ikkje innehalde server adressa.