### PR TITLE
base url for generert k9-sak klient endrast for v2 av api-spesifikasjon.

### DIFF
--- a/packages/v2/backend/package.json
+++ b/packages/v2/backend/package.json
@@ -8,6 +8,7 @@
     "./shared/*": "./src/shared/*",
     "./combined/*": "./src/combined/*",
     "./k9sak/generated": "./src/k9sak/generated/index.js",
+    "./k9sak/generated/metadata": "./src/k9sak/generated/metadata.js",
     "./k9sak/kodeverk/*": "./src/k9sak/kodeverk/*",
     "./k9sak/errorhandling/*": "./src/k9sak/errorhandling/*",
     "./k9formidling/*": "./src/k9formidling/*",

--- a/packages/v2/backend/src/k9sak/generated/metadata.ts
+++ b/packages/v2/backend/src/k9sak/generated/metadata.ts
@@ -1,0 +1,7 @@
+import { OpenAPI } from '@navikt/k9-sak-typescript-client/core/OpenAPI.js';
+
+const version = OpenAPI.VERSION;
+
+const [major, minor] = version.split('.');
+
+export const clientVersion = { major, minor };

--- a/packages/v2/gui/src/app/K9SakClientContext.tsx
+++ b/packages/v2/gui/src/app/K9SakClientContext.tsx
@@ -4,6 +4,7 @@ import { generateNavCallidHeader } from '@k9-sak-web/backend/shared/instrumentat
 import type { ApiRequestOptions } from '@k9-sak-web/backend/k9sak/generated';
 import { K9SakHttpRequest } from '@k9-sak-web/backend/k9sak/errorhandling/K9SakHttpRequest.js';
 import { jsonSerializerOption } from '@k9-sak-web/backend/shared/jsonSerializerOption.js';
+import { clientVersion } from '@k9-sak-web/backend/k9sak/generated/metadata';
 
 const headerResolver = async (options: ApiRequestOptions<Record<string, string>>): Promise<Record<string, string>> => {
   const { headerName, headerValue } = generateNavCallidHeader();
@@ -15,13 +16,19 @@ const headerResolver = async (options: ApiRequestOptions<Record<string, string>>
   };
 };
 
+// generert klientversjon over 1.0 har /api prefix satt på paths generert inn i klientkalla, som er det korrekte.
+// for versjoner under må vi legge /api til på baseUrl for at kalla skal fungere, sidan openapi spesifikasjon generert
+// til fil mangla /api på paths då.
+// Kan fjernast når vi veit vi er komt over på version >= 2.0 av klient.
+const baseUrl = Number(clientVersion.major) > 1 ? '/k9/sak' : '/k9/sak/api';
+
 /**
  * This shall be a top level context providing the K9SakClient instance that will be used for communicating with the backend server.
  */
 export const K9SakClientContext = createContext(
   new K9SakClient(
     {
-      BASE: '/k9/sak/api',
+      BASE: baseUrl,
       HEADERS: headerResolver,
     },
     K9SakHttpRequest,


### PR DESCRIPTION
Pga feil i v1 av typescript klient generator har url paths der mangla /api prefiks. Derfor har dette vore lagt til baseUrl ved initialisering av denne i k9-sak.

Feilen i generatoren blir fiksa, og då må initialisering av klient i k9-sak slutte å legge til /api for å unngå feil.

Inkrementerer derfor major versjon av generert api til 2 ved denne endring, og legger inn sjekk på dette ved initialisering av klient i k9-sak.

Den skal då fungere både med v1 og v2 av generert spesifiksjon i ein overgangsperiode.