### PR TITLE
TSFF-940: uttaksperioder visning toggle periode bug

### DIFF
--- a/packages/prosess-uttak/src/ui/components/uttaksperiode-liste/UttaksperiodeListe.tsx
+++ b/packages/prosess-uttak/src/ui/components/uttaksperiode-liste/UttaksperiodeListe.tsx
@@ -136,8 +136,8 @@ const UttaksperiodeListe = (props: UttaksperiodeListeProps): JSX.Element => {
               )}
               <Uttak
                 uttak={uttak}
-                erValgt={valgtPeriodeIndex === index}
-                velgPeriode={() => velgPeriode(index)}
+                erValgt={valgtPeriodeIndex === (afterOrCovering.length ? afterOrCovering.length + index : index)}
+                velgPeriode={() => velgPeriode(afterOrCovering.length ? afterOrCovering.length + index : index)}
                 withBorderTop={index === 0 && !!virkningsdatoUttakNyeRegler}
               />
             </React.Fragment>


### PR DESCRIPTION
Bakgrunn:
Har en liste som splittes i to, og samme useState brukes til å toggle hvilken uttaksperiode som skal ekspanderes fra de to listene. Input er indeks og vil treffe begge listene

Løsning: 
Gjør valgtPeriodeIndex unik
