### PR TITLE
Ung - endrer historikk til å støtte v2-variant

### DIFF
--- a/packages/ung/sak-app/behandlingsupport/historikk/HistorikkIndex.spec.tsx
+++ b/packages/ung/sak-app/behandlingsupport/historikk/HistorikkIndex.spec.tsx
@@ -1,4 +1,3 @@
-import HistorikkAktor from '@fpsak-frontend/kodeverk/src/historikkAktor';
 import { kjønn } from '@k9-sak-web/backend/k9sak/kodeverk/Kjønn.js';
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router';
@@ -25,20 +24,30 @@ describe('<HistorikkIndex>', () => {
     requestApi.mock(UngSakApiKeys.KODEVERK_KLAGE, {});
     requestApi.mock(UngSakApiKeys.HISTORY_UNGSAK, [
       {
-        opprettetTidspunkt: '2019-01-01',
-        historikkinnslagDeler: [{ skjermlenke: '123' }],
-        type: {
-          kode: 'FORSLAG_VEDTAK',
+        historikkinnslagUuid: '801e6e32-e3c4-4ec2-b4c5-3f3c7d1fd47f',
+        behandlingUuid: '5e0dfaff-3cf6-4877-860f-1b86b4eca51e',
+        aktør: {
+          type: { kode: 'VL', kodeverk: 'HISTORIKK_AKTOER' },
+          ident: null,
         },
-        aktoer: { kode: HistorikkAktor.VEDTAKSLOSNINGEN },
+        skjermlenke: { kode: 'VEDTAK', kodeverk: 'SKJERMLENKE_TYPE' },
+        opprettetTidspunkt: '2025-06-06T11:28:45.63222',
+        dokumenter: [],
+        tittel: null,
+        linjer: [{ type: 'TEKST', tekst: 'Vedtak er fattet: Innvilget.' }],
       },
       {
-        opprettetTidspunkt: '2019-01-06',
-        historikkinnslagDeler: [{ skjermlenke: '123' }],
-        type: {
-          kode: 'FORSLAG_VEDTAK',
+        historikkinnslagUuid: 'f402c588-ef15-438f-bf07-9b4325ed63e3',
+        behandlingUuid: 'b786e660-d2e0-4789-a28a-b58d34e2c3d5',
+        aktør: {
+          type: { kode: 'VL', kodeverk: 'HISTORIKK_AKTOER' },
+          ident: null,
         },
-        aktoer: { kode: HistorikkAktor.VEDTAKSLOSNINGEN },
+        skjermlenke: null,
+        opprettetTidspunkt: '2025-06-05T11:28:46.28268',
+        dokumenter: [],
+        tittel: 'Revurdering opprettet',
+        linjer: [{ type: 'TEKST', tekst: 'Kontroll av registerinntekt.' }],
       },
     ]);
 
@@ -48,7 +57,7 @@ describe('<HistorikkIndex>', () => {
       </MemoryRouter>,
     );
 
-    expect(screen.getByText(/06.01.2019/i)).toBeInTheDocument();
-    expect(screen.getByText(/01.01.2019/i)).toBeInTheDocument();
+    expect(screen.getByText(/06.06.2025/i)).toBeInTheDocument();
+    expect(screen.getByText(/05.06.2025/i)).toBeInTheDocument();
   });
 });

--- a/packages/ung/sak-app/behandlingsupport/historikk/HistorikkIndex.tsx
+++ b/packages/ung/sak-app/behandlingsupport/historikk/HistorikkIndex.tsx
@@ -1,32 +1,22 @@
-import * as Sentry from '@sentry/browser';
-import { useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
-import { useLocation } from 'react-router';
-
 import HistorikkSakIndex from '@fpsak-frontend/sak-historikk';
 import { LoadingPanel, usePrevious } from '@fpsak-frontend/shared-components';
-import { Historikkinnslag, KodeverkMedNavn } from '@k9-sak-web/types';
-
 import { Kjønn } from '@k9-sak-web/backend/k9sak/kodeverk/Kjønn.js';
-import FeatureTogglesContext from '@k9-sak-web/gui/featuretoggles/FeatureTogglesContext.js';
 import { useKodeverkContext } from '@k9-sak-web/gui/kodeverk/hooks/useKodeverkContext.js';
-import { HistorikkinnslagV2 } from '@k9-sak-web/gui/sak/historikk/tilbake/historikkinnslagTsTypeV2.js';
 import { Snakkeboble } from '@k9-sak-web/gui/sak/historikk/snakkeboble/Snakkeboble.js';
+import { HistorikkinnslagV2 } from '@k9-sak-web/gui/sak/historikk/tilbake/historikkinnslagTsTypeV2.js';
 import { isRequestNotDone } from '@k9-sak-web/rest-api-hooks/src/RestApiState';
 import ApplicationContextPath from '@k9-sak-web/sak-app/src/app/ApplicationContextPath';
-import { compareRenderedElementTexts } from '@k9-sak-web/sak-app/src/behandlingsupport/historikk/v1v2Sammenligningssjekk';
-import { HelpText, HStack, Switch } from '@navikt/ds-react';
+import { Historikkinnslag, KodeverkMedNavn } from '@k9-sak-web/types';
 import dayjs from 'dayjs';
+import { useCallback, useMemo } from 'react';
+import { useLocation } from 'react-router';
 import { createLocationForSkjermlenke, pathToBehandling } from '../../app/paths';
 import useGetEnabledApplikasjonContext from '../../app/useGetEnabledApplikasjonContext';
 import useBehandlingEndret from '../../behandling/useBehandlingEndret';
 import { restApiHooks, UngSakApiKeys } from '../../data/ungsakApi';
 
-type HistorikkMedTilbakekrevingIndikator = Historikkinnslag & {
-  erTilbakekreving?: boolean;
-  erKlage?: boolean;
-};
-
-type SakHistorikkInnslagV1 = Historikkinnslag & {
+type UngSakHistorikkinnslagV2 = HistorikkinnslagV2 & {
+  historikkinnslagUuid?: string;
   erKlage?: never;
   erTilbakekreving?: never;
   erSak: boolean;
@@ -38,38 +28,21 @@ type KlageHistorikkInnslagV1 = Historikkinnslag & {
   erSak?: never;
 };
 
-type TilbakeHistorikkInnslagV2 = HistorikkinnslagV2 & {
+type TilbakeHistorikkInnslagV1 = Historikkinnslag & {
   erKlage?: never;
   erTilbakekreving: boolean;
   erSak?: never;
 };
 
-type UlikeHistorikkinnslagTyper = SakHistorikkInnslagV1 | KlageHistorikkInnslagV1 | TilbakeHistorikkInnslagV2;
-
-const sortAndTagTilbakekrevingOgKlage = (
-  historikkK9sak: Historikkinnslag[] = [],
-  historikkTilbake: Historikkinnslag[] = [],
-  historikkKlage: Historikkinnslag[] = [],
-): HistorikkMedTilbakekrevingIndikator[] => {
-  const historikkFraTilbakekrevingMedMarkor = historikkTilbake.map(ht => ({
-    ...ht,
-    erTilbakekreving: true,
-  }));
-  const historikkFraKlageMedMarkor = historikkKlage.map(ht => ({
-    ...ht,
-    erKlage: true,
-  }));
-  return historikkK9sak
-    .concat(historikkFraTilbakekrevingMedMarkor)
-    .concat(historikkFraKlageMedMarkor)
-    .sort((a, b) => dayjs(b.opprettetTidspunkt).diff(dayjs(a.opprettetTidspunkt)));
-};
+type UlikeHistorikkinnslagTyper = UngSakHistorikkinnslagV2 | KlageHistorikkInnslagV1 | TilbakeHistorikkInnslagV1;
 
 const sortAndTagUlikeHistorikkinnslagTyper = (
-  historikkK9sak: Historikkinnslag[] = [],
+  historikkK9sak: HistorikkinnslagV2[] = [],
+  historikkTilbake: Historikkinnslag[] = [],
   historikkKlage: Historikkinnslag[] = [],
 ): UlikeHistorikkinnslagTyper[] => {
   return [
+    ...historikkTilbake.map(v => ({ ...v, erTilbakekreving: true })),
     ...historikkKlage.map(v => ({ ...v, erKlage: true })),
     ...historikkK9sak.map(v => ({ ...v, erSak: true })),
   ].toSorted((a, b) => dayjs(b.opprettetTidspunkt).diff(a.opprettetTidspunkt));
@@ -88,11 +61,8 @@ interface OwnProps {
  * Container komponent. Har ansvar for å hente historiken for en fagsak fra state og vise den
  */
 const HistorikkIndex = ({ saksnummer, behandlingId, behandlingVersjon, kjønn }: OwnProps) => {
-  const featureToggles = useContext(FeatureTogglesContext);
-  const [visV2, setVisV2] = useState(featureToggles?.['HISTORIKK_V2_VIS'] === true); // Rendra historikk innslag v2 skal visast (ikkje berre samanliknast)
   const enabledApplicationContexts = useGetEnabledApplikasjonContext();
   const { getKodeverkNavnFraKodeFn } = useKodeverkContext();
-  const compareTimeoutIdRef = useRef(0);
 
   const alleKodeverkK9Sak = restApiHooks.useGlobalStateRestApiData<{ [key: string]: KodeverkMedNavn[] }>(
     UngSakApiKeys.KODEVERK,
@@ -110,7 +80,7 @@ const HistorikkIndex = ({ saksnummer, behandlingId, behandlingVersjon, kjønn }:
       ...location,
       pathname: pathToBehandling(saksnummer, behandlingId),
     }),
-    [location],
+    [location, saksnummer],
   );
 
   const skalBrukeFpTilbakeHistorikk = enabledApplicationContexts.includes(ApplicationContextPath.TILBAKE);
@@ -120,7 +90,7 @@ const HistorikkIndex = ({ saksnummer, behandlingId, behandlingVersjon, kjønn }:
   const erBehandlingEndret: boolean =
     forrigeSaksnummer !== undefined && forrigeSaksnummer.length > 0 && erBehandlingEndretFraUndefined;
 
-  const { data: historikkK9Sak, state: historikkK9SakState } = restApiHooks.useRestApi<Historikkinnslag[]>(
+  const { data: historikkK9Sak, state: historikkK9SakState } = restApiHooks.useRestApi<HistorikkinnslagV2[]>(
     UngSakApiKeys.HISTORY_UNGSAK,
     { saksnummer },
     {
@@ -147,37 +117,13 @@ const HistorikkIndex = ({ saksnummer, behandlingId, behandlingVersjon, kjønn }:
     },
   );
 
-  const historikkInnslag = useMemo(
-    () => sortAndTagTilbakekrevingOgKlage(historikkK9Sak, historikkTilbake, historikkKlage),
-    [historikkK9Sak, historikkTilbake, historikkKlage],
-  );
   const historikkInnslagV1V2 = useMemo(
-    () => sortAndTagUlikeHistorikkinnslagTyper(historikkK9Sak, historikkKlage),
-    [historikkK9Sak, historikkKlage],
+    () => sortAndTagUlikeHistorikkinnslagTyper(historikkK9Sak, historikkTilbake, historikkKlage),
+    [historikkK9Sak, historikkTilbake, historikkKlage],
   );
 
   const getTilbakeKodeverknavn = getKodeverkNavnFraKodeFn('kodeverkTilbake');
 
-  const v1HistorikkElementer = historikkInnslag.map(innslag => {
-    let alleKodeverk = alleKodeverkK9Sak;
-    if (innslag.erTilbakekreving) {
-      alleKodeverk = alleKodeverkTilbake;
-    }
-    if (innslag.erKlage) {
-      alleKodeverk = alleKodeverkKlage;
-    }
-    return (
-      <HistorikkSakIndex
-        key={innslag.opprettetTidspunkt + innslag.type.kode}
-        historikkinnslag={innslag}
-        saksnummer={saksnummer}
-        alleKodeverk={alleKodeverk}
-        erTilbakekreving={!!innslag.erTilbakekreving}
-        getBehandlingLocation={getBehandlingLocation}
-        createLocationForSkjermlenke={createLocationForSkjermlenke}
-      />
-    );
-  });
   const v2HistorikkElementer = historikkInnslagV1V2.map((innslag, idx) => {
     let alleKodeverk = alleKodeverkK9Sak;
     if (innslag.erTilbakekreving) {
@@ -186,11 +132,11 @@ const HistorikkIndex = ({ saksnummer, behandlingId, behandlingVersjon, kjønn }:
     if (innslag.erKlage) {
       alleKodeverk = alleKodeverkKlage;
     }
-    // tilbakekreving har her historikk innslag v2
-    if (innslag.erTilbakekreving) {
+    if (innslag.erSak) {
+      const key = innslag.historikkinnslagUuid ?? `${innslag.opprettetTidspunkt}-${innslag.aktør.ident}-${idx}`;
       return (
         <Snakkeboble
-          key={`${innslag.opprettetTidspunkt}-${innslag.aktør.ident}-${idx}`}
+          key={key}
           saksnummer={saksnummer}
           historikkInnslag={innslag}
           kjønn={kjønn}
@@ -199,7 +145,7 @@ const HistorikkIndex = ({ saksnummer, behandlingId, behandlingVersjon, kjønn }:
           behandlingLocation={getBehandlingLocation(behandlingId)}
         />
       );
-    } else if (innslag.erSak || innslag.erKlage) {
+    } else if (innslag.erKlage || innslag.erTilbakekreving) {
       return (
         <HistorikkSakIndex
           key={`${innslag.opprettetTidspunkt}-${innslag.aktoer.kode}-${idx}`}
@@ -221,51 +167,11 @@ const HistorikkIndex = ({ saksnummer, behandlingId, behandlingVersjon, kjønn }:
     (skalBrukeFpTilbakeHistorikk && isRequestNotDone(historikkTilbakeState)) ||
     (skalBrukeKlageHistorikk && isRequestNotDone(historikkKlageState));
 
-  // Samanlikning av v1 og v2 render resultat. Sjekker at alle ord rendra i v1 historikkinnslag også bli rendra i v2.
-  // (Uavhengig av rekkefølge på orda.) For å unngå fleire køyringer av sjekk pga re-rendering ved initiell lasting
-  // er køyring forsinka litt, med clearTimeout på forrige timeout id.
-  useEffect(() => {
-    if (compareTimeoutIdRef.current > 0) {
-      window.clearTimeout(compareTimeoutIdRef.current);
-    }
-    if (!isLoading) {
-      compareTimeoutIdRef.current = window.setTimeout(async () => {
-        try {
-          await compareRenderedElementTexts(historikkInnslag, v1HistorikkElementer, v2HistorikkElementer);
-        } catch (err) {
-          setVisV2(false);
-          Sentry.captureException(err, { level: 'warning' });
-        }
-      }, 1_000);
-    }
-  }, [isLoading, historikkInnslag, historikkInnslagV1V2]); // Ønsker bevisst å berre køyre samanlikningssjekk ein gang.
-
   if (isLoading) {
     return <LoadingPanel />;
   }
 
-  return (
-    <div className="grid gap-5">
-      <HStack align="center">
-        <Switch size="small" checked={visV2} onChange={ev => setVisV2(ev.target.checked)}>
-          Ny visning&nbsp;
-        </Switch>
-        <HelpText>
-          <p>Vi er i ferd med å gå over til nytt format/visning av historikk innslag.</p>
-          <p>I en overgangsperiode kan du med denne bryter bytte mellom ny og gammel visning.</p>
-          <p>
-            Ved å gjøre det kan du undersøke om ny visning har mangler, og melde fra om dette så vi kan korrigere evt
-            mangler før gammel visning forsvinner.
-          </p>
-          <p>
-            Bare noen av innslagene vil ha ny/gammel visning tilgjengelig samtidig, så ikke alle vil forandre seg når du
-            skrur på/av denne bryter.
-          </p>
-        </HelpText>
-      </HStack>
-      {visV2 ? v2HistorikkElementer : v1HistorikkElementer}
-    </div>
-  );
+  return <div className="grid gap-5">{v2HistorikkElementer}</div>;
 };
 
 export default HistorikkIndex;


### PR DESCRIPTION
### **Behov / Bakgrunn**
ung-sak har endret historikk til v2-formatet.

### **Løsning**
Tilpasser frontend til å støtte det nye formatet. Har ikke et endepunkt for v1 og et for v2 så viser ikke valg for å bytte mellom disse.

### **Andre endringer**


### **Skjermbilder** (hvis relevant)
