### PR TITLE
TSFF-1637 - Viser ikke visningsnavn dersom førstgangsbehandling

### DIFF
--- a/packages/v2/gui/src/sak/behandling-velger/components/BehandlingPicker.tsx
+++ b/packages/v2/gui/src/sak/behandling-velger/components/BehandlingPicker.tsx
@@ -74,7 +74,11 @@ const renderListItems = ({
         >
           <BehandlingPickerItemContent
             behandling={behandling}
-            behandlingTypeNavn={behandling.visningsnavn || getBehandlingNavn(behandling.type, kodeverkNavnFraKode)}
+            behandlingTypeNavn={
+              behandling.type !== BehandlingDtoType.FØRSTEGANGSSØKNAD && behandling.visningsnavn
+                ? behandling.visningsnavn
+                : getBehandlingNavn(behandling.type, kodeverkNavnFraKode)
+            }
             erAutomatiskRevurdering={erAutomatiskBehandlet(behandling)}
             søknadsperioder={søknadsperioderFraBehandling}
             index={sorterteOgFiltrerteBehandlinger.length - index}
@@ -328,7 +332,9 @@ const BehandlingPicker = ({
           }
           behandlingsårsaker={getÅrsaksliste()}
           behandlingTypeNavn={
-            valgtBehandling.visningsnavn || getBehandlingNavn(valgtBehandling.type, kodeverkNavnFraKode)
+            valgtBehandling.type !== BehandlingDtoType.FØRSTEGANGSSØKNAD && valgtBehandling.visningsnavn
+              ? valgtBehandling.visningsnavn
+              : getBehandlingNavn(valgtBehandling.type, kodeverkNavnFraKode)
           }
           behandlingTypeKode={valgtBehandling.type}
           søknadsperioder={søknadsperioderForValgtehandling}


### PR DESCRIPTION
### **Behov / Bakgrunn**
https://jira.adeo.no/browse/TSFF-1637
Alle behandlinger vises som Kontroll av inntekt - Må skille behandlingene

### **Løsning**
Sjekker om det er førstegangsbehandling og bruker ikke visningsnavn dersom det er tilfelle

### **Andre endringer**


### **Skjermbilder** (hvis relevant)
