### PR TITLE
Vis årsak når det er tilbakekrevings-revurderinger

### DIFF
--- a/packages/sak-meny-ny-behandling/src/components/NyBehandlingModal.tsx
+++ b/packages/sak-meny-ny-behandling/src/components/NyBehandlingModal.tsx
@@ -108,7 +108,8 @@ export const NyBehandlingModal = ({
   }, []);
   const erFørstegangsbehandling = valgtBehandlingTypeKode === bType.FORSTEGANGSSOKNAD;
   const erRevurdering = valgtBehandlingTypeKode === bType.REVURDERING;
-  const visÅrsak = erRevurdering && steg === 'inngangsvilkår';
+  const visÅrsak =
+    (erRevurdering && steg === 'inngangsvilkår') || (!erRevurdering && behandlingArsakTyper.length > 0);
   return (
     <Modal
       className={styles.modal}


### PR DESCRIPTION
Denne PRen endrer slik at man viser årsak i noen tilfeller der man skal vise årsak. Det var en case der noen hadde valgt revurdering av en tilbakekrevingssak hvor man ikke fikk opp årsak, som gjorde at man ikke fikk opprettet ny sak.