### PR TITLE
Initialiser kodeverkoppslag for k9-klage kun når init-fetch har køyrt.

### DIFF
--- a/packages/sak-app/src/app/AppConfigResolver.tsx
+++ b/packages/sak-app/src/app/AppConfigResolver.tsx
@@ -11,6 +11,8 @@ import useHentKodeverk from './useHentKodeverk';
 import { prodFeatureToggles } from '@k9-sak-web/gui/featuretoggles/prodFeatureToggles.js';
 import { useK9Kodeverkoppslag } from '@k9-sak-web/gui/kodeverk/oppslag/useK9Kodeverkoppslag.jsx';
 import { K9KodeverkoppslagContext } from '@k9-sak-web/gui/kodeverk/oppslag/K9KodeverkoppslagContext.jsx';
+import useGetEnabledApplikasjonContext from './useGetEnabledApplikasjonContext';
+import ApplicationContextPath from './ApplicationContextPath';
 
 interface OwnProps {
   children: ReactElement<any>;
@@ -38,11 +40,13 @@ const AppConfigResolver = ({ children }: OwnProps) => {
 
   const { featureToggles } = useFeatureToggles();
 
-  const k9KodeverkOppslag = useK9Kodeverkoppslag();
-
   const { state: sprakFilState } = restApiHooks.useGlobalStateRestApi(K9sakApiKeys.LANGUAGE_FILE, NO_PARAMS);
 
   const harHentetFerdigKodeverk = useHentKodeverk(harHentetFerdigInitLenker);
+
+  const enabledApplicationContexts = useGetEnabledApplikasjonContext();
+  const klageAktivert = enabledApplicationContexts.includes(ApplicationContextPath.KLAGE);
+  const k9KodeverkOppslag = useK9Kodeverkoppslag(klageAktivert);
 
   const harFeilet = harK9sakInitKallFeilet && sprakFilState === RestApiState.SUCCESS;
 

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringForm.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringForm.tsx
@@ -46,7 +46,7 @@ const NødvendigOpplæringForm = ({
       nødvendigOpplæring: booleanToRadioValue(vurdering.nødvendigOpplæring),
     },
   });
-  const K9Kodeverkoppslag = useK9Kodeverkoppslag();
+  const K9Kodeverkoppslag = useK9Kodeverkoppslag(true);
 
   const hentAvslagsårsak = (avslagsårsak: KodeverdiSomObjektAvslagsårsakKilde): KodeverdiSomObjektAvslagsårsak =>
     K9Kodeverkoppslag.k9sak.avslagsårsaker(avslagsårsak);

--- a/packages/v2/gui/src/kodeverk/oppslag/K9KlageKodeverkoppslag.ts
+++ b/packages/v2/gui/src/kodeverk/oppslag/K9KlageKodeverkoppslag.ts
@@ -178,4 +178,8 @@ export class FailingK9KlageKodeverkoppslag extends K9KlageKodeverkoppslag {
   constructor() {
     super({} as AlleKodeverdierSomObjektResponse);
   }
+
+  override finnObjektFraKilde(kodeverk: keyof EnumKodeverdierOppslag, kode: string): never {
+    throw new Error(`K9KlageKodeverkoppslag er ikke initialisert. Kan ikke slå opp ${kodeverk} med kode ${kode}.`);
+  }
 }

--- a/packages/v2/gui/src/kodeverk/oppslag/useK9Kodeverkoppslag.tsx
+++ b/packages/v2/gui/src/kodeverk/oppslag/useK9Kodeverkoppslag.tsx
@@ -13,7 +13,7 @@ export interface K9Kodeverkoppslag {
 }
 
 // Bruk context istadenfor denne hook. `useContext(K9KodeverkoppslagContext)`
-export const useK9Kodeverkoppslag = (): K9Kodeverkoppslag => {
+export const useK9Kodeverkoppslag = (hentKlageKodeverk: boolean): K9Kodeverkoppslag => {
   const k9sakClient = useContext(K9SakClientContext);
   const k9sakQuery = useQuery({
     queryKey: ['k9sak-kodeverkoppslag'],
@@ -25,9 +25,10 @@ export const useK9Kodeverkoppslag = (): K9Kodeverkoppslag => {
       const res = await kodeverk_alleKodeverdierSomObjekt();
       return res.data;
     },
+    enabled: hentKlageKodeverk,
   });
 
-  const isPending = k9sakQuery.isPending || k9klageQuery.isPending;
+  const isPending = k9sakQuery.isPending || (hentKlageKodeverk && k9klageQuery.isPending);
 
   if (isPending) {
     return {
@@ -45,6 +46,8 @@ export const useK9Kodeverkoppslag = (): K9Kodeverkoppslag => {
   return {
     isPending,
     k9sak: new K9SakKodeverkoppslag(k9sakQuery.data),
-    k9klage: new K9KlageKodeverkoppslag(k9klageQuery.data),
+    k9klage: k9klageQuery.isPending
+      ? new FailingK9KlageKodeverkoppslag()
+      : new K9KlageKodeverkoppslag(k9klageQuery.data),
   };
 };


### PR DESCRIPTION
## Bakgrunn

verdikjede test for frontend feila etter at kodeverkoppslag for k9-klage vart lagt til. På grunn av at k9-klage backend ikkje er tilgjengeleg i verdikjedetest for frontend.

## Løysing

Unngår å crashe heile frontend når k9-klage backend er utilgjengeleg (i test eller ved driftsfeil).