### PR TITLE
Legg til X-Json-Serializer-Option: kodeverdi-objekt på alle legacy api requests.

### DIFF
--- a/packages/rest-api/src/axios/getAxiosHttpClientApi.ts
+++ b/packages/rest-api/src/axios/getAxiosHttpClientApi.ts
@@ -4,6 +4,8 @@ import axiosEtag from './axiosEtag';
 import initRestMethods from './initRestMethods';
 import { generateNavCallidHeader } from '@k9-sak-web/backend/shared/instrumentation/navCallid.js';
 import { konverterKodeverkTilKodeSelektivt } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKodeSelektivt.js';
+import { jsonSerializerOption } from '@k9-sak-web/backend/shared/jsonSerializerOption.js';
+import { xJsonSerializerOptions } from '../xJsonSerializerOptions';
 
 /**
  * getAxiosHttpClientApi
@@ -16,6 +18,10 @@ const getAxiosHttpClientApi = () => {
     const { headerName, headerValue } = generateNavCallidHeader();
     const config = { ...c };
     config.headers[headerName] = headerValue;
+    // Legg til X-Json-Serializer-Option header for å instruere server om å bruke legacy "kodeverk-objekt" ObjectMapper
+    // for alle requests som går gjennom denne klient. Kan vurdere å gjere denne meir konfigurerbar pr backend/request
+    // seinare viss det er behov.
+    config.headers[jsonSerializerOption.xJsonSerializerOptionHeader] = xJsonSerializerOptions.kodeverdiObjekt;
     return config;
   });
 

--- a/packages/rest-api/src/xJsonSerializerOptions.ts
+++ b/packages/rest-api/src/xJsonSerializerOptions.ts
@@ -1,0 +1,9 @@
+// Verdier som kan brukast for request header X-Json-Serializer-Option for å styre korleis serialisering/deserialisering skal fungere.
+// Disse kan brukast opp mot ulike backends, men alle backends støtter kanskje ikkje alle verdier, og vil i så fall falle tilbake til standard serialisering/deserialisering.
+export const xJsonSerializerOptions = {
+  default: '', // Matcher ingen spesifikk serialisering/deserialisering på server, så vil bruke standard.
+  // Deaktivert sidan denne berre blir brukt i legacy kode der denne verdi ikkje vil vere korrekt å bruke:
+  // openapiCompat: "openapi-compat", // Bruk denne for å serialisere/deserialisere i henhold til generert typescript fra openapi spesifikasjon.
+  kodeverdiObjekt: 'kodeverdi-objekt', // Bruk denne for å serialisere/deserialisere Kodeverdi implementasjoner som objekt.
+  kodeverdiString: 'kodeverdi-string', // Bruk denne for å serialisere/deserialisere Kodeverdi implementasjoner som objekt.
+} as const;

--- a/packages/sak-behandling-velger/src/components/BehandlingPicker.tsx
+++ b/packages/sak-behandling-velger/src/components/BehandlingPicker.tsx
@@ -17,6 +17,7 @@ import BehandlingSelected from './BehandlingSelected';
 import styles from './behandlingPicker.module.css';
 import { sortBehandlinger } from './behandlingVelgerUtils';
 import { FagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
+import { addLegacySerializerOption } from '@k9-sak-web/gui/utils/axios/axiosUtils.js';
 
 const getBehandlingNavn = (
   behandling: BehandlingAppKontekst,
@@ -106,7 +107,7 @@ const behandlingPerioderÅrsakRel = 'behandling-perioder-årsak-med-vilkår';
 
 const getBehandlingPerioderÅrsaker = (behandling: BehandlingAppKontekst): Promise<PerioderMedBehandlingsId> =>
   axios
-    .get(behandling.links.find(link => link.rel === behandlingPerioderÅrsakRel).href)
+    .get(behandling.links.find(link => link.rel === behandlingPerioderÅrsakRel).href, addLegacySerializerOption())
     .then(response => ({ data: response.data, id: behandling.id }))
     .then(({ data, id }) => ({
       id,

--- a/packages/utils/src/http-utils/axiosHttpUtils.spec.ts
+++ b/packages/utils/src/http-utils/axiosHttpUtils.spec.ts
@@ -1,0 +1,20 @@
+import { addLegacySerializerOption, legacySerializerOptionConfig } from './axiosHttpUtils';
+
+describe('axiosHttpUtils addLegacySerializerOption', () => {
+  it('should return set legacy config if nothing is passed in', () => {
+    expect(addLegacySerializerOption()).toEqual(legacySerializerOptionConfig);
+    expect(addLegacySerializerOption(undefined)).toEqual(legacySerializerOptionConfig);
+  });
+  it('should return merged headers if a config with headers is passed in', () => {
+    expect(addLegacySerializerOption({ headers: { 'X-Something': 'value' } })).toEqual({
+      headers: { 'X-Something': 'value', 'X-Json-Serializer-Option': 'kodeverdi-objekt' },
+    });
+  });
+  it('should return config with serializer option added if config without headers is passed in', () => {
+    const data = { some: 'data' };
+    expect(addLegacySerializerOption({ data })).toEqual({
+      data,
+      headers: { 'X-Json-Serializer-Option': 'kodeverdi-objekt' },
+    });
+  });
+});

--- a/packages/utils/src/http-utils/axiosHttpUtils.ts
+++ b/packages/utils/src/http-utils/axiosHttpUtils.ts
@@ -1,13 +1,24 @@
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { handleErrorExternally, httpErrorShouldBeHandledExternally } from './responseHelpers';
 
+export const legacySerializerOptionConfig: AxiosRequestConfig = {
+  headers: { 'X-Json-Serializer-Option': 'kodeverdi-objekt' },
+};
+
+export const addLegacySerializerOption = (requestConfig?: AxiosRequestConfig): AxiosRequestConfig => {
+  if (requestConfig != null) {
+    return { ...requestConfig, headers: { ...requestConfig.headers, ...legacySerializerOptionConfig.headers } };
+  }
+  return legacySerializerOptionConfig;
+};
+
 export async function get<T>(
   url: string,
   httpErrorHandler: (statusCode: number, locationHeader?: string) => void,
   requestConfig?: AxiosRequestConfig,
 ): Promise<T> {
   try {
-    const response: AxiosResponse<T> = await axios.get(url, requestConfig);
+    const response: AxiosResponse<T> = await axios.get(url, addLegacySerializerOption(requestConfig));
     return response.data;
   } catch (error) {
     console.error(error);
@@ -25,7 +36,7 @@ export async function post<T>(
   requestConfig?: AxiosRequestConfig,
 ): Promise<any> {
   try {
-    const response: AxiosResponse = await axios.post(url, body, requestConfig);
+    const response: AxiosResponse = await axios.post(url, body, addLegacySerializerOption(requestConfig));
     return response.data;
   } catch (error) {
     console.error(error);

--- a/packages/utils/src/http-utils/axiosHttpUtils.ts
+++ b/packages/utils/src/http-utils/axiosHttpUtils.ts
@@ -1,16 +1,6 @@
 import axios, { AxiosRequestConfig, AxiosResponse } from 'axios';
 import { handleErrorExternally, httpErrorShouldBeHandledExternally } from './responseHelpers';
-
-export const legacySerializerOptionConfig: AxiosRequestConfig = {
-  headers: { 'X-Json-Serializer-Option': 'kodeverdi-objekt' },
-};
-
-export const addLegacySerializerOption = (requestConfig?: AxiosRequestConfig): AxiosRequestConfig => {
-  if (requestConfig != null) {
-    return { ...requestConfig, headers: { ...requestConfig.headers, ...legacySerializerOptionConfig.headers } };
-  }
-  return legacySerializerOptionConfig;
-};
+import { addLegacySerializerOption } from '@k9-sak-web/gui/utils/axios/axiosUtils.js';
 
 export async function get<T>(
   url: string,

--- a/packages/v2/gui/src/fakta/vurder-nyoppstartet/VurderNyoppstartetIndex.tsx
+++ b/packages/v2/gui/src/fakta/vurder-nyoppstartet/VurderNyoppstartetIndex.tsx
@@ -5,7 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import NetworkErrorPage from '../../app/feilmeldinger/NetworkErrorPage.js';
 import { type SubmitValues, VurderNyoppstartet } from './VurderNyoppstartet.js';
-import { addLegacySerializerOption } from '../../utils/axios/axiosUtils.ts';
+import { addLegacySerializerOption } from '../../utils/axios/axiosUtils.js';
 
 interface VurderNyoppstartetIndexProps {
   behandlingUUID: string;

--- a/packages/v2/gui/src/fakta/vurder-nyoppstartet/VurderNyoppstartetIndex.tsx
+++ b/packages/v2/gui/src/fakta/vurder-nyoppstartet/VurderNyoppstartetIndex.tsx
@@ -5,6 +5,7 @@ import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import NetworkErrorPage from '../../app/feilmeldinger/NetworkErrorPage.js';
 import { type SubmitValues, VurderNyoppstartet } from './VurderNyoppstartet.js';
+import { addLegacySerializerOption } from '../../utils/axios/axiosUtils.ts';
 
 interface VurderNyoppstartetIndexProps {
   behandlingUUID: string;
@@ -36,7 +37,10 @@ export const VurderNyoppstartetIndex = ({
     queryKey: ['nyoppstartet', behandlingUUID],
     queryFn: () =>
       axios
-        .get('/k9/sak/api/behandling/nyoppstartet', { params: { behandlingUuid: behandlingUUID } })
+        .get(
+          '/k9/sak/api/behandling/nyoppstartet',
+          addLegacySerializerOption({ params: { behandlingUuid: behandlingUUID } }),
+        )
         .then(({ data }) => data),
   });
 

--- a/packages/v2/gui/src/utils/axios/axiosUtils.spec.ts
+++ b/packages/v2/gui/src/utils/axios/axiosUtils.spec.ts
@@ -1,4 +1,4 @@
-import { addLegacySerializerOption, legacySerializerOptionConfig } from './axiosHttpUtils';
+import { addLegacySerializerOption, legacySerializerOptionConfig } from './axiosUtils.js';
 
 describe('axiosHttpUtils addLegacySerializerOption', () => {
   it('should return set legacy config if nothing is passed in', () => {

--- a/packages/v2/gui/src/utils/axios/axiosUtils.ts
+++ b/packages/v2/gui/src/utils/axios/axiosUtils.ts
@@ -6,7 +6,7 @@ export const legacySerializerOptionConfig: AxiosRequestConfig = {
 
 export const addLegacySerializerOption = (requestConfig?: AxiosRequestConfig): AxiosRequestConfig => {
   if (requestConfig != null) {
-    return { ...requestConfig, headers: { ...requestConfig.headers, ...legacySerializerOptionConfig.headers } };
+    return { ...requestConfig, headers: { ...legacySerializerOptionConfig.headers, ...requestConfig.headers } };
   }
   return legacySerializerOptionConfig;
 };

--- a/packages/v2/gui/src/utils/axios/axiosUtils.ts
+++ b/packages/v2/gui/src/utils/axios/axiosUtils.ts
@@ -1,0 +1,12 @@
+import type { AxiosRequestConfig } from 'axios';
+
+export const legacySerializerOptionConfig: AxiosRequestConfig = {
+  headers: { 'X-Json-Serializer-Option': 'kodeverdi-objekt' },
+};
+
+export const addLegacySerializerOption = (requestConfig?: AxiosRequestConfig): AxiosRequestConfig => {
+  if (requestConfig != null) {
+    return { ...requestConfig, headers: { ...requestConfig.headers, ...legacySerializerOptionConfig.headers } };
+  }
+  return legacySerializerOptionConfig;
+};


### PR DESCRIPTION
## Bakgrunn

"legacy" frontend kode forventer å få Kodeverdi enums serialisert som objekt frå backend.

Vi ønsker å skrive om backend kode slik at den som standard serialiserer disse til kode string.

## Løysing

"legacy" frontend må be om å få Kodeverdi serialisert som objekt, ved å legge på X-Json-Serializer-Option header på alle requests.

Slik at server serialiserer/deserialiserer Kodeverdi til/frå objekt sjølv om standardinnstilling på server endre seg.

Førebuing til at ung-sak, k9-tilbake og på lengre sikt k9-sak som standard vil bruke @JsonValue/kodeverdi som string serialisering.