### PR TITLE
Sjekk om aldersvilkår finnes på behandling før panel legges til

### DIFF
--- a/packages/behandling-utvidet-rett/src/components/UtvidetRettProsess.tsx
+++ b/packages/behandling-utvidet-rett/src/components/UtvidetRettProsess.tsx
@@ -171,6 +171,7 @@ const UtvidetRettProsess = ({
     prosessStegUtvidetRettPanelDefinisjoner(
       fagsak.sakstype.kode === fagsakYtelseType.OMSORGSPENGER_ALENE_OM_OMSORGEN,
       fagsak.sakstype.kode === fagsakYtelseType.OMSORGSPENGER_KRONISK_SYKT_BARN,
+      data.vilkar,
       featureToggles,
     ),
     dataTilUtledingAvFpPaneler,

--- a/packages/behandling-utvidet-rett/src/panelDefinisjoner/prosessStegUtvidetRettPanelDefinisjoner.tsx
+++ b/packages/behandling-utvidet-rett/src/panelDefinisjoner/prosessStegUtvidetRettPanelDefinisjoner.tsx
@@ -1,18 +1,21 @@
-import { FeatureToggles } from '@k9-sak-web/types';
+import {FeatureToggles, Vilkar} from '@k9-sak-web/types';
 import InngangsvilkarProsessStegPanelDef from './prosessStegPaneler/InngangsvilkarProsessStegPanelDef';
 import VedtakProsessStegPanelDef from './prosessStegPaneler/VedtakProsessStegPanelDef';
 import UtvidetRettProsessStegPanelDef from './prosessStegPaneler/UtvidetRettProsessStegPanelDef';
 import AlderProsessStegPanelDef from './prosessStegPaneler/AlderProsessStegPanelDef';
+import vilkarType from "@fpsak-frontend/kodeverk/src/vilkarType";
 
 const prosessStegUtvidetRettPanelDefinisjoner = (
   erFagytelseTypeAleneOmOmsorgen: boolean,
   erFagytelseTypeKroniskSyk: boolean,
+  vilkar: Vilkar[],
   featureToggles: FeatureToggles,
 ) => {
   if (featureToggles.AKSJONSPUNKT_9015) {
     const visAlderProsessSteg = erFagytelseTypeAleneOmOmsorgen || (erFagytelseTypeKroniskSyk && featureToggles.ALDERSVILKAR_KRONISK_SYK);
+    const harAldersvilkår = vilkar.some(v => v.vilkarType.kode === vilkarType.ALDERSVILKAR_BARN)
 
-    return visAlderProsessSteg
+    return visAlderProsessSteg && harAldersvilkår
       ? [
         new AlderProsessStegPanelDef(),
         new InngangsvilkarProsessStegPanelDef(),


### PR DESCRIPTION
Når status på et panel sjekkes, ser vi først på status på forrige panel. Dersom det ikke er oppfylt avsluttes sjekken. 

Dersom vilkåret ikke finnes i behandlingen fordi saken ble opprettet før denne ble lagt til i backend, vil visningen bli feil i frontend ettersom første panel blir IKKE_VURDERT => alle panel etter vil ignoreres