### PR TITLE
Overstyring skal kun være mulig for perioder som vurderes i behandlingen

### DIFF
--- a/packages/prosess-vilkar-overstyring/src/components/VilkarresultatMedOverstyringHeader.spec.tsx
+++ b/packages/prosess-vilkar-overstyring/src/components/VilkarresultatMedOverstyringHeader.spec.tsx
@@ -25,7 +25,7 @@ describe('<VilkarresultatMedOverstyringHeader>', () => {
           periode={{
             avslagKode: '',
             begrunnelse: '',
-            vurderesIBehandlingen: false,
+            vurderesIBehandlingen: true,
             merknad: { kode: '', kodeverk: '' },
             merknadParametere: {},
             periode: { fom: '', tom: '' },

--- a/packages/prosess-vilkar-overstyring/src/components/VilkarresultatMedOverstyringHeader.spec.tsx
+++ b/packages/prosess-vilkar-overstyring/src/components/VilkarresultatMedOverstyringHeader.spec.tsx
@@ -22,6 +22,15 @@ describe('<VilkarresultatMedOverstyringHeader>', () => {
           panelTittelKode="Inngangsvilkar.Medlemskapsvilkaret"
           erOverstyrt
           aksjonspunkter={[]}
+          periode={{
+            avslagKode: '',
+            begrunnelse: '',
+            vurderesIBehandlingen: false,
+            merknad: { kode: '', kodeverk: '' },
+            merknadParametere: {},
+            periode: { fom: '', tom: '' },
+            vilkarStatus: { kode: '', kodeverk: '' },
+          }}
           status=""
         />
       </Provider>,

--- a/packages/prosess-vilkar-overstyring/src/components/VilkarresultatMedOverstyringHeader.tsx
+++ b/packages/prosess-vilkar-overstyring/src/components/VilkarresultatMedOverstyringHeader.tsx
@@ -16,8 +16,12 @@ import {
 
 const isOverridden = (aksjonspunktCodes: string[], aksjonspunktCode: string) =>
   aksjonspunktCodes.some(code => code === aksjonspunktCode);
-const isHidden = (kanOverstyre: boolean, aksjonspunktCodes: string[], aksjonspunktCode: string) =>
-  !isOverridden(aksjonspunktCodes, aksjonspunktCode) && !kanOverstyre;
+const isHidden = (
+  kanOverstyre: boolean,
+  aksjonspunktCodes: string[],
+  aksjonspunktCode: string,
+  vurderesIBehandlingen: boolean,
+) => (!isOverridden(aksjonspunktCodes, aksjonspunktCode) && !kanOverstyre) || !vurderesIBehandlingen;
 
 const vilkårResultatText = (originalErVilkarOk: boolean, periode: Vilkarperiode) => {
   let text = 'Ikke behandlet';
@@ -99,7 +103,12 @@ const VilkarresultatMedOverstyringHeader = ({
             {vilkårResultatText(erVilkarOk, periode)}
           </FlexColumn>
           {erVilkarOk !== undefined &&
-            !isHidden(kanOverstyreAccess.isEnabled, aksjonspunktCodes, overstyringApKode) && (
+            !isHidden(
+              kanOverstyreAccess.isEnabled,
+              aksjonspunktCodes,
+              overstyringApKode,
+              periode.vurderesIBehandlingen,
+            ) && (
               <FlexColumn>
                 <VerticalSpacer fourPx />
                 <Button


### PR DESCRIPTION
Bakgrunn:
Overstyr skal kun være mulig for perioder som er til vurdering i behandlingen. Hvis en skal overstyre tidligere perioder, skal man opprette manuell revurdering.

Løsning:
Skjuler overstyring i inngangsvilkår dersom perioden ikke vurderes i behandlingen