### PR TITLE
Fiks github code scanning alert

### DIFF
--- a/.github/workflows/lint-tscheck-build.yml
+++ b/.github/workflows/lint-tscheck-build.yml
@@ -1,5 +1,7 @@
 name: Lint, typescript-sjekk og bygg
-
+permissions:
+  contents: read
+  packages: read
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/storybook-tests.yml
+++ b/.github/workflows/storybook-tests.yml
@@ -1,4 +1,7 @@
 name: 'Storybook Tests'
+permissions:
+  contents: read
+  packages: read
 on:
   workflow_call:
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,7 @@
 name: Tester
+permissions:
+  contents: read
+  packages: read
 
 on:
   workflow_call:

--- a/.github/workflows/valid-pull-request.yml
+++ b/.github/workflows/valid-pull-request.yml
@@ -1,4 +1,7 @@
 name: Valider pull request
+permissions:
+  contents: read
+  packages: read
 on: [pull_request]
 jobs:
   test:


### PR DESCRIPTION
## Bakgrunn

Github code scanning varsler om at "Workflow does not contain permissions".

## Løysing

Legger til permissions på workflows som mangler det.