### PR TITLE
Vise 0% fravær om faktisk og normal arbeidstid er 0

### DIFF
--- a/packages/prosess-uttak/src/ui/components/uttak-detaljer/UttakDetaljer.tsx
+++ b/packages/prosess-uttak/src/ui/components/uttak-detaljer/UttakDetaljer.tsx
@@ -140,9 +140,10 @@ const formatAvkortingMotArbeid = (
         const beregnetFaktiskArbeidstid = beregnDagerTimer(faktiskArbeidstid);
         const erNyInntekt = utbetalingsgradItem?.tilkommet;
         const faktiskOverstigerNormal = beregnetNormalArbeidstid < beregnetFaktiskArbeidstid;
-        const prosentFravær = Math.round(
-          (Math.max(beregnetNormalArbeidstid - beregnetFaktiskArbeidstid, 0) / beregnetNormalArbeidstid) * 100,
-        );
+        const prosentFravær =
+          Math.round(
+            (Math.max(beregnetNormalArbeidstid - beregnetFaktiskArbeidstid, 0) / beregnetNormalArbeidstid) * 100,
+          ) || 0;
 
         const nyInntektTekst = () => {
           if (arbeidsforhold?.type === Arbeidstype.ARBEIDSTAKER) {


### PR DESCRIPTION
Om faktisk og normal arbeidstid blir % fravær vist som NaN (for eksempel ifm. freelancer). Setter vil å vise 0% om prosentutregningen blir NaN