### PR TITLE
Fjerner url property frå Historikkinnslag frå k9-tilbake.

### DIFF
--- a/packages/sak-historikk/src/components/maler/HistorikkMalType7.tsx
+++ b/packages/sak-historikk/src/components/maler/HistorikkMalType7.tsx
@@ -120,7 +120,7 @@ const HistorikkMalType7 = ({
           {dokumentLinks &&
             dokumentLinks.map(dokumentLenke => (
               <HistorikkDokumentLenke
-                key={`${dokumentLenke.tag}@${dokumentLenke.url}`}
+                key={`${dokumentLenke.tag}@${dokumentLenke.dokumentId}-${dokumentLenke.journalpostId}`}
                 dokumentLenke={dokumentLenke}
                 saksnummer={saksnummer}
               />

--- a/packages/sak-historikk/src/components/maler/HistorikkMalType8.tsx
+++ b/packages/sak-historikk/src/components/maler/HistorikkMalType8.tsx
@@ -110,7 +110,7 @@ const HistorikkMalType8 = ({
           {dokumentLinks &&
             dokumentLinks.map(dokumentLenke => (
               <HistorikkDokumentLenke
-                key={`${dokumentLenke.tag}@${dokumentLenke.url}`}
+                key={`${dokumentLenke.tag}@${dokumentLenke.dokumentId}-${dokumentLenke.journalpostId}`}
                 dokumentLenke={dokumentLenke}
                 saksnummer={saksnummer}
               />

--- a/packages/sak-historikk/src/components/maler/HistorikkmalFelles7og8.tsx
+++ b/packages/sak-historikk/src/components/maler/HistorikkmalFelles7og8.tsx
@@ -64,7 +64,7 @@ const HistorikkMalFelles7og8 = ({
             {dokumentLinks &&
               dokumentLinks.map(dokumentLenke => (
                 <HistorikkDokumentLenke
-                  key={`${dokumentLenke.tag}@${dokumentLenke.url}`}
+                  key={`${dokumentLenke.tag}@${dokumentLenke.dokumentId}-${dokumentLenke.journalpostId}`}
                   dokumentLenke={dokumentLenke}
                   saksnummer={saksnummer}
                 />

--- a/packages/sak-historikk/src/components/maler/historikkMalType1.tsx
+++ b/packages/sak-historikk/src/components/maler/historikkMalType1.tsx
@@ -24,7 +24,7 @@ const HistorikkMalType1 = ({ historikkinnslag, getKodeverknavn, saksnummer }: Hi
       {dokumentLinks &&
         dokumentLinks.map(dokumentLenke => (
           <HistorikkDokumentLenke
-            key={`${dokumentLenke.tag}@${dokumentLenke.url}`}
+            key={`${dokumentLenke.tag}@${dokumentLenke.dokumentId}-${dokumentLenke.journalpostId}`}
             dokumentLenke={dokumentLenke}
             saksnummer={saksnummer}
           />

--- a/packages/storybook/stories/mocks/historikkSakV1.ts
+++ b/packages/storybook/stories/mocks/historikkSakV1.ts
@@ -490,7 +490,6 @@ export const historikkSakV1: Historikkinnslag[] = [
         dokumentId: '454322583',
         journalpostId: '453920792',
         tag: 'Vedlegg',
-        url: 'https://192.168.67.212:8080/k9/sak/api/dokument/hent-dokument?journalpostId=453920792&dokumentId=454322583',
         utgått: false,
       },
     ],

--- a/packages/storybook/stories/mocks/historikkSakV1.ts
+++ b/packages/storybook/stories/mocks/historikkSakV1.ts
@@ -109,7 +109,6 @@ export const historikkSakV1: Historikkinnslag[] = [
         dokumentId: '454327391',
         journalpostId: '453925540',
         tag: 'Søknad',
-        url: 'https://192.168.67.212:8080/k9/sak/api/dokument/hent-dokument?journalpostId=453925540&dokumentId=454327391',
         utgått: false,
       },
     ],
@@ -357,7 +356,6 @@ export const historikkSakV1: Historikkinnslag[] = [
         dokumentId: '454322584',
         journalpostId: '453920793',
         tag: 'Inntektsmelding',
-        url: 'https://192.168.67.212:8080/k9/sak/api/dokument/hent-dokument?journalpostId=453920793&dokumentId=454322584',
         utgått: false,
       },
     ],
@@ -486,7 +484,6 @@ export const historikkSakV1: Historikkinnslag[] = [
         dokumentId: '454322582',
         journalpostId: '453920792',
         tag: 'Søknad',
-        url: 'https://192.168.67.212:8080/k9/sak/api/dokument/hent-dokument?journalpostId=453920792&dokumentId=454322582',
         utgått: false,
       },
       {

--- a/packages/v2/gui/src/sak/historikk/historikkinnslagTsTypeV2.ts
+++ b/packages/v2/gui/src/sak/historikk/historikkinnslagTsTypeV2.ts
@@ -20,7 +20,6 @@ export type HistorikkInnslagDokumentLink = Readonly<{
   dokumentId?: string;
   journalpostId?: string;
   tag: string;
-  url?: string;
   utgått: boolean;
 }>;
 

--- a/packages/v2/gui/src/sak/historikk/snakkeboble/Snakkeboble.tsx
+++ b/packages/v2/gui/src/sak/historikk/snakkeboble/Snakkeboble.tsx
@@ -60,7 +60,7 @@ export const Snakkeboble = ({
           <VStack gap="1">
             {dokumenter.map(dokumentLenke => (
               <HistorikkDokumentLenke
-                key={`${dokumentLenke.tag}@${dokumentLenke.url}`}
+                key={`${dokumentLenke.dokumentId}-${dokumentLenke.journalpostId}`}
                 dokumentLenke={dokumentLenke}
                 saksnummer={saksnummer}
               />


### PR DESCRIPTION
## Bakgrunn

url property fjernast frå HistorikkInnslagDokumentLinktDto i k9-tilbake. https://github.com/navikt/fptilbake/pull/2984

## Løysing
Fjerner bruken av property frå k9-sak-web, erstattast med å bruke dokumentId + journalId for key på gui element.