### PR TITLE
PeriodeMedOverlapp.fastsattUttaksgrad kan vere null.

### DIFF
--- a/packages/v2/gui/src/prosess/uttak/vurder-overlappende-sak/VurderOverlappendeSak.tsx
+++ b/packages/v2/gui/src/prosess/uttak/vurder-overlappende-sak/VurderOverlappendeSak.tsx
@@ -70,7 +70,7 @@ const VurderOverlappendeSak: FC<Props> = ({ behandling, aksjonspunkt, api, oppda
       perioder:
         data?.perioderMedOverlapp.map(periode => ({
           periode: { fom: periode.periode.fom || '', tom: periode.periode.tom || '' },
-          søkersUttaksgrad: periode.fastsattUttaksgrad,
+          søkersUttaksgrad: periode.fastsattUttaksgrad ?? 0,
           saksnummer: periode.saksnummer.map(saksNr => saksNr || ''),
         })) || [],
     };


### PR DESCRIPTION
Setter tal 0 i init skjema verdi viss det er tilfelle.