### PR TITLE
Legger til openapi-compat header på k9-sak typescript klient kall.

### DIFF
--- a/packages/v2/backend/src/shared/jsonSerializerOption.ts
+++ b/packages/v2/backend/src/shared/jsonSerializerOption.ts
@@ -1,0 +1,7 @@
+// Disse verdier er også hardkoda i k9-sak ObjectMapperResolver.java
+// Ved å legge til denne header verdi instruerer ein server til å serialisere respons slik at den alltid stemmer med generert
+// openapi spesifikasjon. (Enum verdier må alltid serialiserast til ein string.)
+export const jsonSerializerOption = {
+  xJsonSerializerOptionHeader: 'X-Json-Serializer-Option',
+  xJsonSerializerOptionValue: 'openapi-compat',
+} as const;

--- a/packages/v2/gui/src/app/K9SakClientContext.tsx
+++ b/packages/v2/gui/src/app/K9SakClientContext.tsx
@@ -3,12 +3,15 @@ import { K9SakClient } from '@k9-sak-web/backend/k9sak/generated';
 import { generateNavCallidHeader } from '@k9-sak-web/backend/shared/instrumentation/navCallid.js';
 import type { ApiRequestOptions } from '@k9-sak-web/backend/k9sak/generated';
 import { K9SakHttpRequest } from '@k9-sak-web/backend/k9sak/errorhandling/K9SakHttpRequest.js';
+import { jsonSerializerOption } from '@k9-sak-web/backend/shared/jsonSerializerOption.js';
 
 const headerResolver = async (options: ApiRequestOptions<Record<string, string>>): Promise<Record<string, string>> => {
   const { headerName, headerValue } = generateNavCallidHeader();
+  const { xJsonSerializerOptionHeader, xJsonSerializerOptionValue } = jsonSerializerOption;
   return {
     ...options.headers,
-    [headerName]: headerValue,
+    [headerName]: headerValue, // Legg til nav call id header
+    [xJsonSerializerOptionHeader]: xJsonSerializerOptionValue, // Legg til X-Json-Serializer-Option header
   };
 };
 


### PR DESCRIPTION
Slik at server serialiserer enum verdier tilsvarande slik openapi spesifikasjon blir generert.

Dette skal føre til at kall der respons inkluderer enum verdier skal fungere korrekt.