### PR TITLE
Krever gyldig dato i 9291

### DIFF
--- a/packages/prosess-uttak/src/ui/components/vurderDato/VurderDatoAksjonspunkt.tsx
+++ b/packages/prosess-uttak/src/ui/components/vurderDato/VurderDatoAksjonspunkt.tsx
@@ -1,6 +1,6 @@
 import { Button } from '@navikt/ds-react';
 import { Datepicker, Form, TextAreaField } from '@navikt/ft-form-hooks';
-import { maxLength, minLength, required } from '@navikt/ft-form-validators';
+import { hasValidDate, maxLength, minLength, required } from '@navikt/ft-form-validators';
 import React from 'react';
 import { useForm } from 'react-hook-form';
 import ContainerContext from '../../context/ContainerContext';
@@ -38,7 +38,7 @@ const VurderDatoAksjonspunkt = ({ avbryt, initialValues }: Props) => {
           defaultMonth={new Date()}
           fromDate={new Date('1 Jan 2019')}
           toDate={new Date('31 Dec 2025')}
-          validate={[required]}
+          validate={[required, hasValidDate]}
         />
         <TextAreaField
           name="begrunnelse"


### PR DESCRIPTION
Tror at saksbehandler prøver å skrive inn dato på et annet format enn det vi forventet og at dette er årsaken til noen 400-feil på POST til /aksjonspunkt. Aller helst vil de vel skrive ddmmyy og ikke dd.mm.yyyy, så det er sikkert det som skjer her.