### PR TITLE
fjerner trivy fra workflow da dette steget ofte feiler

### DIFF
--- a/.github/workflows/deploy-docker-image.yml
+++ b/.github/workflows/deploy-docker-image.yml
@@ -70,18 +70,6 @@ jobs:
       suites: "frontend"
       image_version: ${{ needs.build-docker-image.outputs.tag }}
 
-  trivy:
-    needs: [build-docker-image]
-    uses: navikt/sif-gha-workflows/.github/workflows/trivy.yml@main
-    permissions:
-      contents: write
-      id-token: write
-      security-events: write
-      actions: read
-    secrets: inherit
-    with:
-      image: ${{ needs.build-docker-image.outputs.image }}
-      team: k9saksbehandling
 
   deploy-dev:
     name: Deploy to dev
@@ -112,7 +100,7 @@ jobs:
       CLUSTER: prod-fss
     environment: prod-fss:k9saksbehandling
     if: github.ref_name == 'master'
-    needs: [build-docker-image, deploy-dev, verdikjede-tester, trivy]
+    needs: [build-docker-image, deploy-dev, verdikjede-tester]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Trivy-scan er også inkludert i nais/docker-build-push workflowen, så imaget vil fortsatt bli scannet for sårbarheter.

Jeg forstår det som at det eneste vi mister ved å fjerne denne fra vår egen workflow er at det ikke lenger vil bli scannet etter secrets og api-nøkler

<img width="1022" alt="image" src="https://github.com/user-attachments/assets/6680deb7-19fd-40e8-a4a6-574c487cf7e4">
