### PR TITLE
Slå på delvis revurdering feature toggle

### DIFF
--- a/deploy/prod-fss-k9saksbehandling.yml
+++ b/deploy/prod-fss-k9saksbehandling.yml
@@ -109,7 +109,7 @@ spec:
     - name: AUTOMATISK_VURDERT_MEDLEMSKAP
       value: "true"
     - name: DELVIS_REVURDERING
-      value: "false"
+      value: "true"
     - name: "BRUK_V2_SAK_DOKUMENTER"
       value: "false"
     - name: OPPTJENING_READ_ONLY_PERIODER


### PR DESCRIPTION
Denne PRen slår på "delvis revurdering" feature togglen, så saksbehandlere kan revurdere saker fra beregningssteget. 

Det kommer en egen PR som fjerner feature togglen fra koden, som vi kan merge senere.