### PR TITLE
Fiks brevpanel så valgt mottaker viser korrekt etter bytte av mal.

### DIFF
--- a/packages/v2/gui/src/sak/meldinger/MottakerSelect.tsx
+++ b/packages/v2/gui/src/sak/meldinger/MottakerSelect.tsx
@@ -29,7 +29,7 @@ const MottakerSelect = ({
         label="Mottaker"
         size="small"
         placeholder="Velg mottaker"
-        defaultValue={valgtMottakerId}
+        value={valgtMottakerId}
         onChange={e => onChange?.(e.target.value)}
         disabled={disabled}
       >


### PR DESCRIPTION
Før dette kunne tidlegare valgt mottaker vise som valgt etter at ein hadde bytte mal, sjølv om komponent state hadde resatt valgt mottaker til å vere første på valgte mal.