### PR TITLE
ung-sak portnr blir endra i verdikjede.

### DIFF
--- a/ung.vite.config.js
+++ b/ung.vite.config.js
@@ -54,7 +54,7 @@ export default ({ mode }) => {
       port: 9005,
       proxy: {
         '/ung/sak': {
-          target: process.env.APP_URL_UNG_SAK || 'http://localhost:8091',
+          target: process.env.APP_URL_UNG_SAK || 'http://localhost:8991',
           changeOrigin: !!process.env.APP_URL_UNG_SAK,
           ws: false,
           secure: false,
@@ -71,7 +71,7 @@ export default ({ mode }) => {
             });
           },
         },
-        '/ung/feature-toggle/toggles.json': createMockResponder('http://localhost:8091', staticJsonResponse(featureTogglesFactory())),
+        '/ung/feature-toggle/toggles.json': createMockResponder('http://localhost:8991', staticJsonResponse(featureTogglesFactory())),
       },
     },
     base: '/ung/web',

--- a/ung.vite.config.js
+++ b/ung.vite.config.js
@@ -54,7 +54,7 @@ export default ({ mode }) => {
       port: 9005,
       proxy: {
         '/ung/sak': {
-          target: process.env.APP_URL_UNG_SAK || 'http://localhost:8085',
+          target: process.env.APP_URL_UNG_SAK || 'http://localhost:8091',
           changeOrigin: !!process.env.APP_URL_UNG_SAK,
           ws: false,
           secure: false,
@@ -71,7 +71,7 @@ export default ({ mode }) => {
             });
           },
         },
-        '/ung/feature-toggle/toggles.json': createMockResponder('http://localhost:8085', staticJsonResponse(featureTogglesFactory())),
+        '/ung/feature-toggle/toggles.json': createMockResponder('http://localhost:8091', staticJsonResponse(featureTogglesFactory())),
       },
     },
     base: '/ung/web',


### PR DESCRIPTION
Fikser portnr i ung.vite.config.js så det stemmer med nytt portnr mot verdikjede. (For lokalt utviklingsmiljø)