### PR TITLE
Fjern classnames bind

### DIFF
--- a/packages/v2/gui/src/prosess/uttak/uttak-detaljer/GraderingMotArbeidstidDetaljer.tsx
+++ b/packages/v2/gui/src/prosess/uttak/uttak-detaljer/GraderingMotArbeidstidDetaljer.tsx
@@ -1,5 +1,4 @@
 import type { FC } from 'react';
-import classNames from 'classnames/bind';
 import { BodyShort, Box, Detail, HelpText, HStack, Tag, VStack } from '@navikt/ds-react';
 import {
   UttakArbeidsforholdType,
@@ -11,8 +10,6 @@ import { beregnDagerTimer } from '@k9-sak-web/gui/utils/formatters.js';
 
 import styles from './uttakDetaljer.module.css';
 import { arbeidstypeTilVisning } from '../constants/Arbeidstype';
-
-const cx = classNames.bind(styles);
 
 interface ownProps {
   alleArbeidsforhold: ArbeidsgiverOversiktDto['arbeidsgivere'];
@@ -77,10 +74,10 @@ const GraderingMotArbeidstidDetaljer: FC<ownProps> = ({
               <BodyShort size="small" className="leading-6">
                 Normal arbeidstid: {beregnetNormalArbeidstid} timer
               </BodyShort>
-              <BodyShort as="div" size="small" className={cx({ uttakDetaljerBeregningStrek: true, 'leading-6': true })}>
+              <BodyShort as="div" size="small" className={`${styles.uttakDetaljerBeregningStrek} leading-6`}>
                 <HStack gap="1" className="leading-6">
                   Faktisk arbeidstid:
-                  <span className={cx({ uttakDetaljerUtnullet: faktiskOverstigerNormal })}>
+                  <span className={faktiskOverstigerNormal ? styles.uttakDetaljerUtnullet : ''}>
                     {beregnetFaktiskArbeidstid}
                   </span>
                   {faktiskOverstigerNormal && <span> {beregnetNormalArbeidstid}</span>} timer

--- a/packages/v2/gui/src/prosess/uttak/uttak-detaljer/GraderingMotInntektDetaljer.tsx
+++ b/packages/v2/gui/src/prosess/uttak/uttak-detaljer/GraderingMotInntektDetaljer.tsx
@@ -1,5 +1,4 @@
 import React, { type FC } from 'react';
-import classNames from 'classnames/bind';
 import { tilNOK } from '@k9-sak-web/gui/utils/formatters.js';
 import { BodyShort, Box, Tag, VStack } from '@navikt/ds-react';
 import {
@@ -10,8 +9,6 @@ import {
 import UttakDetaljerEkspanderbar from './UttakDetaljerEkspanderbar';
 
 import styles from './uttakDetaljer.module.css';
-
-const cx = classNames.bind(styles);
 
 interface ownProps {
   alleArbeidsforhold: ArbeidsgiverOversiktDto['arbeidsgivere'];
@@ -112,16 +109,16 @@ const GraderingMotInntektDetaljer: FC<ownProps> = ({ alleArbeidsforhold, inntekt
         <BodyShort as="div" size="small" className="leading-6">
           {løpendeInntekt} (utbetalt lønn) /
         </BodyShort>
-        <BodyShort as="div" size="small" className={cx({ uttakDetaljerBeregningStrek: true, 'leading-6': true })}>
+        <BodyShort as="div" size="small" className={`${styles.uttakDetaljerBeregningStrek} leading-6`}>
           {beregningsgrunnlag} (beregningsgrunnlag)
         </BodyShort>
-        <BodyShort as="div" size="small" className={cx({ uttakDetaljerBeregningSum: true, 'leading-6': true })}>
+        <BodyShort as="div" size="small" className={`${styles.uttakDetaljerBeregningSum} leading-6`}>
           = {reduksjonsProsent} % reduksjon pga. utbetalt lønn
         </BodyShort>
       </VStack>
 
       <Box>
-        <BodyShort as="div" size="small" className={cx({ uttakDetaljerDetailSum: true, 'leading-6': true })}>
+        <BodyShort as="div" size="small" className={`${styles.uttakDetaljerDetailSum} leading-6`}>
           = {graderingsProsent} % totalt inntektstap
         </BodyShort>
       </Box>

--- a/packages/v2/gui/src/prosess/uttak/uttak-detaljer/UttakDetaljer.tsx
+++ b/packages/v2/gui/src/prosess/uttak/uttak-detaljer/UttakDetaljer.tsx
@@ -137,7 +137,7 @@ const UttakDetaljer = ({ uttak, arbeidsforhold, manueltOverstyrt, ytelsetype }: 
       <HGrid gap="8" columns={3} align="start" className={styles['uttakDetaljer']}>
         {graderingMotTilsyn && skalViseGraderingMotTilsyn && (
           <Box
-            className={`${styles.uttakDetaljerGraderingDetaljer} ${shouldHighlightTilsyn ? styles.uttakDetaljerGraderingDetaljerHighlight : styles.uttakDetaljerGraderingDetaljerNotHighlighted}`}
+            className={`${styles.uttakDetaljerGraderingDetaljer} ${shouldHighlightTilsyn ? styles.uttakDetaljerGraderingDetaljerHighlighted : styles.uttakDetaljerGraderingDetaljerNotHighlighted}`}
             title="Gradering mot tilsyn"
           >
             {shouldHighlightTilsyn && (
@@ -162,7 +162,7 @@ const UttakDetaljer = ({ uttak, arbeidsforhold, manueltOverstyrt, ytelsetype }: 
         )}
 
         <Box
-          className={`${styles.uttakDetaljerGraderingDetaljer} ${shouldHighlightArbeidstid ? styles.uttakDetaljerGraderingDetaljerHighlight : styles.uttakDetaljerGraderingDetaljerNotHighlighted}`}
+          className={`${styles.uttakDetaljerGraderingDetaljer} ${shouldHighlightArbeidstid ? styles.uttakDetaljerGraderingDetaljerHighlighted : styles.uttakDetaljerGraderingDetaljerNotHighlighted}`}
           title="Gradering mot arbeidstid"
         >
           {shouldHighlightArbeidstid && (
@@ -186,7 +186,7 @@ const UttakDetaljer = ({ uttak, arbeidsforhold, manueltOverstyrt, ytelsetype }: 
 
         {inntektsgradering && (
           <Box
-            className={`${styles.uttakDetaljerGraderingDetaljer} ${shouldHighlightInntekt ? styles.uttakDetaljerGraderingDetaljerHighlight : styles.uttakDetaljerGraderingDetaljerNotHighlighted}`}
+            className={`${styles.uttakDetaljerGraderingDetaljer} ${shouldHighlightInntekt ? styles.uttakDetaljerGraderingDetaljerHighlighted : styles.uttakDetaljerGraderingDetaljerNotHighlighted}`}
             title="Gradering mot inntekt"
           >
             {shouldHighlightInntekt && (

--- a/packages/v2/gui/src/prosess/uttak/uttak-detaljer/UttakDetaljer.tsx
+++ b/packages/v2/gui/src/prosess/uttak/uttak-detaljer/UttakDetaljer.tsx
@@ -1,5 +1,4 @@
 import { type JSX } from 'react';
-import classNames from 'classnames/bind';
 import {
   UttaksperiodeInfoUtfall,
   type UttaksperiodeInfoUtfall as UttaksperiodeInfoUtfallType,
@@ -22,8 +21,6 @@ import {
 } from '../constants/UttaksperiodeInfoÅrsakerTekst';
 import styles from './uttakDetaljer.module.css';
 import { fagsakYtelsesType, type FagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
-
-const cx = classNames.bind(styles);
 
 const getÅrsaksetiketter = (årsaker: UttaksperiodeInfoÅrsakerType[]) => {
   const funnedeÅrsaker = IkkeOppfylteÅrsakerMedTekst.filter(årsak => årsaker.includes(årsak.årsak));
@@ -140,11 +137,7 @@ const UttakDetaljer = ({ uttak, arbeidsforhold, manueltOverstyrt, ytelsetype }: 
       <HGrid gap="8" columns={3} align="start" className={styles['uttakDetaljer']}>
         {graderingMotTilsyn && skalViseGraderingMotTilsyn && (
           <Box
-            className={cx({
-              uttakDetaljerGraderingDetaljer: true,
-              uttakDetaljerGraderingDetaljerHighlighted: shouldHighlightTilsyn,
-              uttakDetaljerGraderingDetaljerNotHighlighted: !shouldHighlightTilsyn,
-            })}
+            className={`${styles.uttakDetaljerGraderingDetaljer} ${shouldHighlightTilsyn ? styles.uttakDetaljerGraderingDetaljerHighlight : styles.uttakDetaljerGraderingDetaljerNotHighlighted}`}
             title="Gradering mot tilsyn"
           >
             {shouldHighlightTilsyn && (
@@ -169,11 +162,7 @@ const UttakDetaljer = ({ uttak, arbeidsforhold, manueltOverstyrt, ytelsetype }: 
         )}
 
         <Box
-          className={cx({
-            uttakDetaljerGraderingDetaljer: true,
-            uttakDetaljerGraderingDetaljerHighlighted: shouldHighlightArbeidstid,
-            uttakDetaljerGraderingDetaljerNotHighlighted: !shouldHighlightArbeidstid,
-          })}
+          className={`${styles.uttakDetaljerGraderingDetaljer} ${shouldHighlightArbeidstid ? styles.uttakDetaljerGraderingDetaljerHighlight : styles.uttakDetaljerGraderingDetaljerNotHighlighted}`}
           title="Gradering mot arbeidstid"
         >
           {shouldHighlightArbeidstid && (
@@ -197,11 +186,7 @@ const UttakDetaljer = ({ uttak, arbeidsforhold, manueltOverstyrt, ytelsetype }: 
 
         {inntektsgradering && (
           <Box
-            className={cx({
-              uttakDetaljerGraderingDetaljer: true,
-              uttakDetaljerGraderingDetaljerHighlighted: shouldHighlightInntekt,
-              uttakDetaljerGraderingDetaljerNotHighlighted: !shouldHighlightInntekt,
-            })}
+            className={`${styles.uttakDetaljerGraderingDetaljer} ${shouldHighlightInntekt ? styles.uttakDetaljerGraderingDetaljerHighlight : styles.uttakDetaljerGraderingDetaljerNotHighlighted}`}
             title="Gradering mot inntekt"
           >
             {shouldHighlightInntekt && (

--- a/packages/v2/gui/src/prosess/uttak/uttak-detaljer/UttakUtregning.tsx
+++ b/packages/v2/gui/src/prosess/uttak/uttak-detaljer/UttakUtregning.tsx
@@ -1,12 +1,9 @@
 import { Label } from '@navikt/ds-react';
 import { GreenCheckIcon } from '@navikt/ft-plattform-komponenter';
-import classNames from 'classnames/bind';
 import * as React from 'react';
 import styles from './uttakUtregning.module.css';
 
 import type { JSX } from 'react';
-
-const cx = classNames.bind(styles);
 
 interface UttakUtregningProps {
   heading: string;
@@ -16,9 +13,7 @@ interface UttakUtregningProps {
 }
 
 const UttakUtregning = ({ heading, children, highlight, headingPostContent }: UttakUtregningProps): JSX.Element => {
-  const uttakUtregningCls = cx('uttakUtregning', {
-    'uttakUtregning--highlighted': highlight,
-  });
+  const uttakUtregningCls = `${styles.uttakUtregning} ${highlight ? styles.uttakUtregningHighlighted : ''}`;
   return (
     <div className={uttakUtregningCls}>
       <div className={styles.uttakUtregningHeadingContainer}>

--- a/packages/v2/gui/src/prosess/uttak/uttak-detaljer/uttakDetaljer.module.css
+++ b/packages/v2/gui/src/prosess/uttak/uttak-detaljer/uttakDetaljer.module.css
@@ -9,7 +9,7 @@
   border-radius: 5px;
 }
 
-.uttakDetaljerGraderingDetaljerHighlight {
+.uttakDetaljerGraderingDetaljerHighlighted {
   background-color: var(--a-deepblue-50);
 }
 

--- a/packages/v2/gui/src/prosess/uttak/uttak-detaljer/uttakDetaljer.module.d.css.ts
+++ b/packages/v2/gui/src/prosess/uttak/uttak-detaljer/uttakDetaljer.module.d.css.ts
@@ -11,7 +11,7 @@ declare const styles: {
   readonly "uttakDetaljerExpandableDetailItemContentCollapsed": string;
   readonly "uttakDetaljerExpandableDetailItemHeader": string;
   readonly "uttakDetaljerGraderingDetaljer": string;
-  readonly "uttakDetaljerGraderingDetaljerHighlight": string;
+  readonly "uttakDetaljerGraderingDetaljerHighlighted": string;
   readonly "uttakDetaljerGraderingDetaljerNotHighlighted": string;
   readonly "uttakDetaljerNyGradering": string;
   readonly "uttakDetaljerNyTag": string;

--- a/packages/v2/gui/src/sak/behandling-velger/components/BehandlingSelected.tsx
+++ b/packages/v2/gui/src/sak/behandling-velger/components/BehandlingSelected.tsx
@@ -2,7 +2,6 @@ import { BehandlingDtoBehandlingResultatType, BehandlingDtoType } from '@k9-sak-
 import { fagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
 import { CalendarIcon } from '@navikt/aksel-icons';
 import { BodyShort, Heading, HStack, Label } from '@navikt/ds-react';
-import classnames from 'classnames/bind';
 import { type Location } from 'history';
 import { NavLink, useLocation } from 'react-router';
 import skjermlenkeCodes from '../../../shared/constants/skjermlenkeCodes';
@@ -16,7 +15,6 @@ import {
   getStatusText,
 } from './behandlingVelgerUtils';
 
-const cx = classnames.bind(styles);
 interface BehandlingSelectedProps {
   opprettetDato: string;
   avsluttetDato?: string;
@@ -44,10 +42,9 @@ const BehandlingSelected = ({
 }: BehandlingSelectedProps) => {
   const location = useLocation();
   const erFerdigstilt = !!avsluttetDato;
-  const containerCls = cx('behandlingSelectedContainer', {
-    aapen:
-      !behandlingsresultatTypeKode || behandlingsresultatTypeKode === BehandlingDtoBehandlingResultatType.IKKE_FASTSATT,
-  });
+  const erÅpen =
+    !behandlingsresultatTypeKode || behandlingsresultatTypeKode === BehandlingDtoBehandlingResultatType.IKKE_FASTSATT;
+  const containerCls = `${styles.behandlingSelectedContainer} ${erÅpen ? styles.aapen : ''}`;
 
   const getÅrsakerForBehandling = () => {
     if (behandlingTypeKode === BehandlingDtoType.FØRSTEGANGSSØKNAD || !behandlingsårsaker.length) {

--- a/packages/v2/gui/src/shared/aksjonspunktBox/AksjonspunktBox.tsx
+++ b/packages/v2/gui/src/shared/aksjonspunktBox/AksjonspunktBox.tsx
@@ -1,11 +1,8 @@
-import classnames from 'classnames/bind';
 import { type ReactNode } from 'react';
 import { Box } from '@navikt/ds-react';
 import { K9MaxTextWidth } from '@k9-sak-web/gui/tokens/tokens.js';
 
 import styles from './aksjonspunktBox.module.css';
-
-const classNames = classnames.bind(styles);
 
 interface OwnProps {
   children: ReactNode | ReactNode[];
@@ -16,7 +13,7 @@ interface OwnProps {
 
 const AksjonspunktBox = ({ erAksjonspunktApent, className, children, maxWidth = false }: OwnProps) => (
   <Box
-    className={classNames('aksjonspunkt', className, { erAksjonspunktApent })}
+    className={`${styles.aksjonspunkt} ${className} ${erAksjonspunktApent ? styles.erAksjonspunktApent : ''}`}
     borderWidth={erAksjonspunktApent ? '3' : undefined}
     borderRadius={erAksjonspunktApent ? 'large' : undefined}
     padding={erAksjonspunktApent ? '4' : undefined}


### PR DESCRIPTION
## Bakgrunn

Ønsker å unngå bruk av classnames/bind funksjon i v2, slik at vi får typescript sjekk på bruke nav css klassenamn.

## Løysing

Skriver om eksisterande bruk til string interpolering.