### PR TITLE
Legger til skjermlenkeCode for medisinsk vilkår

### DIFF
--- a/packages/konstanter/src/prosessStegCodes.ts
+++ b/packages/konstanter/src/prosessStegCodes.ts
@@ -28,6 +28,7 @@ const prosessStegCodes = {
   ANKE_MERKNADER: 'ankemerknader',
   ANKE_RESULTAT: 'ankeresultat',
   MEDISINSK_VILKAR: 'medisinsk_vilkar',
+  PUNKT_FOR_MEDISINSK: 'medisinskvilkaar-v2',
   OPPTJENING: 'opptjening',
   ALDER: 'alder',
   OPPLAERING: 'opplaering',

--- a/packages/konstanter/src/skjermlenkeCodes.ts
+++ b/packages/konstanter/src/skjermlenkeCodes.ts
@@ -123,6 +123,11 @@ const skjermlenkeCodes = {
     faktaNavn: faktaPanelCodes.DEFAULT,
     punktNavn: prosessStegCodes.OPPTJENING,
   },
+  PUNKT_FOR_MEDISINSK: {
+    kode: 'PUNKT_FOR_MEDISINSK',
+    faktaNavn: faktaPanelCodes.DEFAULT,
+    punktNavn: prosessStegCodes.PUNKT_FOR_MEDISINSK,
+  },
   PUNKT_FOR_OMSORG: {
     kode: 'PUNKT_FOR_OMSORG',
     faktaNavn: faktaPanelCodes.DEFAULT,


### PR DESCRIPTION
Skjermlenkecoden til medisinsk vilkår manglet i oppslaget, så lenken fra historikkinnslag til medisinsk vilkår fungerte ikke eller ble helt borte.

Lagt til oppslaget for PUNKT_FOR_MEDISINSK, aka: medisinskvilkaar-v2