### PR TITLE
Legg til ny UNG kodeverdi i FagsakYtelsesType.ts

### DIFF
--- a/packages/v2/backend/src/k9sak/kodeverk/FagsakYtelsesType.ts
+++ b/packages/v2/backend/src/k9sak/kodeverk/FagsakYtelsesType.ts
@@ -1,7 +1,7 @@
 import { type FagsakDto } from '../generated';
 import type { Kodeverk } from '../../shared/Kodeverk.ts';
 
-export type FagsakYtelsesType = FagsakDto['sakstype'];
+export type FagsakYtelsesType = FagsakDto['sakstype'] | 'UNG';
 
 // Oppretter Kodeverk type med verdier frå openapi generert union type
 export type FagsakYtelsesTypeKodeverk = Kodeverk<FagsakYtelsesType, 'FAGSAK_YTELSE'>;
@@ -24,6 +24,7 @@ export const fagsakYtelsesType: Readonly<Record<FagsakYtelsesType, FagsakYtelses
   FP: 'FP',
   SVP: 'SVP',
   EF: 'EF',
+  UNG: 'UNG',
   OBSOLETE: 'OBSOLETE',
   '-': '-',
 };


### PR DESCRIPTION
**Bakgrunn:**
Det viser seg at når ein legger til nye verdier i ein enum i backend der ein har definert ein konstant som skal ha alle verdier frå backend enum i frontend, så oppstår ein "catch 22" situasjon i build pipeline.

Build pipeline for k9-sak vil då feile på kompilatorsjekk av k9-sak-web, fordi den nye enum verdien ikkje er inkludert i konstant-objektet i frontend koden. Samtidig kan ikkje frontend koden på korrekt viss legge til den nye enum verdien før backend pipeline har generert ny versjon av typescript klient biblioteket. Sidan det ikkje blir publisert ny versjon av typescript klient biblioteket før kompilatorsjekk er vellykka blir ein blokkert.

**Løsning:**
I første omgang hardkoder vi inn den nye enum verdien manuellt i frontend koden, slik at k9-sak build og publisering av nytt typescript klient bibliotek går gjennom.

Deretter kan den mindlertidig hardkoda verdien i frontend koden fjernast igjen når ein tek i bruk ny typescript klient bibliotek versjon.

Vidare er planen å aktivere generering av javascript konstanter for alle enums i verktøyet som genererer typescript klient bibliotek frå backend direkte. Då vil ein kunne unngå dette problemet ved å bruke ferdig generert konstant istadenfor å måtte manuelt definere disse i frontend.