### PR TITLE
Alltid vise filter for dokumentliste

### DIFF
--- a/packages/sak-dokumenter/src/components/DocumentList.tsx
+++ b/packages/sak-dokumenter/src/components/DocumentList.tsx
@@ -119,22 +119,8 @@ const DocumentList = ({
   const { data: inntektsmeldingerIBruk } = useQuery({
     queryKey: ['kompletthet'],
     queryFn: ({ signal }) => getInntektsmeldingerIBruk(signal),
-    enabled: erStøttetFagsakYtelseType && !!behandlingUuid
+    enabled: erStøttetFagsakYtelseType && !!behandlingUuid,
   });
-
-  const harMerEnnEnBehandlingKnyttetTilDokumenter = () => {
-    const unikeBehandlinger = [];
-    if (documents.some(document => document.behandlinger?.length > 0)) {
-      documents.forEach(document =>
-        document.behandlinger.forEach(behandling => {
-          if (!unikeBehandlinger.includes(behandling)) {
-            unikeBehandlinger.push(behandling);
-          }
-        }),
-      );
-    }
-    return unikeBehandlinger.length > 1;
-  };
 
   const getModiaLenke = () => (
     <Link target="_blank" className={styles.modiaLink} href={getModiaPath(fagsakPerson?.personnummer)}>
@@ -168,17 +154,15 @@ const DocumentList = ({
   return (
     <>
       <div className={styles.controlsContainer}>
-        {harMerEnnEnBehandlingKnyttetTilDokumenter() && (
-          <Select
-            size="small"
-            onChange={event => setSelectedFilter(event.target.value)}
-            label="Hvilke behandlinger skal vises?"
-            hideLabel
-          >
-            <option value={alleBehandlinger}>Alle behandlinger</option>
-            <option value={behandlingId}>Denne behandlingen</option>
-          </Select>
-        )}
+        <Select
+          size="small"
+          onChange={event => setSelectedFilter(event.target.value)}
+          label="Hvilke behandlinger skal vises?"
+          hideLabel
+        >
+          <option value={alleBehandlinger}>Alle behandlinger</option>
+          <option value={behandlingId}>Denne behandlingen</option>
+        </Select>
         {getModiaLenke()}
       </div>
       <Table>


### PR DESCRIPTION
Bakgrunn: Valget for å filtrere dokumentlisten på dokumenter for "denne behandlingen" eller "Alle behandlinger" var ikke synlig om alle dokumentene gjaldt én og samme behandling. Dette virket forvirrende.

Løsning: Viser valget for å filtrere listen uansett. 

![Skjermbilde 2024-09-18 kl  14 48 42](https://github.com/user-attachments/assets/917b8226-61d5-4dde-81f2-5960d688b4f9)
