### PR TITLE
Justerer spacing i feilmeldingslinja.

### DIFF
--- a/packages/sak-dekorator/src/ErrorMessagePanel.tsx
+++ b/packages/sak-dekorator/src/ErrorMessagePanel.tsx
@@ -1,6 +1,6 @@
 import { decodeHtmlEntity } from '@fpsak-frontend/utils';
 import { XMarkIcon } from '@navikt/aksel-icons';
-import { Button, Detail, HGrid } from '@navikt/ds-react';
+import { Button, Detail, HStack } from '@navikt/ds-react';
 import React, { useMemo, useState } from 'react';
 import { FormattedMessage, WrappedComponentProps, injectIntl } from 'react-intl';
 import { v4 as uuidv4 } from 'uuid';
@@ -49,7 +49,7 @@ export const ErrorMessagePanel = (props: OwnProps & WrappedComponentProps) => {
   return (
     <div className={styles.container}>
       {errorMessagesWithId.map((message, index) => (
-        <HGrid gap="1" columns={{ xs: '11fr 1fr' }} key={message.id}>
+        <HStack gap="3" key={message.id}>
           <Detail className={styles.wordWrap}>{`${decodeHtmlEntity(message.message)} `}</Detail>
           {message.additionalInfo && (
             <Detail>
@@ -64,7 +64,7 @@ export const ErrorMessagePanel = (props: OwnProps & WrappedComponentProps) => {
               </a>
             </Detail>
           )}
-        </HGrid>
+        </HStack>
       ))}
       <div className={styles.lukkContainer}>
         <Button

--- a/packages/sak-dekorator/src/HeaderWithErrorPanel.stories.tsx
+++ b/packages/sak-dekorator/src/HeaderWithErrorPanel.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import HeaderWithErrorPanel from './HeaderWithErrorPanel';
 
 export default {
@@ -21,7 +21,13 @@ export const visDekoratorUtenFeilmeldinger = () => (
 );
 
 export const visDekoratorMedFeilmeldinger = () => {
-  const [errorMessages, removeErrorMessages] = useState([{ message: 'Feilmelding 1' }, { message: 'Feilmelding 2' }]);
+  const [errorMessages, removeErrorMessages] = useState([
+    { message: 'Feilmelding 1' },
+    {
+      message: 'En lang feilmelding som også har ekstra informasjon som kan åpnes i en popup.',
+      additionalInfo: { feilmelding: 'Detaljert feilmelding', url: '' },
+    },
+  ]);
   return (
     <div style={{ marginLeft: '-56px' }}>
       <HeaderWithErrorPanel


### PR DESCRIPTION
Bakgrunn: Plassering av knapp for detaljert informasjon for feilmelding var litt på ville veier.
<img width="1386" alt="Skjermbilde 2024-10-21 kl  11 47 23" src="https://github.com/user-attachments/assets/e3f773a2-419d-45b5-aa4f-1174e3a52839">


Løsning: Legger knapp nært feilmeldingen, slik det var før.
<img width="1379" alt="Skjermbilde 2024-10-21 kl  11 47 01" src="https://github.com/user-attachments/assets/12e5ca6a-6899-4da0-9a98-0d0bb1f7ed15">

