### PR TITLE
TSFF-954

### DIFF
--- a/packages/prosess-tilkjent-ytelse/src/components/manuellePerioder/NyPeriode.tsx
+++ b/packages/prosess-tilkjent-ytelse/src/components/manuellePerioder/NyPeriode.tsx
@@ -22,7 +22,9 @@ interface Periode {
 }
 
 export const sjekkOverlappendePerioder = (index: number, nestePeriode: Periode, forrigePeriode: Periode) =>
-  index !== 0 && initializeDate(nestePeriode.fom).isSameOrBefore(initializeDate(forrigePeriode.tom));
+  index !== 0
+  && initializeDate(nestePeriode.fom).isSameOrBefore(initializeDate(forrigePeriode.tom))
+  && initializeDate(nestePeriode.tom).isSameOrAfter(initializeDate(forrigePeriode.fom))
 
 const validateForm = (perioder: BeriketBeregningsresultatPeriode[], nyPeriodeFom: string, nyPeriodeTom: string) => {
   let feilmelding = '';


### PR DESCRIPTION
Legg til en sjekk på at ny tomdato er etter eksisternde fomdato. Dette sørger for at sjekken går gjennom når perioden i sin helhet er før den eksisterende perioden, også når det ikke er overlapp