### PR TITLE
/arbeidsgivere API blir ikke kalt

### DIFF
--- a/packages/sak-app/src/fagsak/FagsakIndex.tsx
+++ b/packages/sak-app/src/fagsak/FagsakIndex.tsx
@@ -151,7 +151,7 @@ const FagsakIndex = () => {
     K9sakApiKeys.ARBEIDSGIVERE,
     {},
     {
-      updateTriggers: [!behandling],
+      updateTriggers: [behandlingId],
       suspendRequest: !behandling,
     },
   );
@@ -181,7 +181,7 @@ const FagsakIndex = () => {
     K9sakApiKeys.DIREKTE_OVERGANG_FRA_INFOTRYGD,
     {},
     {
-      updateTriggers: [!behandling],
+      updateTriggers: [behandlingId],
       suspendRequest: !behandling,
     },
   );
@@ -206,7 +206,7 @@ const FagsakIndex = () => {
     K9sakApiKeys.LOS_HENTE_MERKNAD,
     {},
     {
-      updateTriggers: [!behandling],
+      updateTriggers: [behandlingId],
       suspendRequest: !behandling || !featureToggles?.LOS_MARKER_BEHANDLING,
     },
   );


### PR DESCRIPTION
Ser ut som det skjer når man går inn på en fagsak og første behandlingen man havner på ikke er førstegangsbehandling eller viderebehandling. Men alle disse apiene her bør vel kalles på nytt hvis behandlingId endres?