### PR TITLE
Fiks Vilkårtype så ny generert backend klientkode blir kompatibel.

### DIFF
--- a/packages/v2/backend/src/k9sak/kodeverk/behandling/VilkårType.ts
+++ b/packages/v2/backend/src/k9sak/kodeverk/behandling/VilkårType.ts
@@ -1,6 +1,26 @@
-import { vilkarType as GeneratedVilkarType } from '../../generated';
+type VilkårTypeNames =
+  | 'ALDERSVILKÅR_BARN'
+  | 'ALDERSVILKÅR'
+  | 'BEREGNINGSGRUNNLAGVILKÅR'
+  | 'GJENNOMGÅ_OPPLÆRING'
+  | 'GODKJENT_OPPLÆRINGSINSTITUSJON'
+  | 'I_LIVETS_SLUTTFASE'
+  | 'K9_VILKÅRET'
+  | 'LANGVARIG_SYKDOM'
+  | 'MEDISINSKEVILKÅR_18_ÅR'
+  | 'MEDISINSKEVILKÅR_UNDER_18_ÅR'
+  | 'MEDLEMSKAPSVILKÅRET'
+  | 'NØDVENDIG_OPPLÆRING'
+  | 'OMSORGEN_FOR'
+  | 'OPPTJENINGSPERIODEVILKÅR'
+  | 'OPPTJENINGSVILKÅRET'
+  | 'SØKERSOPPLYSNINGSPLIKT'
+  | 'SØKNADSFRIST'
+  | 'UDEFINERT'
+  | 'UNGDOMSPROGRAMVILKÅRET'
+  | 'UTVIDETRETT';
 
-export const vilkarType: Readonly<Record<GeneratedVilkarType, string>> = {
+export const vilkarType: Readonly<Record<VilkårTypeNames, string>> = {
   ALDERSVILKÅR_BARN: 'K9_VK_5_3',
   ALDERSVILKÅR: 'K9_VK_3',
   BEREGNINGSGRUNNLAGVILKÅR: 'FP_VK_41',


### PR DESCRIPTION
Bakgrunn: Vilkårtype enum har blitt generert med verdier lik enum name frå backend. Dette var ein feil, skulle blitt generert med kode verdi.

Løysing: For å få kompilert med ny generert klientkode der Vilkårtype er basert på kode verdier må eksisterande bruk av name verdiane endrast til å bli hardkoda.

Når ny generert klientkode er tatt inn i master bør denne også skrivast om til å bruke verdiane derifrå istadenfor hardkoda string verdier som no.