### PR TITLE
TSFF-1307: Legg til nullsjekk i mapVilkar

### DIFF
--- a/packages/utils/src/beregning/VilkarMapper.tsx
+++ b/packages/utils/src/beregning/VilkarMapper.tsx
@@ -14,9 +14,9 @@ const erForlengelse = (beregningreferanserTilVurdering: BeregningReferanse[], pe
 
 const mapVilkar = (vilkar: VilkårMedPerioderDto, beregningreferanserTilVurdering: BeregningReferanse[]): FTVilkarType =>
   ({
-    vilkarType: vilkar.vilkarType,
-    overstyrbar: vilkar.overstyrbar,
-    perioder: vilkar.perioder.map(p => ({
+    vilkarType: vilkar?.vilkarType,
+    overstyrbar: vilkar?.overstyrbar,
+    perioder: vilkar?.perioder.map(p => ({
       avslagKode: p.avslagKode,
       begrunnelse: p.begrunnelse,
       vurderesIBehandlingen: p.vurderesIBehandlingen,


### PR DESCRIPTION
Beregningspanelet fører til teknisk feil i opplæringspenger fordi vurdering av søknadsfrist skjer før initialisering av vilkår. Om man da går inn på beregning klienten kræsje, ettersom beregningsvilkåret er udefinert.

Dette er forøvrig også en feil i pleiepenger, men har nok ikke blitt oppdaget der da man ikke starter i beregningspanelet. Om man manuelt forsøker å gjøre det kræsjer det der, også