### PR TITLE
Fix ny behandling modal ytelsetype

### DIFF
--- a/packages/sak-app/src/behandlingmenu/BehandlingMenuIndex.tsx
+++ b/packages/sak-app/src/behandlingmenu/BehandlingMenuIndex.tsx
@@ -275,7 +275,7 @@ export const BehandlingMenuIndex = ({
               behandlingVersjon={behandlingVersjon}
               forhandsvisHenleggBehandling={previewHenleggBehandling}
               henleggBehandling={shelveBehandling}
-              ytelseType={fagsak.sakstype.kode}
+              ytelseType={fagsak.sakstype}
               behandlingType={behandling?.type.kode}
               behandlingResultatTyper={menyKodeverk
                 .getKodeverkForValgtBehandling(kodeverkTyper.BEHANDLING_RESULTAT_TYPE)
@@ -327,7 +327,7 @@ export const BehandlingMenuIndex = ({
                 BehandlingType.REVURDERING,
                 kodeverkTyper.BEHANDLING_AARSAK,
               )}
-              ytelseType={fagsak.sakstype.kode}
+              ytelseType={fagsak.sakstype}
               lagNyBehandling={lagNyBehandling}
               sjekkOmTilbakekrevingKanOpprettes={sjekkTilbakeKanOpprettes}
               sjekkOmTilbakekrevingRevurderingKanOpprettes={sjekkTilbakeRevurdKanOpprettes}

--- a/packages/v2/gui/src/sak/meny/ny-behandling/MenyNyBehandlingIndex.tsx
+++ b/packages/v2/gui/src/sak/meny/ny-behandling/MenyNyBehandlingIndex.tsx
@@ -7,6 +7,7 @@ import { useCallback, useContext } from 'react';
 import { K9SakClientContext } from '../../../app/K9SakClientContext';
 import NyBehandlingModal, { type BehandlingOppretting, type FormValues } from './components/NyBehandlingModal';
 import VilkårBackendClient from './VilkårBackendClient';
+import type { FagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
 
 const TILBAKEKREVING_BEHANDLINGSTYPER = [
   BehandlingTypeK9Klage.TILBAKEKREVING,
@@ -14,7 +15,7 @@ const TILBAKEKREVING_BEHANDLINGSTYPER = [
 ];
 
 interface OwnProps {
-  ytelseType: string;
+  ytelseType: FagsakYtelsesType;
   saksnummer: string;
   behandlingId?: number;
   behandlingUuid?: string;

--- a/packages/v2/gui/src/sak/meny/ny-behandling/components/NyBehandlingModal.tsx
+++ b/packages/v2/gui/src/sak/meny/ny-behandling/components/NyBehandlingModal.tsx
@@ -10,6 +10,7 @@ import { required } from '@navikt/ft-form-validators';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 import styles from './nyBehandlingModal.module.css';
+import type { FagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
 
 const createOptions = (bt: KodeverkObject, enabledBehandlingstyper: KodeverkObject[]) => {
   const navn = bt.kode === BehandlingTypeK9Klage.REVURDERING ? 'Revurderingsbehandling' : bt.navn;
@@ -33,13 +34,13 @@ export type FormValues = {
 };
 
 interface NyBehandlingModalProps {
-  ytelseType: string;
+  ytelseType: FagsakYtelsesType;
   saksnummer: string;
   cancelEvent: () => void;
   submitCallback: (
     data: {
       eksternUuid?: string;
-      fagsakYtelseType: string;
+      fagsakYtelseType: FagsakYtelsesType;
     } & FormValues,
   ) => void;
   behandlingOppretting: BehandlingOppretting[];
@@ -89,6 +90,9 @@ export const NyBehandlingModal = ({
   sisteDagISøknadsperiode,
 }: NyBehandlingModalProps) => {
   useEffect(() => {
+    const erTilbakekreving =
+      behandlingType === BehandlingTypeK9Klage.TILBAKEKREVING ||
+      behandlingType === BehandlingTypeK9Klage.REVURDERING_TILBAKEKREVING;
     if (erTilbakekrevingAktivert) {
       if (uuidForSistLukkede !== undefined) {
         sjekkOmTilbakekrevingKanOpprettes({ saksnummer, uuid: uuidForSistLukkede });
@@ -97,7 +101,15 @@ export const NyBehandlingModal = ({
         sjekkOmTilbakekrevingRevurderingKanOpprettes({ uuid: behandlingUuid });
       }
     }
-  }, []);
+  }, [
+    behandlingUuid,
+    behandlingType,
+    erTilbakekrevingAktivert,
+    saksnummer,
+    sjekkOmTilbakekrevingKanOpprettes,
+    sjekkOmTilbakekrevingRevurderingKanOpprettes,
+    uuidForSistLukkede,
+  ]);
 
   const formMethods = useForm<FormValues>({
     defaultValues: {
@@ -126,9 +138,6 @@ export const NyBehandlingModal = ({
   const visÅrsak =
     (erRevurdering && steg === 'inngangsvilkår') ||
     (!erRevurdering && BehandlingÅrsakDtoBehandlingArsakTyper.length > 0);
-  const erTilbakekreving =
-    behandlingType === BehandlingTypeK9Klage.TILBAKEKREVING ||
-    behandlingType === BehandlingTypeK9Klage.REVURDERING_TILBAKEKREVING;
   const handleSubmit = (formValues: FormValues) => {
     const klageOnlyValues =
       formValues?.behandlingType === BehandlingTypeK9Klage.KLAGE


### PR DESCRIPTION
**Bakgrunn**
Oppretting av ny klagebehandling frå v2 NyBehandlingModal.tsx feila pga at ytelsestype ikkje vart sendt med, fordi koden framleis rekna med at denne kom inn som eit kodeverk objekt, medan det er no ein kode string.
