### PR TITLE
historikk: Bruk samme aksjonspunkt kode tekstmapping som server har for kode 6003.

### DIFF
--- a/packages/sak-historikk/i18n/nb_NO.json
+++ b/packages/sak-historikk/i18n/nb_NO.json
@@ -519,5 +519,6 @@
   "Historikk.VurderFaktaATFLSN": "Vurder fakta for beregning",
   "Historikk.Sykdom": "Sykdom",
   "Historikk.FaktaUttak.ForsteUttakDato": "Kontroller manglende uttaksperiode",
-  "Historikk.FaktaUttak.VurderAnnenForelder": "Vurdering om den andre forelderen har rett til pleiepenger"
+  "Historikk.FaktaUttak.VurderAnnenForelder": "Vurdering om den andre forelderen har rett til pleiepenger",
+  "Historikk.OverstyringOmsorgenFor": "Overstyring av Omsorgen for"
 }

--- a/packages/sak-historikk/src/components/maler/historikkMalType3.tsx
+++ b/packages/sak-historikk/src/components/maler/historikkMalType3.tsx
@@ -24,7 +24,7 @@ const aksjonspunktCodesToTextCode = {
   [aksjonspunktCodes.AVKLAR_OM_BRUKER_ER_BOSATT]: 'Historikk.Bosatt',
   [aksjonspunktCodes.AVKLAR_OPPHOLDSRETT]: 'Historikk.Rett',
   [aksjonspunktCodes.AVKLAR_PERSONSTATUS]: 'Historikk.CheckAvklarPersonstatus',
-  [aksjonspunktCodes.OVERSTYR_OMSORGEN_FOR]: 'Historikk.fodselsvilkar',
+  [aksjonspunktCodes.OVERSTYR_OMSORGEN_FOR]: 'Historikk.OverstyringOmsorgenFor',
   [aksjonspunktCodes.OVERSTYR_ADOPSJONSVILKAR]: 'Historikk.adopsjonsvilkar',
   [aksjonspunktCodes.OVERSTYRING_AV_OPPTJENINGSVILKARET]: 'Historikk.opptjeningsvilkår',
   [aksjonspunktCodes.OVERSTYR_MEDLEMSKAPSVILKAR]: 'Historikk.medlemskapsvilkar',


### PR DESCRIPTION
## Bakgrunn

Det ser ut til at spesiell tekstmapping for aksjonspunkt koder (i området 6000 -> 7000) for historikkinnslag av type SAK_RETUR har vore gammel kode frå FP frontend, og ikkje korrekt for k9 sine backend definisjoner.

## Løysing

Endre mapping til å stemme med tekst definert i backend kode.

Av dei med eigen mapping er det kun kode 6003 som er brukt i db, så endre kun denne sidan all denne frontend kode skal slettast snart uansett.