### PR TITLE
Vis spinner på knapp for å forhåndsvise brev

### DIFF
--- a/packages/prosess-vedtak/src/VedtakProsessIndex.tsx
+++ b/packages/prosess-vedtak/src/VedtakProsessIndex.tsx
@@ -52,7 +52,7 @@ interface VedtakProsessIndexProps {
   };
   overlappendeYtelser: Array<OverlappendeYtelseDto>;
   personopplysninger: PersonopplysningDto;
-  previewCallback: () => void;
+  previewCallback: () => Promise<any>;
   simuleringResultat: VedtakSimuleringResultat;
   submitCallback: (data) => void;
   tilbakekrevingvalg: TilbakekrevingValgDto;

--- a/packages/prosess-vedtak/src/components/VedtakForm.tsx
+++ b/packages/prosess-vedtak/src/components/VedtakForm.tsx
@@ -86,7 +86,7 @@ interface Props {
   medlemskapFom: string;
   overlappendeYtelser: Array<OverlappendeYtelseDto>;
   personopplysninger: PersonopplysningDto;
-  previewCallback: (values, aapneINyttVindu) => void;
+  previewCallback: (values, aapneINyttVindu) => Promise<any>;
   readOnly: boolean;
   simuleringResultat: VedtakSimuleringResultat;
   sprakkode: string;

--- a/packages/prosess-vedtak/src/components/VedtakPanels.tsx
+++ b/packages/prosess-vedtak/src/components/VedtakPanels.tsx
@@ -45,7 +45,7 @@ interface VedtakPanelsProps {
   medlemskapFom: string | undefined;
   overlappendeYtelser: Array<OverlappendeYtelseDto>;
   personopplysninger: PersonopplysningDto;
-  previewCallback: () => void;
+  previewCallback: () => Promise<any>;
   readOnly: boolean;
   simuleringResultat: VedtakSimuleringResultat;
   sprakkode: string;

--- a/packages/prosess-vedtak/src/components/brev/BrevPanel.tsx
+++ b/packages/prosess-vedtak/src/components/brev/BrevPanel.tsx
@@ -54,7 +54,7 @@ export const manuellBrevPreview = ({
   aapneINyttVindu,
 }: {
   tilgjengeligeVedtaksbrev: TilgjengeligeVedtaksbrev;
-  previewCallback: (values, aapneINyttVindu) => void;
+  previewCallback: (values, aapneINyttVindu) => Promise<any>;
   values: FormikValues;
   redigertHtml: any;
   overstyrtMottaker: Brevmottaker;
@@ -109,14 +109,14 @@ const getManuellBrevCallback =
     overskrift: string;
     overstyrtMottaker?: Brevmottaker;
     formProps: CustomFormikProps;
-    previewCallback: (values, aapneINyttVindu) => void;
+    previewCallback: (values, aapneINyttVindu) => Promise<any>;
     tilgjengeligeVedtaksbrev: TilgjengeligeVedtaksbrev;
   }) =>
   async (e, redigertHtml = undefined) => {
     e.preventDefault();
     const errors = await formProps.validateForm();
     if (Object.keys(errors).length === 0) {
-      manuellBrevPreview({
+      await manuellBrevPreview({
         tilgjengeligeVedtaksbrev,
         previewCallback,
         values: formProps.values,
@@ -155,7 +155,7 @@ interface BrevPanelProps {
   overskrift: string;
   overstyrtMottaker?: Brevmottaker;
   personopplysninger: PersonopplysningDto;
-  previewCallback: (values, aapneINyttVindu) => void;
+  previewCallback: (values, aapneINyttVindu) => Promise<any>;
   readOnly: boolean;
   skalBrukeOverstyrendeFritekstBrev: boolean;
   sprakkode: string;


### PR DESCRIPTION
### Bakgrunn
Man får ingen indikasjon på at forhåndsvisning lastes når man klikker på knapp for å forhåndsvise brev. Fører til at mange klikker flere ganger.

### Løsning
Sette spinner på knappen mens forhåndsvisningen laster.