### PR TITLE
Legger inn manglende tekst for historikkinnslag

### DIFF
--- a/packages/sak-historikk/i18n/nb_NO.json
+++ b/packages/sak-historikk/i18n/nb_NO.json
@@ -513,6 +513,7 @@
   "Historikk.BeregningsgrunnlagOgInntektskategoriTY": "Fastsatt beregningsgrunnlag og inntektskategori for bruker med tilstøtende ytelse",
   "Historikk.BeregningsgrunnlagManueltSNNYIArbeidslivet": "Fastsatt beregningsgrunnlag for selvstendig næring ny i arbeidslivet",
   "Historikk.VurderFaktaATFLSN": "Vurder fakta for beregning",
+  "Historikk.Sykdom": "Sykdom",
   "Historikk.FaktaUttak.ForsteUttakDato": "Kontroller manglende uttaksperiode",
   "Historikk.FaktaUttak.VurderAnnenForelder": "Vurdering om den andre forelderen har rett til pleiepenger"
 }

--- a/packages/sak-historikk/src/components/maler/historikkMalType3.tsx
+++ b/packages/sak-historikk/src/components/maler/historikkMalType3.tsx
@@ -2,7 +2,7 @@ import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import { VerticalSpacer } from '@fpsak-frontend/shared-components';
 import { HistorikkInnslagAksjonspunkt } from '@k9-sak-web/types';
 import { BodyShort, Label } from '@navikt/ds-react';
-import React, { ReactNode } from 'react';
+import { ReactNode } from 'react';
 import { IntlShape, WrappedComponentProps, injectIntl } from 'react-intl';
 
 import { decodeHtmlEntity } from '@fpsak-frontend/utils';
@@ -47,6 +47,7 @@ const aksjonspunktCodesToTextCode = {
     'Historikk.BeregningsgrunnlagManueltSNNYIArbeidslivet',
   [aksjonspunktCodes.VURDER_FAKTA_FOR_ATFL_SN]: 'Historikk.VurderFaktaATFLSN',
   [aksjonspunktCodes.FORESLA_VEDTAK]: 'Historikk.Vedtak.Fritekstbrev',
+  [aksjonspunktCodes.MEDISINSK_VILKAAR]: 'Historikk.Sykdom',
 };
 
 const tilbakekrevingsAksjonspunktCodesToTextCode = {};


### PR DESCRIPTION
Bakgrunn: Ved retur av behandling til saksbehandler mangler tekst i historikkinnslag for aksjonspunktet sykdom.

Løsning: Legger inn manglende tekst.