### PR TITLE
Default for large_client_header_buffers er 4 8k; Øker denne for å bli…

### DIFF
--- a/deploy/prod-fss-k9saksbehandling.yml
+++ b/deploy/prod-fss-k9saksbehandling.yml
@@ -12,7 +12,7 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: '600'
     nginx.ingress.kubernetes.io/proxy-send-timeout: '600'
 spec:
-  image: { { image } }
+  image: {{ image }}
   port: 9000
   liveness:
     path: /isAlive

--- a/proxy.nginx
+++ b/proxy.nginx
@@ -27,7 +27,6 @@ server {
   proxy_buffers 16 32k;
   proxy_buffer_size 32k;
   large_client_header_buffers 8 16k;
-  client_max_body_size 2m;
 
   proxy_pass_header       Nav-Callid;
   proxy_set_header        Referer $http_referer;

--- a/proxy.nginx
+++ b/proxy.nginx
@@ -26,6 +26,9 @@ server {
   # Proxy headers. Will be overwritten if you set them in blocks.
   proxy_buffers 16 32k;
   proxy_buffer_size 32k;
+  large_client_header_buffers 8 16k;
+  client_max_body_size 2m;
+
   proxy_pass_header       Nav-Callid;
   proxy_set_header        Referer $http_referer;
   proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
… kvitt 431 Request Header Fields Too Large som dukker opp iblant