### PR TITLE
Return null hvis resultatet er undefined

### DIFF
--- a/packages/v2/gui/src/prosess/uttak/BehandlingUttakBackendClient.ts
+++ b/packages/v2/gui/src/prosess/uttak/BehandlingUttakBackendClient.ts
@@ -13,7 +13,7 @@ export default class BehandlingUttakBackendClient {
   }
 
   async getEgneOverlappendeSaker(behandlingUuid: string): Promise<EgneOverlappendeSakerDto> {
-    return this.#k9sak.behandlingUttak.hentEgneOverlappendeSaker(behandlingUuid);
+    return (await this.#k9sak.behandlingUttak.hentEgneOverlappendeSaker(behandlingUuid)) ?? null;
   }
 
   async bekreftAksjonspunkt(requestBody: BekreftData['requestBody']): Promise<BekreftResponse> {


### PR DESCRIPTION
Om hentEgneOverlappendeSaker returnerer med http code 204 No Content, blir resultatet undefined og tanstack tolker det som en feil. Prøver med å returnere null etter råd fra tanstack query issues.