### PR TITLE
Utvidet rett argument fix

### DIFF
--- a/packages/behandling-utvidet-rett/src/panelDefinisjoner/prosessStegPaneler/UtvidetRettOmsorgenForMikrofrontendFelles.ts
+++ b/packages/behandling-utvidet-rett/src/panelDefinisjoner/prosessStegPaneler/UtvidetRettOmsorgenForMikrofrontendFelles.ts
@@ -3,13 +3,21 @@ import { formatereLukketPeriode } from '@k9-sak-web/lib/dateUtils/dateUtils.js';
 import { Vilkar } from '@k9-sak-web/types';
 import { InformasjonOmVurdertVilkar } from '../../types/utvidetRettMikrofrontend/InformasjonOmVurdertVilkar';
 
-export const generereInfoForVurdertVilkar = (
-  skalVilkarsUtfallVises: boolean,
-  vilkar: Vilkar,
-  begrunnelseFraAksjonspunkt: string,
-  begrunnelseFraVilkar: string,
-  navnPåAksjonspunkt: string,
-) => {
+type GenerereInfoForVurdertVilkarProps = {
+  skalVilkarsUtfallVises: boolean;
+  vilkår: Vilkar;
+  begrunnelseFraAksjonspunkt: string;
+  begrunnelseFraVilkår: string;
+  navnPåAksjonspunkt: string;
+};
+
+export const generereInfoForVurdertVilkar = ({
+  skalVilkarsUtfallVises,
+  vilkår,
+  begrunnelseFraAksjonspunkt,
+  begrunnelseFraVilkår,
+  navnPåAksjonspunkt,
+}: GenerereInfoForVurdertVilkarProps) => {
   const vurdertVilkar = {
     begrunnelse: '',
     navnPåAksjonspunkt,
@@ -18,12 +26,12 @@ export const generereInfoForVurdertVilkar = (
     periode: '',
   } as InformasjonOmVurdertVilkar;
 
-  if (skalVilkarsUtfallVises && vilkar.perioder[0]) {
-    const periode = vilkar.perioder[0];
-    vurdertVilkar.begrunnelse = begrunnelseFraAksjonspunkt ? begrunnelseFraAksjonspunkt : begrunnelseFraVilkar;
+  if (skalVilkarsUtfallVises && vilkår.perioder[0]) {
+    const periode = vilkår.perioder[0];
+    vurdertVilkar.begrunnelse = begrunnelseFraAksjonspunkt ? begrunnelseFraAksjonspunkt : begrunnelseFraVilkår;
     vurdertVilkar.navnPåAksjonspunkt = navnPåAksjonspunkt;
     vurdertVilkar.vilkarOppfylt = periode.vilkarStatus.kode === vilkarUtfallType.OPPFYLT;
-    vurdertVilkar.vilkar = vilkar.lovReferanse;
+    vurdertVilkar.vilkar = vilkår.lovReferanse;
     vurdertVilkar.periode = formatereLukketPeriode(`${periode.periode.fom}/${periode.periode.tom}`);
   }
   return vurdertVilkar;

--- a/packages/behandling-utvidet-rett/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/omsorgenForMikrofrontend/KartleggePropertyTilOmsorgenForMikrofrontendKomponent.ts
+++ b/packages/behandling-utvidet-rett/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/omsorgenForMikrofrontend/KartleggePropertyTilOmsorgenForMikrofrontendKomponent.ts
@@ -3,8 +3,8 @@ import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import behandlingStatus from '@fpsak-frontend/kodeverk/src/behandlingStatus';
 import vilkarType from '@fpsak-frontend/kodeverk/src/vilkarType';
 import vilkarUtfallType from '@fpsak-frontend/kodeverk/src/vilkarUtfallType';
-import { Behandling } from '@k9-sak-web/types';
 import { KomponenterEnum } from '@k9-sak-web/prosess-omsorgsdager';
+import { Behandling } from '@k9-sak-web/types';
 import {
   AksjonspunktInformasjon,
   VilkarInformasjon,
@@ -72,13 +72,13 @@ const KartleggePropertyTilOmsorgenForMikrofrontendKomponent = ({
         barn: angitteBarn.map(barn => barn.personIdent),
         harBarnSoktForRammevedtakOmKroniskSyk,
         vedtakFattetVilkarOppfylt: skalVilkarsUtfallVises,
-        informasjonOmVilkar: generereInfoForVurdertVilkar(
+        informasjonOmVilkar: generereInfoForVurdertVilkar({
           skalVilkarsUtfallVises,
-          omsorgenForVilkar,
-          aksjonspunkt.begrunnelse,
-          omsorgenForVilkar?.perioder[0].begrunnelse,
-          'Omsorgen for',
-        ),
+          vilkår: omsorgenForVilkar,
+          begrunnelseFraAksjonspunkt: aksjonspunkt.begrunnelse,
+          begrunnelseFraVilkår: omsorgenForVilkar?.perioder[0].begrunnelse,
+          navnPåAksjonspunkt: 'Omsorgen for',
+        }),
         losAksjonspunkt: (harOmsorgen, begrunnelse) => {
           submitCallback([
             {
@@ -103,13 +103,13 @@ const KartleggePropertyTilOmsorgenForMikrofrontendKomponent = ({
         barn: angitteBarn.map(barn => barn.personIdent),
         harBarnSoktForRammevedtakOmKroniskSyk,
         vedtakFattetVilkarOppfylt: true,
-        informasjonOmVilkar: generereInfoForVurdertVilkar(
-          true,
-          omsorgenForVilkar,
-          '',
-          omsorgenForVilkar.perioder[0].begrunnelse,
-          'Omsorgen for',
-        ),
+        informasjonOmVilkar: generereInfoForVurdertVilkar({
+          skalVilkarsUtfallVises: true,
+          vilkår: omsorgenForVilkar,
+          begrunnelseFraAksjonspunkt: '',
+          begrunnelseFraVilkår: omsorgenForVilkar?.perioder[0].begrunnelse,
+          navnPåAksjonspunkt: 'Omsorgen for',
+        }),
         formState: FormState,
       },
     };

--- a/packages/behandling-utvidet-rett/src/panelDefinisjoner/prosessStegPaneler/utvidetRettPanel/utvidetRettMikrofrontend/formateringAvDataTilMikrofrontend/AleneOmOmsorgenObjektTilMikrofrontend.ts
+++ b/packages/behandling-utvidet-rett/src/panelDefinisjoner/prosessStegPaneler/utvidetRettPanel/utvidetRettMikrofrontend/formateringAvDataTilMikrofrontend/AleneOmOmsorgenObjektTilMikrofrontend.ts
@@ -1,17 +1,17 @@
-import { Aksjonspunkt, Behandling, Vilkar } from '@k9-sak-web/types';
 import { FormState } from '@fpsak-frontend/form/index';
+import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
+import BehandlingType from '@fpsak-frontend/kodeverk/src/behandlingType';
 import vilkarUtfallType from '@fpsak-frontend/kodeverk/src/vilkarUtfallType';
 import { KomponenterEnum } from '@k9-sak-web/prosess-omsorgsdager';
-import BehandlingType from '@fpsak-frontend/kodeverk/src/behandlingType';
-import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
-import { generereInfoForVurdertVilkar } from '../../../UtvidetRettOmsorgenForMikrofrontendFelles';
+import { Aksjonspunkt, Behandling, Vilkar } from '@k9-sak-web/types';
 import UtvidetRettSoknad from '../../../../../types/UtvidetRettSoknad';
+import AvslagskoderAleneOmOmsorgen from '../../../../../types/utvidetRettMikrofrontend/AvslagskoderAleneOmOmsorgen';
 import {
   AleneOmOmsorgenAksjonspunktObjekt,
   AleneOmOmsorgenLosAksjonspunktK9Format,
   AleneOmOmsorgenProps,
 } from '../../../../../types/utvidetRettMikrofrontend/VilkarAleneOmOmsorgenProps';
-import AvslagskoderAleneOmOmsorgen from '../../../../../types/utvidetRettMikrofrontend/AvslagskoderAleneOmOmsorgen';
+import { generereInfoForVurdertVilkar } from '../../../UtvidetRettOmsorgenForMikrofrontendFelles';
 
 interface OwnProps {
   behandling: Behandling;
@@ -103,13 +103,13 @@ const AleneOmOmsorgenObjektTilMikrofrontend = ({
         fraDatoFraVilkar: vilkar?.perioder[0]?.periode?.fom,
         vedtakFattetVilkarOppfylt: skalVilkarsUtfallVises,
         erBehandlingstypeRevurdering: erBehandlingRevurdering,
-        informasjonOmVilkar: generereInfoForVurdertVilkar(
+        informasjonOmVilkar: generereInfoForVurdertVilkar({
           skalVilkarsUtfallVises,
-          vilkar,
-          aksjonspunkt.begrunnelse,
-          vilkar?.perioder[0].begrunnelse,
-          'Utvidet Rett',
-        ),
+          vilkår: vilkar,
+          begrunnelseFraAksjonspunkt: aksjonspunkt.begrunnelse,
+          begrunnelseFraVilkår: vilkar?.perioder[0].begrunnelse,
+          navnPåAksjonspunkt: 'Utvidet Rett',
+        }),
         informasjonTilLesemodus: formatereLesemodusObjekt(vilkar, aksjonspunkt, status),
         losAksjonspunkt: ({ begrunnelse, vilkarOppfylt, avslagsårsakKode, fraDato, tilDato }) => {
           submitCallback([
@@ -137,13 +137,13 @@ const AleneOmOmsorgenObjektTilMikrofrontend = ({
         fraDatoFraVilkar: vilkar?.perioder[0]?.periode?.fom,
         vedtakFattetVilkarOppfylt: true,
         erBehandlingstypeRevurdering: erBehandlingRevurdering,
-        informasjonOmVilkar: generereInfoForVurdertVilkar(
-          true,
-          vilkar,
-          '',
-          vilkar?.perioder[0].begrunnelse,
-          'Utvidet Rett',
-        ),
+        informasjonOmVilkar: generereInfoForVurdertVilkar({
+          skalVilkarsUtfallVises: true,
+          vilkår: vilkar,
+          begrunnelseFraAksjonspunkt: '',
+          begrunnelseFraVilkår: vilkar?.perioder[0].begrunnelse,
+          navnPåAksjonspunkt: 'Utvidet Rett',
+        }),
         formState: FormState,
       } as AleneOmOmsorgenProps,
     };

--- a/packages/behandling-utvidet-rett/src/panelDefinisjoner/prosessStegPaneler/utvidetRettPanel/utvidetRettMikrofrontend/formateringAvDataTilMikrofrontend/KroniskSykObjektTilMikrofrontend.ts
+++ b/packages/behandling-utvidet-rett/src/panelDefinisjoner/prosessStegPaneler/utvidetRettPanel/utvidetRettMikrofrontend/formateringAvDataTilMikrofrontend/KroniskSykObjektTilMikrofrontend.ts
@@ -1,15 +1,15 @@
-import { Aksjonspunkt, Vilkar } from '@k9-sak-web/types';
 import { FormState } from '@fpsak-frontend/form/index';
+import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import vilkarUtfallType from '@fpsak-frontend/kodeverk/src/vilkarUtfallType';
 import { KomponenterEnum } from '@k9-sak-web/prosess-omsorgsdager';
-import { generereInfoForVurdertVilkar } from '../../../UtvidetRettOmsorgenForMikrofrontendFelles';
+import Komponenter from '@k9-sak-web/prosess-omsorgsdager/src/types/Komponenter';
+import { Aksjonspunkt, Vilkar } from '@k9-sak-web/types';
 import {
   InformasjonTilLesemodusKroniskSyk,
   VilkarKroniskSyktBarnProps,
 } from '../../../../../types/utvidetRettMikrofrontend/VilkarKroniskSyktBarnProps';
 import UtvidetRettSoknad from '../../../../../types/UtvidetRettSoknad';
-import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
-import Komponenter from '@k9-sak-web/prosess-omsorgsdager/src/types/Komponenter';
+import { generereInfoForVurdertVilkar } from '../../../UtvidetRettOmsorgenForMikrofrontendFelles';
 
 interface OwnProps {
   behandlingsID: string;
@@ -98,13 +98,13 @@ const KroniskSykObjektTilMikrofrontend = ({
         soknadsdato: soknad.soknadsdato,
         informasjonTilLesemodus: formatereLesemodusObjektForKroniskSyk(vilkar, aksjonspunkt),
         vedtakFattetVilkarOppfylt: skalVilkarsUtfallVises,
-        informasjonOmVilkar: generereInfoForVurdertVilkar(
+        informasjonOmVilkar: generereInfoForVurdertVilkar({
           skalVilkarsUtfallVises,
-          vilkar,
-          aksjonspunkt.begrunnelse,
-          vilkar?.perioder[0].begrunnelse,
-          'Utvidet Rett',
-        ),
+          vilkår: vilkar,
+          begrunnelseFraAksjonspunkt: aksjonspunkt.begrunnelse,
+          begrunnelseFraVilkår: vilkar?.perioder[0].begrunnelse,
+          navnPåAksjonspunkt: 'Utvidet Rett',
+        }),
         losAksjonspunkt: (harDokumentasjonOgFravaerRisiko, begrunnelse, avslagsårsakKode, fraDato) => {
           submitCallback([
             formatereLosAksjonspunktObjektForKroniskSyk(
@@ -131,13 +131,13 @@ const KroniskSykObjektTilMikrofrontend = ({
         aksjonspunktLost: false,
         soknadsdato: soknad.soknadsdato,
         vedtakFattetVilkarOppfylt: true,
-        informasjonOmVilkar: generereInfoForVurdertVilkar(
-          true,
-          vilkar,
-          '',
-          vilkar?.perioder[0].begrunnelse,
-          'Utvidet Rett',
-        ),
+        informasjonOmVilkar: generereInfoForVurdertVilkar({
+          skalVilkarsUtfallVises: true,
+          vilkår: vilkar,
+          begrunnelseFraAksjonspunkt: '',
+          begrunnelseFraVilkår: vilkar?.perioder[0].begrunnelse,
+          navnPåAksjonspunkt: 'Utvidet Rett',
+        }),
         formState: FormState,
       } as VilkarKroniskSyktBarnProps,
     };

--- a/packages/behandling-utvidet-rett/src/panelDefinisjoner/prosessStegPaneler/utvidetRettPanel/utvidetRettMikrofrontend/formateringAvDataTilMikrofrontend/MidlertidigAleneObjektTilMikrofrontend.ts
+++ b/packages/behandling-utvidet-rett/src/panelDefinisjoner/prosessStegPaneler/utvidetRettPanel/utvidetRettMikrofrontend/formateringAvDataTilMikrofrontend/MidlertidigAleneObjektTilMikrofrontend.ts
@@ -1,10 +1,10 @@
-import { Aksjonspunkt, Vilkar } from '@k9-sak-web/types';
 import { FormState } from '@fpsak-frontend/form/index';
 import vilkarUtfallType from '@fpsak-frontend/kodeverk/src/vilkarUtfallType';
 import { KomponenterEnum } from '@k9-sak-web/prosess-omsorgsdager';
-import { generereInfoForVurdertVilkar } from '../../../UtvidetRettOmsorgenForMikrofrontendFelles';
+import { Aksjonspunkt, Vilkar } from '@k9-sak-web/types';
 import { VilkarMidlertidigAleneProps } from '../../../../../types/utvidetRettMikrofrontend/VilkarMidlertidigAleneProps';
 import UtvidetRettSoknad from '../../../../../types/UtvidetRettSoknad';
+import { generereInfoForVurdertVilkar } from '../../../UtvidetRettOmsorgenForMikrofrontendFelles';
 
 interface OwnProps {
   behandlingsID: string;
@@ -89,13 +89,13 @@ const MidlertidigAleneObjektTilMikrofrontend = ({
         soknadsdato: soknad.soknadsdato,
       },
       vedtakFattetVilkarOppfylt: skalVilkarsUtfallVises,
-      informasjonOmVilkar: generereInfoForVurdertVilkar(
+      informasjonOmVilkar: generereInfoForVurdertVilkar({
         skalVilkarsUtfallVises,
-        vilkar,
-        aksjonspunkt.begrunnelse,
-        vilkar?.perioder[0].begrunnelse,
-        'Utvidet Rett',
-      ),
+        vilkår: vilkar,
+        begrunnelseFraAksjonspunkt: aksjonspunkt.begrunnelse,
+        begrunnelseFraVilkår: vilkar?.perioder[0].begrunnelse,
+        navnPåAksjonspunkt: 'Utvidet Rett',
+      }),
       informasjonTilLesemodus: formatereLesemodusObjektForMidlertidigAlene(vilkar, aksjonspunkt, status),
       losAksjonspunkt: ({ begrunnelse, erSokerenMidlertidigAleneOmOmsorgen, fra, til, avslagsårsakKode }) => {
         submitCallback([


### PR DESCRIPTION
Bakgrunn: Gammel variant var en funksjon som tok inn mange argumenter, men kan bli vanskelig å lese og fort gjort å sende inn i feil rekkefølge.

Løsning: Sende inn objekt i stedet der man må spesifisere hvert argument med navn.