### PR TITLE
TSFF-890: Viser når opptjening er løst på grunnlag av §8-47 og vi ikke har aksjonspunkt for 5089 i behandlingen

### DIFF
--- a/packages/behandling-omsorgspenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/OpptjeningPanelDef.tsx
+++ b/packages/behandling-omsorgspenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/OpptjeningPanelDef.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import vilkarType from '@fpsak-frontend/kodeverk/src/vilkarType';
 import OpptjeningVilkarProsessIndex from '@fpsak-frontend/prosess-vilkar-opptjening-oms';
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';

--- a/packages/prosess-vilkar-opptjening-oms/i18n/nb_NO.json
+++ b/packages/prosess-vilkar-opptjening-oms/i18n/nb_NO.json
@@ -12,14 +12,10 @@
   "OpptjeningPanel.ErIkkeOppfylt": "Vilkåret er avslått",
   "OpptjeningPanel.IkkeBehandlet": "Ikke behandlet",
 
-
   "OpptjeningVilkarAksjonspunktPanel.SokerHarVurdertOpptjentRettTilPleiepenger": "Opptjent rett til pleiepenger",
   "OpptjeningVilkarAksjonspunktPanel.SokerHarVurdertOpptjentRettTilOmsorgspenger": "Opptjent rett til omsorgspenger",
   "OpptjeningVilkarAksjonspunktPanel.OmsorgspengerVurderLabel": "Vurder om bruker oppfyller opptjening jf § 9-2 eller § 8-47 bokstav B",
   "OpptjeningVilkarAksjonspunktPanel.ErOppfylt": "Søker har oppfylt krav om 28 dagers opptjening, vilkåret er oppfylt.",
-  "OpptjeningVilkarAksjonspunktPanel.Er847": "Vilkåret beregnes jf § 8-47.",
-  "OpptjeningVilkarAksjonspunktPanel.Er847A": "Vilkåret beregnes jf § 8-47 bokstav A.",
-  "OpptjeningVilkarAksjonspunktPanel.Er847B": "Vilkåret beregnes jf § 8-47 bokstav B.",
 
   "OpptjeningVilkarAksjonspunktPanel.ErIkkeOppfylt": "Søker har ikke oppfylt krav om 28 dagers opptjening, vilkåret er <b>ikke</b> oppfylt.",
   "OpptjeningVilkarAksjonspunktPanel.Opptjeningsvilkaret": "Opptjening",
@@ -27,8 +23,6 @@
   "OpptjeningVilkarAksjonspunktPanel.MidlertidigInaktivB": "Søker oppfyller vilkåret til opptjening jf § 8-47 bokstav B",
   "OpptjeningVilkarAksjonspunktPanel.VurderingHjelpetekst": "<b>Veiledning for vurdering av opptjent rett</b> {linebreak}• Sjekk Opptjening i Saksopplysninger. {linebreak} • Kontroller opplysningene i Arbeidsforhold. {linebreak} • Er det perioder uten arbeidsforhold eller med permisjon/permittering i noen av arbeidsforholdene som varer lengre en 14 dager? {linebreak} • Sjekk opplysningene i A-inntekt {linebreak} • Vurder om det kan være mangelfull registrering fra arbeidsgiver i Aa-registret. Hvis så, ta kontakt med arbeidsgiver for korrigering.{linebreak} • Skal ytelse være en del av opptjeningen? Husk at perioder med ytelse før skjæringstidspunktet må være utbetalt før det blir med i opptjening.{linebreak}{linebreak} <b>Vurder om bruker oppfyller opptjeningsvilkåret jf. § 9-2</b> {linebreak} • Hvis § 9-2 ikke er oppfylt. Vurder om § 8-47 bokstav A eller § 8-47 bokstav B er oppfylt. Bruker må ha aktivt arbeidsforhold på skjæringstidspunktet for at bokstav B kan være oppfylt.",
   "OpptjeningVilkarAksjonspunktPanel.VurderingPlaceholderText": "Begrunn vurderingen din. Se hjelpetekst for veiledning.",
-
-
 
   "TimeLineNavigation.openData": "Åpne info om første periode",
   "TimeLineData.nextPeriod": "Neste periode",

--- a/packages/prosess-vilkar-opptjening-oms/src/components/OpptjeningVilkarAksjonspunktPanel.tsx
+++ b/packages/prosess-vilkar-opptjening-oms/src/components/OpptjeningVilkarAksjonspunktPanel.tsx
@@ -3,7 +3,7 @@ import FagsakYtelseType from '@fpsak-frontend/kodeverk/src/fagsakYtelseType';
 import { ProsessStegBegrunnelseTextField } from '@k9-sak-web/prosess-felles';
 import { Aksjonspunkt, Opptjening, SubmitCallback, Vilkarperiode } from '@k9-sak-web/types';
 import { HelpText, Label } from '@navikt/ds-react';
-import React, { useMemo } from 'react';
+import { useMemo } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { InjectedFormProps } from 'redux-form';
@@ -12,7 +12,7 @@ import { createSelector } from 'reselect';
 import dayjs from 'dayjs';
 import isBetween from 'dayjs/plugin/isBetween';
 import styles from './OpptjeningVilkarAksjonspunktPanel.module.css';
-import VilkarField, { erVilkarOk, midlertidigInaktiv, VilkårFieldType } from './VilkarField';
+import VilkarField, { erVilkarOk, opptjeningMidlertidigInaktivKoder, VilkårFieldType } from './VilkarField';
 import OpptjeningPanel from './OpptjeningPanel';
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 
@@ -196,7 +196,9 @@ const transformValues = (
   vilkårPeriodeVurderinger: values.vilkarFields.map((vilkarField, index) => ({
     ...vilkarField,
     erVilkarOk: erVilkarOk(vilkarField.kode),
-    innvilgelseMerknadKode: Object.values(midlertidigInaktiv).includes(vilkarField.kode) ? vilkarField.kode : undefined,
+    innvilgelseMerknadKode: Object.values(opptjeningMidlertidigInaktivKoder).includes(vilkarField.kode)
+      ? vilkarField.kode
+      : undefined,
     periode: Array.isArray(vilkårPerioder) && vilkårPerioder[index] ? vilkårPerioder[index].periode : {},
   })),
   opptjeningPerioder: Array.isArray(opptjeninger)

--- a/packages/prosess-vilkar-opptjening-oms/src/components/VilkarField.tsx
+++ b/packages/prosess-vilkar-opptjening-oms/src/components/VilkarField.tsx
@@ -12,7 +12,7 @@ import innvilgetImage from '@fpsak-frontend/assets/images/check.svg';
 import styles from './VilkarFields.module.css';
 import dayjs from 'dayjs';
 
-export const midlertidigInaktiv = {
+export const opptjeningMidlertidigInaktivKoder = {
   TYPE_A: '7847A',
   TYPE_B: '7847B',
 };
@@ -37,12 +37,24 @@ interface VilkarFieldsProps {
 }
 
 export const erVilkarOk = (kode: string) => {
-  if (kode === 'OPPFYLT' || midlertidigInaktiv.TYPE_A === kode || midlertidigInaktiv.TYPE_B === kode) {
+  if (
+    kode === 'OPPFYLT' ||
+    opptjeningMidlertidigInaktivKoder.TYPE_A === kode ||
+    opptjeningMidlertidigInaktivKoder.TYPE_B === kode
+  ) {
     return true;
   }
   return false;
 };
 
+export const hent847Text = (kode: string) => {
+  const kodeTekster: { [key: string]: string } = {
+    [opptjeningMidlertidigInaktivKoder.TYPE_A]: 'Vilkåret beregnes jf § 8-47 bokstav A',
+    [opptjeningMidlertidigInaktivKoder.TYPE_B]: 'Vilkåret beregnes jf § 8-47 bokstav B',
+  };
+
+  return kodeTekster[kode] || '';
+};
 export const VilkarField = ({
   erOmsorgspenger,
   fieldPrefix,
@@ -56,20 +68,9 @@ export const VilkarField = ({
   );
   const erOppfyltText = <FormattedMessage id="OpptjeningVilkarAksjonspunktPanel.ErOppfylt" />;
 
-  const hent847Text = () => {
-    switch (field?.kode) {
-      case midlertidigInaktiv.TYPE_A:
-        return <FormattedMessage id="OpptjeningVilkarAksjonspunktPanel.Er847A" />;
-      case midlertidigInaktiv.TYPE_B:
-        return <FormattedMessage id="OpptjeningVilkarAksjonspunktPanel.Er847B" />;
-      default:
-        return <FormattedMessage id="OpptjeningVilkarAksjonspunktPanel.Er847" />;
-    }
-  };
-
   const vilkarVurderingTekst = () => {
-    if (erVilkarOk(field?.kode) && Object.values(midlertidigInaktiv).includes(field?.kode)) {
-      return hent847Text();
+    if (erVilkarOk(field?.kode) && Object.values(opptjeningMidlertidigInaktivKoder).includes(field?.kode)) {
+      return hent847Text(field?.kode);
     }
     if (erVilkarOk(field?.kode)) {
       return erOppfyltText;
@@ -128,7 +129,7 @@ export const VilkarField = ({
             ...(!erOmsorgspenger
               ? [
                   {
-                    value: midlertidigInaktiv.TYPE_A,
+                    value: opptjeningMidlertidigInaktivKoder.TYPE_A,
                     label: intl.formatMessage({ id: 'OpptjeningVilkarAksjonspunktPanel.MidlertidigInaktivA' }),
                   },
                 ]
@@ -136,7 +137,7 @@ export const VilkarField = ({
             ...(skalValgMidlertidigInaktivTypeBVises
               ? [
                   {
-                    value: midlertidigInaktiv.TYPE_B,
+                    value: opptjeningMidlertidigInaktivKoder.TYPE_B,
                     label: intl.formatMessage({ id: 'OpptjeningVilkarAksjonspunktPanel.MidlertidigInaktivB' }),
                   },
                 ]
@@ -151,7 +152,10 @@ export const VilkarField = ({
 
 VilkarField.buildInitialValues = (vilkårPerioder: Vilkarperiode[], opptjening: Opptjening[]): FormValues => {
   const utledKode = (periode: Vilkarperiode) => {
-    if (periode.merknad.kode === midlertidigInaktiv.TYPE_A || periode.merknad.kode === midlertidigInaktiv.TYPE_B) {
+    if (
+      periode.merknad.kode === opptjeningMidlertidigInaktivKoder.TYPE_A ||
+      periode.merknad.kode === opptjeningMidlertidigInaktivKoder.TYPE_B
+    ) {
       return periode.merknad.kode as '7847A' | '7847B';
     }
     return periode.vilkarStatus.kode as 'OPPFYLT' | 'IKKE_OPPFYLT';

--- a/packages/prosess-vilkar-overstyring/src/VilkarresultatMedOverstyringProsessIndex.stories.tsx
+++ b/packages/prosess-vilkar-overstyring/src/VilkarresultatMedOverstyringProsessIndex.stories.tsx
@@ -28,6 +28,9 @@ const vilkarOpptjening = [
     perioder: [
       {
         vilkarStatus: { kode: vilkarUtfallType.OPPFYLT, kodeverk: 'test' },
+        merknad: {
+          kode: '7847B',
+        },
         periode: {
           fom: '2020-01-30',
           tom: '2020-02-29',
@@ -35,13 +38,16 @@ const vilkarOpptjening = [
       },
       {
         vilkarStatus: { kode: vilkarUtfallType.OPPFYLT, kodeverk: 'test' },
+        merknad: {
+          kode: '-',
+        },
         periode: {
           fom: '2020-03-01',
           tom: '2020-03-31',
         },
       },
     ],
-  } as Vilkar,
+  },
 ];
 
 const vilkarMedlemskap = [
@@ -87,7 +93,7 @@ export const visOverstyringspanelForOpptjening = args => {
       panelTittelKode="Inngangsvilkar.Opptjeningsvilkaret"
       lovReferanse="§§ Dette er en lovreferanse"
       overstyringApKode={aksjonspunktCode.OVERSTYRING_AV_OPPTJENINGSVILKARET}
-      visPeriodisering={false}
+      visPeriodisering={true}
       vilkar={vilkarOpptjening}
       visAllePerioder
       erMedlemskapsPanel={false}

--- a/packages/prosess-vilkar-overstyring/src/VilkarresultatMedOverstyringProsessIndex.tsx
+++ b/packages/prosess-vilkar-overstyring/src/VilkarresultatMedOverstyringProsessIndex.tsx
@@ -119,7 +119,7 @@ const VilkarresultatMedOverstyringProsessIndex = ({
             overrideReadOnly={overrideReadOnly}
             overstyringApKode={overstyringApKode}
             panelTittelKode={panelTittelKode}
-            status={activePeriode.vilkarStatus.kode}
+            periode={activePeriode}
             toggleOverstyring={toggleOverstyring}
           />
           {featureToggles?.OMSORGEN_FOR_PERIODISERT && (

--- a/packages/prosess-vilkar-overstyring/src/components/VilkarresultatMedOverstyringHeader.tsx
+++ b/packages/prosess-vilkar-overstyring/src/components/VilkarresultatMedOverstyringHeader.tsx
@@ -27,8 +27,6 @@ const vilkårResultatText = (originalErVilkarOk: boolean, periode: Vilkarperiode
   if (originalErVilkarOk === false) {
     text = 'Vilkåret er avslått';
   }
-  console.log('periode.merknad.kode', periode.merknad.kode);
-  console.log('Object.values(opptjeningMidlertidigInaktivKoder)', Object.entries(opptjeningMidlertidigInaktivKoder));
   if (Object.values(opptjeningMidlertidigInaktivKoder).includes(periode.merknad.kode)) {
     text = hent847Text(periode.merknad.kode);
   }

--- a/packages/prosess-vilkar-overstyring/src/components/VilkarresultatMedOverstyringHeader.tsx
+++ b/packages/prosess-vilkar-overstyring/src/components/VilkarresultatMedOverstyringHeader.tsx
@@ -27,7 +27,7 @@ const vilkårResultatText = (originalErVilkarOk: boolean, periode: Vilkarperiode
   if (originalErVilkarOk === false) {
     text = 'Vilkåret er avslått';
   }
-  if (Object.values(opptjeningMidlertidigInaktivKoder).includes(periode.merknad.kode)) {
+  if (Object.values(opptjeningMidlertidigInaktivKoder).includes(periode?.merknad?.kode)) {
     text = hent847Text(periode.merknad.kode);
   }
   return (
@@ -65,7 +65,7 @@ const VilkarresultatMedOverstyringHeader = ({
   periode,
 }: Partial<VilkarresultatMedOverstyringHeaderProps>) => {
   const aksjonspunktCodes = aksjonspunkter.map(a => a.definisjon.kode);
-  const status = periode.vilkarStatus.kode;
+  const status = periode?.vilkarStatus?.kode;
   const erOppfylt = vilkarUtfallType.OPPFYLT === status;
   const erVilkarOk = vilkarUtfallType.IKKE_VURDERT !== status ? erOppfylt : undefined;
   const togglePa = () => {

--- a/packages/prosess-vilkar-overstyring/src/components/VilkarresultatMedOverstyringHeader.tsx
+++ b/packages/prosess-vilkar-overstyring/src/components/VilkarresultatMedOverstyringHeader.tsx
@@ -3,29 +3,38 @@ import innvilgetImage from '@fpsak-frontend/assets/images/innvilget_hover.svg';
 import vilkarUtfallType from '@fpsak-frontend/kodeverk/src/vilkarUtfallType';
 import { FlexColumn, FlexContainer, FlexRow, Image, VerticalSpacer } from '@fpsak-frontend/shared-components';
 import { Lovreferanse } from '@k9-sak-web/gui/shared/lovreferanse/Lovreferanse.js';
-import { Aksjonspunkt } from '@k9-sak-web/types';
+import { Aksjonspunkt, Vilkarperiode } from '@k9-sak-web/types';
 import { KeyHorizontalIcon } from '@navikt/aksel-icons';
 import { Button, Detail, Heading, Label } from '@navikt/ds-react';
 import { SetStateAction } from 'react';
 import { FormattedMessage } from 'react-intl';
 import styles from './vilkarresultatMedOverstyringForm.module.css';
+import {
+  hent847Text,
+  opptjeningMidlertidigInaktivKoder,
+} from '@fpsak-frontend/prosess-vilkar-opptjening-oms/src/components/VilkarField';
 
 const isOverridden = (aksjonspunktCodes: string[], aksjonspunktCode: string) =>
   aksjonspunktCodes.some(code => code === aksjonspunktCode);
 const isHidden = (kanOverstyre: boolean, aksjonspunktCodes: string[], aksjonspunktCode: string) =>
   !isOverridden(aksjonspunktCodes, aksjonspunktCode) && !kanOverstyre;
 
-const getVilkarOkMessage = (originalErVilkarOk: boolean) => {
-  let messageId = 'Ikke behandlet';
+const vilkårResultatText = (originalErVilkarOk: boolean, periode: Vilkarperiode) => {
+  let text = 'Ikke behandlet';
   if (originalErVilkarOk) {
-    messageId = 'Vilkåret er oppfylt';
-  } else if (originalErVilkarOk === false) {
-    messageId = 'Vilkåret er avslått';
+    text = 'Vilkåret er oppfylt';
   }
-
+  if (originalErVilkarOk === false) {
+    text = 'Vilkåret er avslått';
+  }
+  console.log('periode.merknad.kode', periode.merknad.kode);
+  console.log('Object.values(opptjeningMidlertidigInaktivKoder)', Object.entries(opptjeningMidlertidigInaktivKoder));
+  if (Object.values(opptjeningMidlertidigInaktivKoder).includes(periode.merknad.kode)) {
+    text = hent847Text(periode.merknad.kode);
+  }
   return (
     <Label size="small" as="p">
-      {messageId}
+      {text}
     </Label>
   );
 };
@@ -43,6 +52,7 @@ interface VilkarresultatMedOverstyringHeaderProps {
   panelTittelKode: string;
   toggleOverstyring: (overstyrtPanel: SetStateAction<string[]>) => void;
   status: string;
+  periode: Vilkarperiode;
 }
 
 const VilkarresultatMedOverstyringHeader = ({
@@ -54,9 +64,10 @@ const VilkarresultatMedOverstyringHeader = ({
   kanOverstyreAccess,
   toggleOverstyring,
   aksjonspunkter,
-  status,
+  periode,
 }: Partial<VilkarresultatMedOverstyringHeaderProps>) => {
   const aksjonspunktCodes = aksjonspunkter.map(a => a.definisjon.kode);
+  const status = periode.vilkarStatus.kode;
   const erOppfylt = vilkarUtfallType.OPPFYLT === status;
   const erVilkarOk = vilkarUtfallType.IKKE_VURDERT !== status ? erOppfylt : undefined;
   const togglePa = () => {
@@ -87,7 +98,7 @@ const VilkarresultatMedOverstyringHeader = ({
         <FlexRow>
           <FlexColumn>
             <VerticalSpacer eightPx />
-            {getVilkarOkMessage(erVilkarOk)}
+            {vilkårResultatText(erVilkarOk, periode)}
           </FlexColumn>
           {erVilkarOk !== undefined &&
             !isHidden(kanOverstyreAccess.isEnabled, aksjonspunktCodes, overstyringApKode) && (


### PR DESCRIPTION
Bakgrunn: 
Når vi ikke har aksjonspunkt for 5089 i behandlingen brukes den generelle VilkarresultatMedOverstyringProsessIndex-komponenten i stedet for OpptjeningProsessIndex. Der får ikke saksbehandler informasjon om vilkåret er oppfylt på grunnlag av §8-47, i stedet står det bare at det er oppfylt.

Løsning: 
Viser når perioder er oppfylt på grunnlag av §8-47