### PR TITLE
k9-sak-typescript-client: Fiks destrukturering av objekt som query string parameter.

### DIFF
--- a/packages/v2/backend/src/k9sak/errorhandling/requestWithExtendedErrorHandler.ts
+++ b/packages/v2/backend/src/k9sak/errorhandling/requestWithExtendedErrorHandler.ts
@@ -9,10 +9,43 @@ import {
   getResponseHeader,
   getResponseBody,
   catchErrorCodes,
-  getQueryString,
 } from '@navikt/k9-sak-typescript-client/core/request.js';
 import { navCallidHeaderName } from '../../shared/instrumentation/navCallid.js';
 import { K9SakApiError } from './K9SakApiError.js';
+
+// Kopiert inn frå @navikt/k9-sak-typescript-client/core/request.ts, for å fikse problem med objekt som query param verdier.
+// Denne er ein endra versjon som "destrukturerer" objektverdier slik at dei blir ein flat propname=verdi query string.
+// Det ser ut til at dette matcher det swagger server gjere i slike tilfeller, istadenfor original oppførsel til generert kodelib.
+// Behovet for denne skal forsvinne etter neste hovedoppdatering av generert klient.
+const getQueryString = (params: Record<string, unknown>): string => {
+  const qs: string[] = [];
+
+  const append = (key: string, value: unknown) => {
+    qs.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+  };
+
+  const encodePair = (key: string, value: unknown) => {
+    if (value === undefined || value === null) {
+      return;
+    }
+
+    if (value instanceof Date) {
+      append(key, value.toISOString());
+    } else if (Array.isArray(value)) {
+      value.forEach(v => encodePair(key, v));
+    } else if (typeof value === 'object') {
+      for (const [k, v] of Object.entries(value)) {
+        encodePair(k, v); // Rekursivt encode alle props = verdi for objekt
+      }
+    } else {
+      append(key, value);
+    }
+  };
+
+  Object.entries(params).forEach(([key, value]) => encodePair(key, value));
+
+  return qs.length ? `?${qs.join('&')}` : '';
+};
 
 // Kopiert inn frå @navikt/k9-sak-typescript-client/core/request.js, sidan den ikkje blir eksportert der
 const getUrl = (config: OpenAPIConfig, options: ApiRequestOptions): string => {


### PR DESCRIPTION
**Bakgrunn**
Nokre openapi endepunkt definerer query params som er objekt typer. For disse skal query parameter verdier konstruerast ved å destrukturere gitte objekt properties.

**Løysing**
Legger inn midlertidig spesialtilpasning for å få dette til, inntil generert klient er fiksa.