### PR TITLE
Skru av refetchOnWindowFocus i QueryClient

### DIFF
--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/2-sykdom/SykdomUperiodisertForm.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/2-sykdom/SykdomUperiodisertForm.tsx
@@ -45,13 +45,7 @@ const SykdomUperiodisertForm = ({
   const { behandlingUuid } = useContext(SykdomOgOpplæringContext);
   const { setNyVurdering } = useContext(SykdomUperiodisertContext);
   const { refetchBehandling } = useContext(BehandlingContext);
-  const queryClient = useQueryClient({
-    defaultOptions: {
-      queries: {
-        refetchOnWindowFocus: false,
-      },
-    },
-  });
+  const queryClient = useQueryClient();
   const { data: vurderingBruktIAksjonspunkt } = useVurdertLangvarigSykdom(behandlingUuid);
   const { mutate: opprettSykdomsvurdering } = useOpprettSykdomsvurdering({
     onSuccess: async () => {


### PR DESCRIPTION
### **Behov / Bakgrunn**
Når token til klage går ut og vi prøver å refetche returneres 302 på kallene i stedet for 401. Det er ikke forventet, og vi får CORS-error fordi det redirectes til microsoft-login

### **Løsning**
Disable refetch som quickfix. Uansett ikke nødvendig at alle queries blir refetchet på nytt når man kommer inn igjen fra en annen tab.

### **Andre endringer**


### **Skjermbilder** (hvis relevant)
