### PR TITLE
Vise uttak selv om man får avslag i tidligere paneler

### DIFF
--- a/packages/behandling-felles/src/util/prosessSteg/prosessStegHooks.ts
+++ b/packages/behandling-felles/src/util/prosessSteg/prosessStegHooks.ts
@@ -72,7 +72,7 @@ const useProsessStegPaneler = (
         urlKode === prosessStegCodes.SIMULERING ||
         urlKode === prosessStegCodes.VEDTAK ||
         urlKode === prosessStegCodes.KLAGE_RESULTAT ||
-        (fagsak.sakstype === fagsakYtelsesType.PLEIEPENGER_SYKT_BARN && urlKode === prosessStegCodes.UTTAK)
+        urlKode === prosessStegCodes.UTTAK
       ) {
         return panel;
       }

--- a/packages/behandling-felles/src/util/prosessSteg/prosessStegHooks.ts
+++ b/packages/behandling-felles/src/util/prosessSteg/prosessStegHooks.ts
@@ -4,7 +4,6 @@ import { Aksjonspunkt, Behandling, Fagsak, Vilkar } from '@k9-sak-web/types';
 
 import vilkarUtfallType from '@fpsak-frontend/kodeverk/src/vilkarUtfallType';
 import { prosessStegCodes } from '@k9-sak-web/konstanter';
-import { fagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
 import ProsessStegMenyRad from '../../types/prosessStegMenyRadTsType';
 import Rettigheter from '../../types/rettigheterTsType';
 import { ProsessStegDef } from './ProsessStegDef';


### PR DESCRIPTION
**Bakgrunn**
PSB viser uttak selv om man får avslag i et av de tidligere panelene. Andre ytelser viser at steget ikke er vurdert. Men vi har data til å vise panelet

**Løsning**
Vise panelet for PILS og OLP også
