### PR TITLE
Kompatibiltetsfiks med ny openapi generator

### DIFF
--- a/packages/v2/backend/src/k9sak/kodeverk/OpptjeningAktivitetType.ts
+++ b/packages/v2/backend/src/k9sak/kodeverk/OpptjeningAktivitetType.ts
@@ -1,7 +1,7 @@
 import type { OpptjeningAktivitetDto } from '../generated';
 import type { Kodeverk } from '../../shared/Kodeverk.ts';
 
-export type OpptjeningAktivitetType = Exclude<OpptjeningAktivitetDto['aktivitetType'], undefined>;
+export type OpptjeningAktivitetType = Exclude<OpptjeningAktivitetDto['aktivitetType'], undefined | null>;
 
 export type OpptjeningAktivitetTypeKodeverk = Kodeverk<OpptjeningAktivitetType, 'OPPTJENING_AKTIVITET_TYPE'>;
 

--- a/packages/v2/backend/src/k9sak/kodeverk/behandling/FagsakStatus.ts
+++ b/packages/v2/backend/src/k9sak/kodeverk/behandling/FagsakStatus.ts
@@ -1,7 +1,7 @@
 import type { FagsakDto } from '../../generated';
 import type { Kodeverk } from '../../../shared/Kodeverk.ts';
 
-export type FagsakStatus = Exclude<FagsakDto['status'], undefined>;
+export type FagsakStatus = Exclude<FagsakDto['status'], undefined | null>;
 
 export type FagsakStatusKodeverk = Kodeverk<FagsakStatus, 'FAGSAK_STATUS'>;
 

--- a/packages/v2/gui/src/sak/meldinger/MeldingerBackendClient.ts
+++ b/packages/v2/gui/src/sak/meldinger/MeldingerBackendClient.ts
@@ -36,7 +36,7 @@ export default class MeldingerBackendClient {
       if (resp !== null && resp.navn !== undefined && resp.navn !== null) {
         return {
           name: resp.navn,
-          utilgjengelig: resp.utilgjengeligÅrsak,
+          utilgjengelig: resp.utilgjengeligÅrsak || undefined,
         };
       }
       if (promise.isCancelled) {

--- a/packages/v2/gui/src/sak/meldinger/MeldingerBackendClient.ts
+++ b/packages/v2/gui/src/sak/meldinger/MeldingerBackendClient.ts
@@ -33,7 +33,7 @@ export default class MeldingerBackendClient {
       const promise = this.#k9sak.brev.getBrevMottakerinfoEreg({ organisasjonsnr: organisasjonsnr.trim() });
       abort?.addEventListener('abort', () => promise.cancel(), { signal: abortListenerRemover.signal });
       const resp = await promise;
-      if (resp !== null && resp.navn !== undefined) {
+      if (resp !== null && resp.navn !== undefined && resp.navn !== null) {
         return {
           name: resp.navn,
           utilgjengelig: resp.utilgjengeligÅrsak,


### PR DESCRIPTION
**Bakgrunn**
Ny openapi generator på k9-sak setter nullable korrekt på alle properties som teknisk sett kan vere null i java. Altså alle som ikkje eksplisitt er markert med `@NotNull` annotasjon.

**Løysing**
Denne PR legger til `null` som ein mulig type på dei typane der det er nødvendig for kompatibilitet med openapi spesifikasjon generert med ny definisjon frå k9-sak.