### PR TITLE
Legg til valideringsmeldinger igjen

### DIFF
--- a/packages/sak-meny-ny-behandling/src/MenyNyBehandlingIndex.tsx
+++ b/packages/sak-meny-ny-behandling/src/MenyNyBehandlingIndex.tsx
@@ -1,8 +1,9 @@
-import React, { useCallback } from 'react';
+import { useCallback } from 'react';
 import { createIntl, createIntlCache, RawIntlProvider } from 'react-intl';
 
 import BehandlingType from '@fpsak-frontend/kodeverk/src/behandlingType';
 import { Kodeverk, KodeverkMedNavn } from '@k9-sak-web/types';
+import messages from './i18n/nb_NO.json';
 
 import NyBehandlingModal, { BehandlingOppretting, FormValues } from './components/NyBehandlingModal';
 
@@ -12,7 +13,7 @@ const TILBAKEKREVING_BEHANDLINGSTYPER = [BehandlingType.TILBAKEKREVING, Behandli
 const intl = createIntl(
   {
     locale: 'nb-NO',
-    messages: {},
+    messages,
   },
   createIntlCache(),
 );

--- a/packages/sak-meny-ny-behandling/src/i18n/nb_NO.json
+++ b/packages/sak-meny-ny-behandling/src/i18n/nb_NO.json
@@ -1,0 +1,3 @@
+{
+  "ValidationMessage.NotEmpty": "Feltet må fylles ut"
+}


### PR DESCRIPTION
Det viser seg at vi ikke kunne fjerne i18n-opplegget helt enda, siden vi bruker gamle komponenter som krever denne intl-fila for å vise feilmeldinger :( 

Legger den heller tilbake igjen, også får vi migrere over til nye komponenter ved en senere anledning.