### PR TITLE
Separat ung.vite.config.js for devserver og build av ung-sak-web.

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "build-storybook-test": "VITE_LOCAL_STORYBOOK=true storybook build --test -o .static_storybook",
     "prepare": "husky",
     "sentry-release": "(SENTRY_RELEASE=$(git rev-parse --short HEAD); node ./scripts/sentry-release.cjs)",
+    "sentry-release-ung": "(SENTRY_RELEASE=$(git rev-parse --short HEAD); node ./scripts/sentry-release-ung.cjs)",
     "dev:ung": "vite -c ung.vite.config.js serve",
     "build:ung": "VITE_SENTRY_RELEASE=$(git rev-parse --short HEAD) vite -c ung.vite.config.js build"
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "build-storybook": "storybook build -o .static_storybook",
     "build-storybook-test": "VITE_LOCAL_STORYBOOK=true storybook build --test -o .static_storybook",
     "prepare": "husky",
-    "sentry-release": "(SENTRY_RELEASE=$(git rev-parse --short HEAD); node ./scripts/sentry-release.cjs)"
+    "sentry-release": "(SENTRY_RELEASE=$(git rev-parse --short HEAD); node ./scripts/sentry-release.cjs)",
+    "dev:ung": "vite -c ung.vite.config.js serve",
+    "build:ung": "VITE_SENTRY_RELEASE=$(git rev-parse --short HEAD) vite -c ung.vite.config.js build"
   },
   "workspaces": [
     "packages/*",

--- a/packages/rest-api/src/requestApi/RequestRunner.ts
+++ b/packages/rest-api/src/requestApi/RequestRunner.ts
@@ -1,10 +1,10 @@
-import EventType from './eventType';
-import AsyncPollingStatus from './asyncPollingStatus';
 import HttpClientApi from '../HttpClientApiTsType';
-import { Response } from './ResponseTsType';
 import RequestAdditionalConfig from '../RequestAdditionalConfigTsType';
-import TimeoutError from './error/TimeoutError';
+import AsyncPollingStatus from './asyncPollingStatus';
 import RequestErrorEventHandler from './error/RequestErrorEventHandler';
+import TimeoutError from './error/TimeoutError';
+import EventType from './eventType';
+import { Response } from './ResponseTsType';
 
 const HTTP_ACCEPTED = 202;
 const MAX_POLLING_ATTEMPTS = 150;
@@ -136,7 +136,8 @@ class RequestRunner {
       if (popupWindow === null) {
         const location = `${response.headers.location}`;
         const queryParamAddition = location.includes('?') ? '&' : '?';
-        const redirectLocation = `${location}${queryParamAddition}redirectTo=/k9/web/close`;
+        const redirectTo = location.includes('/ung/sak/') ? '/ung/web' : '/k9/web';
+        const redirectLocation = `${location}${queryParamAddition}redirectTo=${redirectTo}/close`;
         popupWindow = window.open(redirectLocation, undefined, 'height=600,width=800');
       }
       const timer = setInterval(async () => {

--- a/packages/sak-app/src/bootstrapUng.tsx
+++ b/packages/sak-app/src/bootstrapUng.tsx
@@ -1,0 +1,117 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
+import { RestApiErrorProvider, RestApiProvider } from '@k9-sak-web/rest-api-hooks';
+import { init } from '@sentry/browser';
+import * as Sentry from '@sentry/react';
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import { Provider } from 'react-redux';
+import { BrowserRouter, createRoutesFromChildren, matchRoutes, useLocation, useNavigationType } from 'react-router-dom';
+
+import { ExtendedApiError } from '@k9-sak-web/backend/shared/instrumentation/ExtendedApiError.js';
+import { AppIndex } from '../../ung/sak-app';
+import configureStore from './configureStore';
+import { IS_DEV, VITE_SENTRY_RELEASE } from './constants';
+
+import { isAlertInfo } from '@k9-sak-web/gui/app/alerts/AlertInfo.js';
+import { AxiosError } from 'axios';
+
+/* eslint no-undef: "error" */
+const isDevelopment = IS_DEV;
+const environment = window.location.hostname;
+
+console.debug('************** bootstrapUng');
+
+init({
+  environment,
+  dsn: isDevelopment ? 'http://dev@localhost:9000/1' : 'https://251afca29aa44d738b73f1ff5d78c67f@sentry.gc.nav.no/31',
+  release: VITE_SENTRY_RELEASE || 'unknown',
+  // tracesSampleRate: isDevelopment ? 1.0 : 0.5, // Consider adjusting this in production
+  tracesSampleRate: 1.0,
+  integrations: [
+    Sentry.breadcrumbsIntegration({ console: false }),
+    Sentry.reactRouterV6BrowserTracingIntegration({
+      useEffect: React.useEffect,
+      useLocation,
+      useNavigationType,
+      createRoutesFromChildren,
+      matchRoutes,
+    }),
+  ],
+  beforeSend: (event, hint) => {
+    try {
+      event.extra = event.extra || {};
+      const exception = hint.originalException;
+      if (exception instanceof AxiosError) {
+        const requestUrl = new URL(exception.request.responseURL);
+        event.fingerprint = [
+          '{{ default }}',
+          String(exception.name),
+          String(exception.message),
+          String(requestUrl.pathname),
+        ];
+        event.extra.callId = exception.response.config.headers['Nav-Callid'];
+      } else if (exception instanceof ExtendedApiError) {
+        event.fingerprint = ['{{ default }}', exception.name, exception.statusText, exception.url];
+        event.extra.callId = exception.navCallid;
+      }
+      // For alle Error typer som implementerer AlertInfo tek vi med errorId i sentry rapport.
+      if (isAlertInfo(exception)) {
+        event.extra.errorId = `${exception.errorId}`;
+      }
+    } catch (e) {
+      try {
+        event.exception.values.push(e);
+        console.error('Sentry beforeSend failure. Will send the original event with extra error attached', e);
+      } catch (e2) {
+        console.error(
+          'Sentry beforeSend failure. Will send the original event. Attaching of extra error also failed',
+          e,
+          e2,
+        );
+      }
+    }
+    return event;
+  },
+});
+
+const store = configureStore();
+
+const renderFunc = Component => {
+  /**
+   * Redirecte til riktig basename om man kommer hit uten
+   * Vil kunne forekomme lokalt og i tester
+   */
+  if (window.location.pathname === '/') {
+    window.location.assign('/k9/web');
+  }
+
+  const app = document.getElementById('app');
+  if (app === null) {
+    throw new Error('No app element');
+  }
+
+  const prepare = async (): Promise<void> => {
+    // eslint-disable-next-line no-undef
+    if (process.env.NODE_ENV === 'test') {
+      const { worker } = await import('../../mocks/browser');
+      worker.start({ onUnhandledRequest: 'bypass' });
+    }
+  };
+
+  prepare().then(() => {
+    const root = createRoot(app);
+    root.render(
+      <Provider store={store}>
+        <BrowserRouter basename="/k9/web">
+          <RestApiProvider>
+            <RestApiErrorProvider>
+              <Component />
+            </RestApiErrorProvider>
+          </RestApiProvider>
+        </BrowserRouter>
+      </Provider>,
+    );
+  });
+};
+
+renderFunc(AppIndex);

--- a/packages/sak-app/src/bootstrapUng.tsx
+++ b/packages/sak-app/src/bootstrapUng.tsx
@@ -82,7 +82,7 @@ const renderFunc = Component => {
    * Vil kunne forekomme lokalt og i tester
    */
   if (window.location.pathname === '/') {
-    window.location.assign('/k9/web');
+    window.location.assign('/ung/web');
   }
 
   const app = document.getElementById('app');
@@ -102,7 +102,7 @@ const renderFunc = Component => {
     const root = createRoot(app);
     root.render(
       <Provider store={store}>
-        <BrowserRouter basename="/k9/web">
+        <BrowserRouter basename="/ung/web">
           <RestApiProvider>
             <RestApiErrorProvider>
               <Component />

--- a/packages/sak-app/src/bootstrapUng.tsx
+++ b/packages/sak-app/src/bootstrapUng.tsx
@@ -23,7 +23,7 @@ console.debug('************** bootstrapUng');
 
 init({
   environment,
-  dsn: isDevelopment ? 'http://dev@localhost:9000/1' : 'https://251afca29aa44d738b73f1ff5d78c67f@sentry.gc.nav.no/31',
+  dsn: isDevelopment ? 'http://dev@localhost:9000/1' : 'https://e0b47ccba910402c81fcae9bf04d2427@sentry.gc.nav.no/176',
   release: VITE_SENTRY_RELEASE || 'unknown',
   // tracesSampleRate: isDevelopment ? 1.0 : 0.5, // Consider adjusting this in production
   tracesSampleRate: 1.0,

--- a/packages/ung/sak-app/app/paths.ts
+++ b/packages/ung/sak-app/app/paths.ts
@@ -116,5 +116,5 @@ export const goToLos = () => {
 };
 
 export const goToSearch = () => {
-  window.location.assign('/k9/web');
+  window.location.assign('/ung/web');
 };

--- a/packages/ung/sak-app/data/ungsakApi.ts
+++ b/packages/ung/sak-app/data/ungsakApi.ts
@@ -144,7 +144,7 @@ const endpoints = new RestApiConfigBuilder()
   .withPost('/ung/formidling/api/brev/forhaandsvis', UngSakApiKeys.PREVIEW_MESSAGE_FORMIDLING, { isResponseBlob: true })
 
   // Språkfil (ligg på klient - Skal fjernast - Det som ligg i denne skal flyttes til spesifikke pakker)
-  .withGet('/k9/web/sprak/nb_NO.json', UngSakApiKeys.LANGUAGE_FILE)
+  .withGet('/ung/web/sprak/nb_NO.json', UngSakApiKeys.LANGUAGE_FILE)
 
   // Kun brukt for søk på localhost
   .withPost('/ung/sak/api/fagsak/sok', UngSakApiKeys.SEARCH_FAGSAK)

--- a/scripts/sentry-release-ung.cjs
+++ b/scripts/sentry-release-ung.cjs
@@ -1,0 +1,36 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const SentryCli = require('@sentry/cli');
+
+async function opprettReleaseTilSentry() {
+  const release = process.env.SENTRY_RELEASE;
+  const authToken = process.env.SENTRY_AUTH_TOKEN;
+
+  if (!release) {
+    throw new Error('"SENTRY_RELEASE" er ikke satt');
+  }
+
+  if (!authToken) {
+    throw new Error('"SENTRY_AUTH_TOKEN" er ikke satt');
+  }
+
+  const cli = new SentryCli();
+
+  try {
+    console.log(`Oppretter Sentry-release ${release}`);
+    await cli.releases.new(release);
+
+    console.log('Laster opp source maps');
+    await cli.releases.uploadSourceMaps(release, {
+      include: ['dist/ung/web'],
+      urlPrefix: '~/ung/web/',
+      rewrite: false,
+    });
+
+    console.log('Releaser');
+    await cli.releases.finalize(release);
+  } catch (e) {
+    console.error('Noe gikk galt under source map-opplasting:', e);
+  }
+}
+
+opprettReleaseTilSentry();

--- a/ung.html
+++ b/ung.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="no">
+<head>
+  <meta http-equiv="x-ua-compatible" content="IE=edge" />
+  <meta charset="utf-8" />
+  <meta name="format-detection" content="telephone=no" />
+  <link rel="icon" type="image/x-icon" href="/client/favicon.ico" />
+  <title>Ung-sak</title>
+  <script type="module" src="/packages/sak-app/src/bootstrapUng.tsx"></script>
+</head>
+<body>
+<div id="app"></div>
+</body>
+</html>

--- a/ung.vite.config.js
+++ b/ung.vite.config.js
@@ -2,11 +2,11 @@ import react from '@vitejs/plugin-react';
 import fs from 'fs/promises';
 import path from 'path';
 import { loadEnv } from 'vite';
+import { createHtmlPlugin } from "vite-plugin-html";
 import svgr from 'vite-plugin-svgr';
 import { defineConfig } from 'vitest/config';
 import { createMockResponder, staticJsonResponse } from "./_mocks/createMockResponder.js";
 import { featureTogglesFactory } from "./_mocks/featureToggles.js";
-import {createHtmlPlugin} from "vite-plugin-html";
 
 const createProxy = (target, pathRewrite) => ({
   target,
@@ -19,7 +19,7 @@ const createProxy = (target, pathRewrite) => ({
     proxy.on('proxyRes', (proxyRes, req, res) => {
       if (proxyRes.statusCode === 401) {
         // eslint-disable-next-line no-param-reassign
-        proxyRes.headers.location = `/k9/sak/resource/login?original=${req.originalUrl}`;
+        proxyRes.headers.location = `/ung/sak/resource/login?original=${req.originalUrl}`;
       }
       // Viss respons frå proxied server inneheld location header med server adresse, fjern server addressa slik at redirect
       // går til dev server istadenfor proxied server. Dette for å unngå CORS feil når request går direkte til proxied server.
@@ -68,7 +68,7 @@ export default ({ mode }) => {
               }
               if (proxyRes.statusCode === 401) {
                 // eslint-disable-next-line no-param-reassign
-                proxyRes.headers.location = '/k9/sak/resource/login';
+                proxyRes.headers.location = '/ung/sak/resource/login';
               }
             });
           },
@@ -104,7 +104,7 @@ export default ({ mode }) => {
         '/ung/feature-toggle/toggles.json': createMockResponder('http://localhost:8085', staticJsonResponse(featureTogglesFactory())),
       },
     },
-    base: '/k9/web',
+    base: '/ung/web',
     publicDir: './public',
     plugins: [
       createHtmlPlugin({
@@ -120,16 +120,16 @@ export default ({ mode }) => {
         // Endre namn på bygd entrypoint html frå ung.html til index.html
         name: "rename-html-entry",
         closeBundle: async () => {
-          const buildDir = path.join(__dirname, "dist/k9/web")
+          const buildDir = path.join(__dirname, "dist/ung/web")
           const oldPath = path.join(buildDir, "ung.html")
           const newPath = path.join(buildDir, "index.html")
           await fs.rename(oldPath, newPath)
         }
-}
+      }
     ],
     build: {
       // Relative to the root
-      outDir: './dist/k9/web',
+      outDir: './dist/ung/web',
       sourcemap: true,
       rollupOptions: {
         input: './ung.html',


### PR DESCRIPTION
yarn dev:ung starter devserver med ung.html entrypoint og devserver oppsett.

yarn dev:build bygger bundle med ung.html som entrypoint.

Merk at disse framleis bruker /k9/web som base path. Bør endrast til /ung/web.