### PR TITLE
Sender ned backend client som prop

### DIFF
--- a/packages/sak-app/src/fagsakprofile/FagsakProfileIndex.tsx
+++ b/packages/sak-app/src/fagsakprofile/FagsakProfileIndex.tsx
@@ -1,5 +1,7 @@
 import FagsakProfilSakIndex from '@fpsak-frontend/sak-fagsak-profil';
 import { LoadingPanel, requireProps } from '@fpsak-frontend/shared-components';
+import { K9SakClientContext } from '@k9-sak-web/gui/app/K9SakClientContext.js';
+import BehandlingVelgerBackendClient from '@k9-sak-web/gui/sak/behandling-velger/BehandlingVelgerK9BackendClient.js';
 import BehandlingVelgerSakV2 from '@k9-sak-web/gui/sak/behandling-velger/BehandlingVelgerSakIndex.js';
 import FeatureTogglesContext from '@k9-sak-web/gui/utils/featureToggles/FeatureTogglesContext.js';
 import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
@@ -65,6 +67,8 @@ export const FagsakProfileIndex = ({
 }: OwnProps) => {
   const getKodeverkFn = useGetKodeverkFn();
   const featureToggles = useContext(FeatureTogglesContext);
+  const k9SakClient = useContext(K9SakClientContext);
+  const behandlingVelgerBackendClient = new BehandlingVelgerBackendClient(k9SakClient);
 
   const fagsakStatusMedNavn = useFpSakKodeverkMedNavn<KodeverkMedNavn>(fagsak.status);
 
@@ -133,6 +137,7 @@ export const FagsakProfileIndex = ({
                   behandlingId={behandlingId}
                   fagsak={fagsakV2}
                   createLocationForSkjermlenke={createLocationForSkjermlenke}
+                  api={behandlingVelgerBackendClient}
                 />
               );
             }

--- a/packages/v2/gui/src/sak/behandling-velger/BehandlingVelgerK9BackendClient.ts
+++ b/packages/v2/gui/src/sak/behandling-velger/BehandlingVelgerK9BackendClient.ts
@@ -2,7 +2,7 @@ import type { K9SakClient } from '@k9-sak-web/backend/k9sak/generated';
 import type { Behandling } from './types/Behandling';
 import type { PerioderMedBehandlingsId } from './types/PerioderMedBehandlingsId';
 
-export default class BehandlingVelgerBackendClient {
+export default class BehandlingVelgerK9BackendClient {
   #k9sak: K9SakClient;
   constructor(k9sakClient: K9SakClient) {
     this.#k9sak = k9sakClient;

--- a/packages/v2/gui/src/sak/behandling-velger/BehandlingVelgerSakIndex.stories.tsx
+++ b/packages/v2/gui/src/sak/behandling-velger/BehandlingVelgerSakIndex.stories.tsx
@@ -11,6 +11,7 @@ import type { Meta, StoryObj } from '@storybook/react';
 import { expect, userEvent } from '@storybook/test';
 import withKodeverkContext from '../../storybook/decorators/withKodeverkContext.js';
 import withMaxWidth from '../../storybook/decorators/withMaxWidth.js';
+import { FakeBehandlingVelgerBackendApi } from '../../storybook/mocks/FakeBehandlingVelgerBackendApi.js';
 import BehandlingVelgerSakV2 from './BehandlingVelgerSakIndex';
 
 const behandlinger = [
@@ -68,6 +69,8 @@ const meta = {
 
 export default meta;
 
+const api = new FakeBehandlingVelgerBackendApi();
+
 export const Default: StoryObj<typeof meta> = {
   args: {
     getBehandlingLocation: () => locationMock,
@@ -76,6 +79,7 @@ export const Default: StoryObj<typeof meta> = {
     behandlinger,
     noExistingBehandlinger: false,
     behandlingId: 1,
+    api,
   },
   play: async ({ canvas, step }) => {
     await step('skal rendre komponent', async () => {
@@ -93,6 +97,7 @@ export const IngenBehandlinger: StoryObj<typeof meta> = {
     createLocationForSkjermlenke: () => locationMock,
     behandlinger: [],
     noExistingBehandlinger: true,
+    api,
   },
   play: async ({ canvas, step }) => {
     await step('skal vise forklarende tekst når det ikke finnes behandlinger', async () => {

--- a/packages/v2/gui/src/sak/behandling-velger/BehandlingVelgerSakIndex.tsx
+++ b/packages/v2/gui/src/sak/behandling-velger/BehandlingVelgerSakIndex.tsx
@@ -1,8 +1,6 @@
 import { FagsakDtoSakstype, type FagsakDto } from '@k9-sak-web/backend/k9sak/generated';
 import { type Location } from 'history';
-import { useContext } from 'react';
-import { K9SakClientContext } from '../../app/K9SakClientContext';
-import BehandlingVelgerBackendClient from './BehandlingVelgerBackendClient';
+import type { BehandlingVelgerBackendApiType } from './BehandlingVelgerBackendApiType';
 import BehandlingPicker from './components/BehandlingPicker';
 import type { Behandling } from './types/Behandling';
 
@@ -13,6 +11,7 @@ interface OwnProps {
   behandlingId?: number;
   fagsak: Pick<FagsakDto, 'sakstype'>;
   createLocationForSkjermlenke: (behandlingLocation: Location, skjermlenkeCode: string) => Location;
+  api: BehandlingVelgerBackendApiType;
 }
 
 const BehandlingVelgerSakV2 = ({
@@ -22,10 +21,8 @@ const BehandlingVelgerSakV2 = ({
   behandlingId,
   fagsak,
   createLocationForSkjermlenke,
+  api,
 }: OwnProps) => {
-  const k9SakClient = useContext(K9SakClientContext);
-  const behandlingVelgerBackendClient = new BehandlingVelgerBackendClient(k9SakClient);
-
   const hentSøknadsperioder = ![
     FagsakDtoSakstype.FRISINN,
     FagsakDtoSakstype.OMSORGSPENGER_AO,
@@ -42,7 +39,7 @@ const BehandlingVelgerSakV2 = ({
       createLocationForSkjermlenke={createLocationForSkjermlenke}
       sakstypeKode={fagsak.sakstype}
       hentSøknadsperioder={hentSøknadsperioder}
-      api={behandlingVelgerBackendClient}
+      api={api}
     />
   );
 };

--- a/packages/v2/gui/src/storybook/mocks/FakeBehandlingVelgerBackendApi.ts
+++ b/packages/v2/gui/src/storybook/mocks/FakeBehandlingVelgerBackendApi.ts
@@ -1,0 +1,7 @@
+import { type PerioderMedBehandlingsId } from '../../sak/behandling-velger/types/PerioderMedBehandlingsId';
+
+export class FakeBehandlingVelgerBackendApi {
+  async getBehandlingPerioderÅrsaker(): Promise<PerioderMedBehandlingsId> {
+    return { perioderMedÅrsak: [], perioder: [], id: 1 };
+  }
+}


### PR DESCRIPTION
Da kan man gjøre tilsvarende for ung og pakken blir ikke k9-spesifikk