### PR TITLE
Historikkv2/tsff 1567 

### DIFF
--- a/packages/sak-app/src/behandlingsupport/historikk/v1v2Sammenligningssjekk.tsx
+++ b/packages/sak-app/src/behandlingsupport/historikk/v1v2Sammenligningssjekk.tsx
@@ -120,6 +120,13 @@ const historikkInnslagMissingWordsExemptions = new Map<string, string[]>();
 historikkInnslagMissingWordsExemptions.set('KLAGE_BEH_NFP', ['endret', 'fra']);
 historikkInnslagMissingWordsExemptions.set(KodeverdiSomObjektHistorikkinnslagTypeKilde.FAKTA_ENDRET, [
   'Aldersvilkåret',
+  // v1 mangler støtte for EndretFeltVerdiTypeCode.UAVKLART, så er ein feil i v1 som ikkje er i v2:
+  'EndretFeltVerdiTypeCode',
+  'finnes',
+  'LEGG',
+  'DET',
+  'INN',
+  // ===
 ]);
 historikkInnslagMissingWordsExemptions.set(
   KodeverdiSomObjektHistorikkinnslagTypeKilde.TILBAKEKREVING_VIDEREBEHANDLING,

--- a/packages/sak-app/src/behandlingsupport/historikk/v1v2Sammenligningssjekk.tsx
+++ b/packages/sak-app/src/behandlingsupport/historikk/v1v2Sammenligningssjekk.tsx
@@ -137,6 +137,15 @@ historikkInnslagMissingWordsExemptions.set(KodeverdiSomObjektHistorikkinnslagTyp
   'eller',
   'Fastsatt',
 ]);
+// Historikkinnslag av type BEH_AVBRUTT_OVERLAPP har ingen mal i frontend(!)
+historikkInnslagMissingWordsExemptions.set(KodeverdiSomObjektHistorikkinnslagTypeKilde.BEH_AVBRUTT_OVERLAPP, [
+  'Kan',
+  'ikke',
+  'finne',
+  'mal',
+  'dette',
+  'historikkinnslaget',
+]);
 
 // Nokre enkle samanbindingsord utelatast frå samanlikning for alle historikkinnslag typer
 const wordsAlwaysExempted = ['er', 'Er'];

--- a/packages/v2/backend/package.json
+++ b/packages/v2/backend/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "@navikt/k9-klage-typescript-client": "3.0.20250512080735",
-    "@navikt/k9-sak-typescript-client": "2.0.20250513120447",
+    "@navikt/k9-sak-typescript-client": "2.0.20250522095735",
     "@navikt/ung-sak-typescript-client": "0.2.20250521124912"
   },
   "devDependencies": {

--- a/packages/v2/gui/src/kodeverk/mocks/oppslagKodeverkSomObjektK9Sak.ts
+++ b/packages/v2/gui/src/kodeverk/mocks/oppslagKodeverkSomObjektK9Sak.ts
@@ -2982,7 +2982,7 @@ export const oppslagKodeverkSomObjektK9Sak = {
       kode: '-',
       kodeverk: 'HISTORIKKINNSLAG_TYPE',
       navn: 'Ikke definert',
-      kilde: 'UDEFINERT',
+      kilde: '-',
     },
     {
       kode: 'AVBRUTT_BEH',
@@ -3198,7 +3198,7 @@ export const oppslagKodeverkSomObjektK9Sak = {
       kode: 'OVST_UTTAK_FJERNE',
       kodeverk: 'HISTORIKKINNSLAG_TYPE',
       navn: 'Manuell overstyring av uttak - fjernet overstyring for periode',
-      kilde: 'OVST_UTTAK_FJERNET',
+      kilde: 'OVST_UTTAK_FJERNE',
     },
     {
       kode: 'OVST_UTTAK_NY',
@@ -3210,7 +3210,7 @@ export const oppslagKodeverkSomObjektK9Sak = {
       kode: 'OVST_UTTAK_OPPDATERE',
       kodeverk: 'HISTORIKKINNSLAG_TYPE',
       navn: 'Manuell overstyring av uttak - oppdaterte overstyring for periode',
-      kilde: 'OVST_UTTAK_OPPDATERT',
+      kilde: 'OVST_UTTAK_OPPDATERE',
     },
     {
       kode: 'OVST_UTTAK_SPLITT',
@@ -3258,7 +3258,7 @@ export const oppslagKodeverkSomObjektK9Sak = {
       kode: 'TILBAKEKR_VIDEREBEHANDLING',
       kodeverk: 'HISTORIKKINNSLAG_TYPE',
       navn: 'Metode for å håndtere tilbakekreving av feilutbetailng er valgt.',
-      kilde: 'TILBAKEKREVING_VIDEREBEHANDLING',
+      kilde: 'TILBAKEKR_VIDEREBEHANDLING',
     },
     {
       kode: 'UENDRET_UTFALL',

--- a/packages/v2/gui/src/sak/totrinnskontroll/TotrinnskontrollSakIndex.stories.tsx
+++ b/packages/v2/gui/src/sak/totrinnskontroll/TotrinnskontrollSakIndex.stories.tsx
@@ -2,7 +2,7 @@ import { behandlingType } from '@k9-sak-web/backend/k9klage/kodeverk/behandling/
 import withKodeverkContext from '@k9-sak-web/gui/storybook/decorators/withKodeverkContext.js';
 import { BehandlingDtoStatus } from '@navikt/k9-sak-typescript-client';
 import type { Meta, StoryObj } from '@storybook/react';
-import { expect, fn, userEvent, waitFor } from '@storybook/test';
+import { expect, fn, userEvent } from '@storybook/test';
 import TotrinnskontrollSakIndex from './TotrinnskontrollSakIndex';
 import type { Behandling } from './types/Behandling';
 import type { TotrinnskontrollAksjonspunkt } from './types/TotrinnskontrollAksjonspunkt';
@@ -148,7 +148,6 @@ export const SenderBehandlingTilbakeTilSaksbehandler: Story = {
     await expect(canvas.getByRole('button', { name: 'Godkjenn vedtaket' })).toBeDisabled();
     await expect(canvas.getByRole('button', { name: 'Send til saksbehandler' })).toBeEnabled();
     await userEvent.click(canvas.getByRole('button', { name: 'Send til saksbehandler' }));
-    await waitFor(() => expect(args.onSubmit).toHaveBeenCalledTimes(1));
     await expect(args.onSubmit).toHaveBeenNthCalledWith(1, {
       fatterVedtakAksjonspunktDto: {
         '@type': '5016',
@@ -206,7 +205,6 @@ export const GodkjennerVedtak: Story = {
     await expect(canvas.getByRole('button', { name: 'Godkjenn vedtaket' })).toBeEnabled();
     await expect(canvas.getByRole('button', { name: 'Send til saksbehandler' })).toBeDisabled();
     await userEvent.click(canvas.getByRole('button', { name: 'Godkjenn vedtaket' }));
-    await waitFor(() => expect(args.onSubmit).toHaveBeenCalledTimes(1));
     await expect(args.onSubmit).toHaveBeenNthCalledWith(1, {
       fatterVedtakAksjonspunktDto: {
         '@type': '5016',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3794,7 +3794,7 @@ __metadata:
   resolution: "@k9-sak-web/backend@workspace:packages/v2/backend"
   dependencies:
     "@navikt/k9-klage-typescript-client": "npm:3.0.20250512080735"
-    "@navikt/k9-sak-typescript-client": "npm:2.0.20250513120447"
+    "@navikt/k9-sak-typescript-client": "npm:2.0.20250522095735"
     "@navikt/ung-sak-typescript-client": "npm:0.2.20250521124912"
     "@tanstack/eslint-plugin-query": "npm:^5.74.7"
   languageName: unknown
@@ -5156,10 +5156,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/k9-sak-typescript-client@npm:2.0.20250513120447":
-  version: 2.0.20250513120447
-  resolution: "@navikt/k9-sak-typescript-client@npm:2.0.20250513120447::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-sak-typescript-client%2F2.0.20250513120447%2F714809223066fbf33ad65adc57ee3f0974cf9699"
-  checksum: 10/cbbe119b1fd3bc32a9748e557354e59e477e14293c88a4eca09ea52f346682406a3338d1d5f853b277ac5f48fff787eb655b67bc2ae67aaaa824a365d3c8a9a7
+"@navikt/k9-sak-typescript-client@npm:2.0.20250522095735":
+  version: 2.0.20250522095735
+  resolution: "@navikt/k9-sak-typescript-client@npm:2.0.20250522095735::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-sak-typescript-client%2F2.0.20250522095735%2F14e14965c5fe5e4365ec0520ccd2bab8c7c56e3f"
+  checksum: 10/c577392fc39426de7fdf419ff70870b5d97a5daf5ed787ff6683f4c620950ee66289221cb1ef2c7c0c96b52d62ea9123f9027c9d1c9df40382d3f2bffca6a92d
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3794,7 +3794,7 @@ __metadata:
   resolution: "@k9-sak-web/backend@workspace:packages/v2/backend"
   dependencies:
     "@navikt/k9-klage-typescript-client": "npm:3.0.20250512080735"
-    "@navikt/k9-sak-typescript-client": "npm:2.0.20250513120447"
+    "@navikt/k9-sak-typescript-client": "npm:2.0.20250522095735"
     "@navikt/ung-sak-typescript-client": "npm:0.2.20250522102547"
     "@tanstack/eslint-plugin-query": "npm:^5.74.7"
   languageName: unknown
@@ -5156,10 +5156,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/k9-sak-typescript-client@npm:2.0.20250513120447":
-  version: 2.0.20250513120447
-  resolution: "@navikt/k9-sak-typescript-client@npm:2.0.20250513120447::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-sak-typescript-client%2F2.0.20250513120447%2F714809223066fbf33ad65adc57ee3f0974cf9699"
-  checksum: 10/cbbe119b1fd3bc32a9748e557354e59e477e14293c88a4eca09ea52f346682406a3338d1d5f853b277ac5f48fff787eb655b67bc2ae67aaaa824a365d3c8a9a7
+"@navikt/k9-sak-typescript-client@npm:2.0.20250522095735":
+  version: 2.0.20250522095735
+  resolution: "@navikt/k9-sak-typescript-client@npm:2.0.20250522095735::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-sak-typescript-client%2F2.0.20250522095735%2F14e14965c5fe5e4365ec0520ccd2bab8c7c56e3f"
+  checksum: 10/c577392fc39426de7fdf419ff70870b5d97a5daf5ed787ff6683f4c620950ee66289221cb1ef2c7c0c96b52d62ea9123f9027c9d1c9df40382d3f2bffca6a92d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Bakgrunn

Differanser/manglande ord i v2 historikk rapportert gjennom Sentry.

## Løysing

- Justerer historikk v1/v2 samanlikningssjekk basert på undersøkelse av rapporterte differanser, for bestemte historikk innslag typer.
- Fikser feil som gjorde at ignorering av kjende differanser ikkje alltid fungerte.

## Andre endringer
Fikser ustabil testkode.