### PR TITLE
Unngå javascript feil pga undefined templates i MeldingerSakIndex.tsx.

### DIFF
--- a/packages/sak-app/src/behandlingsupport/melding/MeldingIndex.tsx
+++ b/packages/sak-app/src/behandlingsupport/melding/MeldingIndex.tsx
@@ -15,6 +15,7 @@ import {
 } from '@k9-sak-web/types';
 import { useFpSakKodeverk } from '../../data/useKodeverk';
 import { K9sakApiKeys, requestApi, restApiHooks } from '../../data/k9sakApi';
+import { Alert } from '@navikt/ds-react';
 
 export interface BackendApi extends MeldingerSakIndexBackendApi {}
 
@@ -91,6 +92,9 @@ const MeldingIndex = ({
     (skalHenteRevAp && stateRevAp === RestApiState.LOADING)
   ) {
     return <LoadingPanel />;
+  }
+  if (skalHenteBrevmaler && stateBrevmaler === RestApiState.ERROR) {
+    return <Alert variant="error">Feil ved henting av maler. Brevsending ikke mulig</Alert>;
   }
 
   return (


### PR DESCRIPTION
Bakgrunn:
Ved feil i bakenforliggande system kan det skje at kall til formidling server for å hente maler feiler (returnerer 500). Dette førte til javascript feil sidan MeldingIndex forventa at templates verdi alltid skulle vere eit objekt, og ikkje undefined som det vart viss serverkall feila.

Løysing:
Viser alert med informativ feilmelding istadenfor meldingspanel, viss kall for å hente maler har feila.

Svakhet:
Viss det finnast tilfeller der det er korrekt at det ikkje blir returnert maler for ei sak, så vil det framleis føre til feil. Antar at dette aldri skal skje.