### PR TITLE
Omskriving til k9-klage v2 generert typescript klient.

### DIFF
--- a/packages/prosess-vedtak/src/components/VedtakHelper.spec.tsx
+++ b/packages/prosess-vedtak/src/components/VedtakHelper.spec.tsx
@@ -1,5 +1,5 @@
 import { fagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
-import { behandlingResultatType as klageBehandlingsresultat } from '@navikt/k9-klage-typescript-client';
+import { behandlingType as klageBehandlingsresultat } from '@k9-sak-web/backend/k9klage/kodeverk/behandling/BehandlingType.js';
 import {
   AvslagsårsakPrPeriodeDto,
   AvslagsårsakPrPeriodeDtoAvslagsårsak,

--- a/packages/prosess-vedtak/src/components/VedtakHelper.tsx
+++ b/packages/prosess-vedtak/src/components/VedtakHelper.tsx
@@ -3,7 +3,7 @@ import { erFagytelseTypeUtvidetRett } from '@k9-sak-web/behandling-utvidet-rett/
 import { TIDENES_ENDE } from '@k9-sak-web/lib/dateUtils/dateUtils.js';
 import { KodeverkNavnFraKodeType } from '@k9-sak-web/lib/kodeverk/types.js';
 import { KodeverkType } from '@k9-sak-web/lib/kodeverk/types/KodeverkType.js';
-import { behandlingResultatType as klageBehandlingsresultat } from '@navikt/k9-klage-typescript-client';
+import { BehandlingsresultatDtoType as klageBehandlingsresultat } from '@k9-sak-web/backend/k9klage/generated';
 import {
   AvslagsårsakPrPeriodeDto,
   BeregningsgrunnlagPeriodeDto,

--- a/packages/sak-app/src/fagsakprofile/FagsakProfileIndex.tsx
+++ b/packages/sak-app/src/fagsakprofile/FagsakProfileIndex.tsx
@@ -13,7 +13,7 @@ import {
   KodeverkMedNavn,
   Personopplysninger,
 } from '@k9-sak-web/types';
-import { behandlingType } from '@navikt/k9-klage-typescript-client';
+import { BehandlingDtoType } from '@navikt/k9-klage-typescript-client';
 import { Location } from 'history';
 import { useCallback, useContext } from 'react';
 import { Navigate, useLocation, useMatch } from 'react-router';
@@ -125,7 +125,7 @@ export const FagsakProfileIndex = ({
               const behandlingerV2 = JSON.parse(JSON.stringify(alleBehandlinger));
               const fagsakV2 = JSON.parse(JSON.stringify(fagsak));
               const erTilbakekreving = alleBehandlinger.some(
-                behandling => behandling.type.kode === behandlingType.BT_007,
+                behandling => behandling.type.kode === BehandlingDtoType.TILBAKEKREVING,
               );
               konverterKodeverkTilKode(behandlingerV2, erTilbakekreving);
               konverterKodeverkTilKode(fagsakV2, erTilbakekreving);

--- a/packages/v2/backend/package.json
+++ b/packages/v2/backend/package.json
@@ -16,7 +16,7 @@
     "./k9klage/kodeverk/*": "./src/k9klage/kodeverk/*"
   },
   "dependencies": {
-    "@navikt/k9-klage-typescript-client": "1.0.20241206133624",
+    "@navikt/k9-klage-typescript-client": "2.0.20250218125133",
     "@navikt/k9-sak-typescript-client": "1.0.20250205155930"
   },
   "devDependencies": {

--- a/packages/v2/backend/src/k9klage/kodeverk/behandling/BehandlingType.ts
+++ b/packages/v2/backend/src/k9klage/kodeverk/behandling/BehandlingType.ts
@@ -1,24 +1,8 @@
-import type { BehandlingDto } from '../../generated';
+import { type BehandlingDtoType as uniontype, BehandlingDtoType } from '../../generated';
 import type { Kodeverk } from '../../../shared/Kodeverk.js';
 
-export type BehandlingType = BehandlingDto['type'];
+export type BehandlingType = uniontype;
 
 export type BehandlingTypeKodeverk = Kodeverk<BehandlingType, 'BEHANDLING_TYPE'>;
 
-// Sidan verdiane er litt abstrakte bruker vi namn frå java enum i k9-klage kodebasen som nøkler for denne
-type BehandlingTypeName =
-  | 'FØRSTEGANGSSØKNAD'
-  | 'KLAGE'
-  | 'REVURDERING'
-  | 'TILBAKEKREVING'
-  | 'REVURDERING_TILBAKEKREVING'
-  | 'UDEFINERT';
-
-export const behandlingType: Readonly<Record<BehandlingTypeName, BehandlingType>> = {
-  FØRSTEGANGSSØKNAD: 'BT-002',
-  KLAGE: 'BT-003',
-  REVURDERING: 'BT-004',
-  TILBAKEKREVING: 'BT-007',
-  REVURDERING_TILBAKEKREVING: 'BT-009',
-  UDEFINERT: '-',
-};
+export const behandlingType = BehandlingDtoType;

--- a/packages/v2/gui/src/sak/behandling-velger/components/BehandlingPicker.tsx
+++ b/packages/v2/gui/src/sak/behandling-velger/components/BehandlingPicker.tsx
@@ -1,4 +1,4 @@
-import { behandlingType as k9KlageBehandlingType } from '@k9-sak-web/backend/k9klage/generated';
+import { behandlingType as k9KlageBehandlingType } from '@k9-sak-web/backend/k9klage/kodeverk/behandling/BehandlingType.js';
 import { BehandlingDtoStatus, BehandlingDtoType } from '@k9-sak-web/backend/k9sak/generated';
 import { useKodeverkContext } from '@k9-sak-web/gui/kodeverk/index.js';
 import { type KodeverkNavnFraKodeType, KodeverkType } from '@k9-sak-web/lib/kodeverk/types.js';
@@ -23,10 +23,10 @@ const getBehandlingNavn = (behandlingTypeKode: string, kodeverkNavnFraKode: Kode
     case BehandlingDtoType.FØRSTEGANGSSØKNAD:
       return kodeverkNavnFraKode(behandlingTypeKode, KodeverkType.BEHANDLING_TYPE);
 
-    case k9KlageBehandlingType.BT_003:
+    case k9KlageBehandlingType.KLAGE:
       return kodeverkNavnFraKode(behandlingTypeKode, KodeverkType.BEHANDLING_TYPE, 'kodeverkKlage');
 
-    case k9KlageBehandlingType.BT_007:
+    case k9KlageBehandlingType.TILBAKEKREVING:
       return kodeverkNavnFraKode(behandlingTypeKode, KodeverkType.BEHANDLING_TYPE, 'kodeverkTilbake');
 
     default:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3982,7 +3982,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@k9-sak-web/backend@workspace:packages/v2/backend"
   dependencies:
-    "@navikt/k9-klage-typescript-client": "npm:1.0.20241206133624"
+    "@navikt/k9-klage-typescript-client": "npm:2.0.20250218125133"
     "@navikt/k9-sak-typescript-client": "npm:1.0.20250205155930"
     "@tanstack/eslint-plugin-query": "npm:^5.66.0"
   languageName: unknown
@@ -5363,10 +5363,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/k9-klage-typescript-client@npm:1.0.20241206133624":
-  version: 1.0.20241206133624
-  resolution: "@navikt/k9-klage-typescript-client@npm:1.0.20241206133624::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-klage-typescript-client%2F1.0.20241206133624%2F5b10fcf775c127f0f9757788c647fd8b3cfbdafb"
-  checksum: 10/b23b62664c9d2f7e17890d0528bd5b43c8bbc78a4e7ed01fbe929ec89880a29c370bb5f6d2b6bc3b6f3e253987c3f1ba87f98db95ce6e2f5884845565b715802
+"@navikt/k9-klage-typescript-client@npm:2.0.20250218125133":
+  version: 2.0.20250218125133
+  resolution: "@navikt/k9-klage-typescript-client@npm:2.0.20250218125133::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-klage-typescript-client%2F2.0.20250218125133%2Fcb25392e65d5a682d7e7850224638c5baaf12798"
+  checksum: 10/d6af3c013671c17aa2713632d2be84809ca99020a7ac84afb9eb909c6529e6dd91ede1515b228368670895e64a95bdd9d56da853d8493e4cc2440436b6f17967
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
(Forbetra enum generering).

Ingen faktisk endring i funksjonalitet, kun type/property namn.