### PR TITLE
historikk v2: Mangla (utgått) markering på dokumentlenke.

### DIFF
--- a/packages/v2/gui/src/sak/historikk/snakkeboble/HistorikkDokumentLenke.tsx
+++ b/packages/v2/gui/src/sak/historikk/snakkeboble/HistorikkDokumentLenke.tsx
@@ -18,7 +18,7 @@ export const HistorikkDokumentLenke = ({
     return (
       <HStack align="center" gap="1">
         <FileIcon title={tag} width={24} height={24} />
-        <BodyShort size="small">{tag}</BodyShort>
+        <BodyShort size="small">{tag} (utgått)</BodyShort>
       </HStack>
     );
   }


### PR DESCRIPTION

## Bakgrunn

Når dokumentlenke er utgått har v1 historikkinnslag lagt til tekst (utgått) bak "tag" verdien. Dette var ikkje med i v2 visning.

## Løsning

Legger til (utgått), slik at v2 blir likt v1.