### PR TITLE
Fjerner IKKE_GODKJENT_AUTOMATISK da denne er fjernet fra k9-sak

### DIFF
--- a/packages/v2/gui/src/shared/vurderingsperiode-navigasjon/PeriodeRad.tsx
+++ b/packages/v2/gui/src/shared/vurderingsperiode-navigasjon/PeriodeRad.tsx
@@ -36,13 +36,6 @@ const renderStatusIcon = (resultat?: ResultatType) => {
     );
   }
 
-  if (resultat === Resultat.IKKE_GODKJENT_AUTOMATISK) {
-    return (
-      <ContentWithTooltip tooltipText="Vilkåret er automatisk ikke oppfylt">
-        <OverlayedIcons indicatorRenderer={() => <RedCrossIconFilled />} overlayRenderer={() => <InstitutionIcon />} />
-      </ContentWithTooltip>
-    );
-  }
   if (resultat === Resultat.GODKJENT_MANUELT || resultat === Resultat.OPPFYLT || resultat === Resultat.GODKJENT) {
     return (
       <ContentWithTooltip tooltipText="Vilkåret er oppfylt">


### PR DESCRIPTION
Change and compatibility check typescript client-steget i k9-sak gha feiler fordi IKKE_GODKJENT_AUTOMATISK er fjernet i k9-sak, men fortsatt i bruk her