### PR TITLE
TSFF-1696 - Viser endret startdato i ungdomsytelsen

### DIFF
--- a/packages/v2/gui/src/prosess/ung-inngangsvilkår/UngInngangsvilkår.stories.tsx
+++ b/packages/v2/gui/src/prosess/ung-inngangsvilkår/UngInngangsvilkår.stories.tsx
@@ -53,7 +53,7 @@ export const InnvilgetAlderOgUngdomsprogram: Story = {
   },
 };
 
-export const InngilvetAlderOgUtmeldtUngdomsprogram: Story = {
+export const InnvilgetAlderOgUtmeldtUngdomsprogram: Story = {
   args: {
     vilkar: [
       {

--- a/packages/v2/gui/src/prosess/ung-inngangsvilkår/UngInngangsvilkår.stories.tsx
+++ b/packages/v2/gui/src/prosess/ung-inngangsvilkår/UngInngangsvilkår.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { expect } from 'storybook/test';
 import { UngInngangsvilkår } from './UngInngangsvilkår';
 
 const meta = {
@@ -45,6 +46,10 @@ export const InnvilgetAlderOgUngdomsprogram: Story = {
         ],
       },
     ],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Vilkåret er oppfylt 01.02.2025 - 30.01.2026')).toBeInTheDocument();
+    await expect(canvas.getByText('Deltaker meldt inn 01.02.2025')).toBeInTheDocument();
   },
 };
 
@@ -94,5 +99,145 @@ export const InngilvetAlderOgUtmeldtUngdomsprogram: Story = {
         ],
       },
     ],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Vilkåret er oppfylt 01.12.2024 - 30.11.2025')).toBeInTheDocument();
+    await expect(canvas.getByText('Deltaker meldt inn 01.12.2024')).toBeInTheDocument();
+    await expect(canvas.getByText('Deltaker meldt ut 30.11.2025')).toBeInTheDocument();
+  },
+};
+
+export const EndretOppstartsdatoUngdomsprogram: Story = {
+  args: {
+    vilkar: [
+      {
+        vilkarType: 'UNG_VK_1',
+        lovReferanse: 'Forskrift om ungdomsprogram og ungdomsprogramytelse § 3 bokstav a',
+        overstyrbar: false,
+        perioder: [
+          {
+            avslagKode: '',
+            merknadParametere: {},
+            vilkarStatus: 'OPPFYLT',
+            periode: {
+              fom: '2025-06-09',
+              tom: '2026-06-14',
+            },
+            begrunnelse: '',
+            vurderesIBehandlingen: true,
+            merknad: '-',
+          },
+        ],
+      },
+      {
+        vilkarType: 'UNG_VK_2',
+        lovReferanse: 'Forskrift om ungdomsprogram og ungdomsprogramytelse § 8',
+        overstyrbar: false,
+        perioder: [
+          {
+            avslagKode: '2002',
+            merknadParametere: {},
+            vilkarStatus: 'IKKE_OPPFYLT',
+            periode: {
+              fom: '2025-06-09',
+              tom: '2025-06-15',
+            },
+            begrunnelse: '',
+            vurderesIBehandlingen: true,
+            merknad: '-',
+          },
+          {
+            avslagKode: '',
+            merknadParametere: {},
+            vilkarStatus: 'OPPFYLT',
+            periode: {
+              fom: '2025-06-16',
+              tom: '2026-06-14',
+            },
+            begrunnelse: '',
+            vurderesIBehandlingen: true,
+            merknad: '-',
+          },
+        ],
+      },
+    ],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Vilkåret er oppfylt 09.06.2025 - 14.06.2026')).toBeInTheDocument();
+    await expect(canvas.getByText('Deltaker meldt inn 09.06.2025')).toBeInTheDocument();
+    await expect(canvas.getByText('Startdato er endret fra 09.06.2025 til 16.06.2025')).toBeInTheDocument();
+  },
+};
+
+export const EndretOppstartsdatoOgSåOpphørUngdomsprogram: Story = {
+  args: {
+    vilkar: [
+      {
+        vilkarType: 'UNG_VK_1',
+        lovReferanse: 'Forskrift om ungdomsprogram og ungdomsprogramytelse § 3 bokstav a',
+        overstyrbar: false,
+        perioder: [
+          {
+            avslagKode: '',
+            merknadParametere: {},
+            vilkarStatus: 'OPPFYLT',
+            periode: {
+              fom: '2025-06-09',
+              tom: '2026-06-14',
+            },
+            begrunnelse: '',
+            vurderesIBehandlingen: true,
+            merknad: '-',
+          },
+        ],
+      },
+      {
+        vilkarType: 'UNG_VK_2',
+        lovReferanse: 'Forskrift om ungdomsprogram og ungdomsprogramytelse § 8',
+        overstyrbar: false,
+        perioder: [
+          {
+            avslagKode: '2002',
+            merknadParametere: {},
+            vilkarStatus: 'IKKE_OPPFYLT',
+            periode: {
+              fom: '2025-06-09',
+              tom: '2025-06-15',
+            },
+            begrunnelse: '',
+            vurderesIBehandlingen: true,
+            merknad: '-',
+          },
+          {
+            avslagKode: '',
+            merknadParametere: {},
+            vilkarStatus: 'OPPFYLT',
+            periode: {
+              fom: '2025-06-16',
+              tom: '2026-06-14',
+            },
+            begrunnelse: '',
+            vurderesIBehandlingen: true,
+            merknad: '-',
+          },
+          {
+            avslagKode: '-',
+            merknadParametere: {},
+            vilkarStatus: 'IKKE_OPPFYLT',
+            periode: {
+              fom: '2025-06-16',
+              tom: '2026-06-15',
+            },
+            vurderesIBehandlingen: true,
+          },
+        ],
+      },
+    ],
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Vilkåret er oppfylt 09.06.2025 - 14.06.2026')).toBeInTheDocument();
+    await expect(canvas.getByText('Deltaker meldt inn 09.06.2025')).toBeInTheDocument();
+    await expect(canvas.getByText('Startdato er endret fra 09.06.2025 til 16.06.2025')).toBeInTheDocument();
+    await expect(canvas.getByText('Deltaker meldt ut 15.06.2026')).toBeInTheDocument();
   },
 };

--- a/packages/v2/gui/src/prosess/ung-inngangsvilkår/Ungdomsvilkår.tsx
+++ b/packages/v2/gui/src/prosess/ung-inngangsvilkår/Ungdomsvilkår.tsx
@@ -1,4 +1,8 @@
-import { VilkårPeriodeDtoVilkarStatus, type VilkårMedPerioderDto } from '@k9-sak-web/backend/ungsak/generated';
+import {
+  VilkårPeriodeDtoVilkarStatus,
+  VilkårResultatDtoAvslagsårsak,
+  type VilkårMedPerioderDto,
+} from '@k9-sak-web/backend/ungsak/generated';
 import { formatDate } from '@k9-sak-web/lib/dateUtils/dateUtils.js';
 import { CheckmarkCircleFillIcon, InformationSquareFillIcon } from '@navikt/aksel-icons';
 import { BodyShort, Box, Detail, Heading, HStack, VStack } from '@navikt/ds-react';
@@ -6,19 +10,41 @@ import { Lovreferanse } from '../../shared/lovreferanse/Lovreferanse';
 import styles from './ungInngangsvilkår.module.css';
 import { VilkårComponent } from './VilkårComponent';
 
+const VilkårHeadingSection = ({ lovreferanse }: { lovreferanse?: string }) => (
+  <HStack gap="4" align="baseline">
+    <Heading size="small" level="2">
+      I ungdomsprogrammet
+    </Heading>
+    {lovreferanse && (
+      <Box>
+        <Detail className={styles.lovreferanse}>
+          <Lovreferanse>{lovreferanse}</Lovreferanse>
+        </Detail>
+      </Box>
+    )}
+  </HStack>
+);
+
 interface UngdomsvilkårProps {
   vilkår: VilkårMedPerioderDto;
 }
 
 export const Ungdomsvilkår = ({ vilkår }: UngdomsvilkårProps) => {
-  const oppstartsperiode = vilkår?.perioder?.find(p => p.vilkarStatus === VilkårPeriodeDtoVilkarStatus.OPPFYLT);
-  const opphørsperiode = vilkår?.perioder?.find(p => p.vilkarStatus === VilkårPeriodeDtoVilkarStatus.IKKE_OPPFYLT);
-  const oppstartsdato = oppstartsperiode?.periode.fom;
-  const opphørsdato = opphørsperiode?.periode.tom;
+  const periodeMedEndretStartdato = vilkår?.perioder?.find(
+    periode =>
+      periode.vilkarStatus === VilkårPeriodeDtoVilkarStatus.IKKE_OPPFYLT &&
+      periode.avslagKode === VilkårResultatDtoAvslagsårsak.ENDRET_STARTDATO_UNGDOMSPROGRAM,
+  );
+  const periodeMedOpphør = vilkår?.perioder?.find(
+    periode =>
+      periode.vilkarStatus === VilkårPeriodeDtoVilkarStatus.IKKE_OPPFYLT &&
+      (periode.avslagKode === VilkårResultatDtoAvslagsårsak.UDEFINERT || periode.avslagKode == undefined),
+  );
+  const oppfyltPeriode = vilkår?.perioder?.find(p => p.vilkarStatus === VilkårPeriodeDtoVilkarStatus.OPPFYLT);
   return (
     <VilkårComponent>
       <VStack gap="6">
-        {opphørsperiode && (
+        {periodeMedOpphør && (
           <HStack gap="4">
             <InformationSquareFillIcon
               title="Deltagelse er opphørt"
@@ -26,23 +52,25 @@ export const Ungdomsvilkår = ({ vilkår }: UngdomsvilkårProps) => {
               style={{ color: 'var(--a-lightblue-700)' }}
             />
             <VStack gap="2">
-              <HStack gap="4" align="baseline">
-                <Heading size="small" level="2">
-                  I ungdomsprogrammet
-                </Heading>
-                {vilkår?.lovReferanse && (
-                  <Box>
-                    <Detail className={styles.lovreferanse}>
-                      <Lovreferanse>{vilkår.lovReferanse}</Lovreferanse>
-                    </Detail>
-                  </Box>
-                )}
-              </HStack>
-              {opphørsdato && <BodyShort size="small">{`Deltaker meldt ut ${formatDate(opphørsdato)}`}</BodyShort>}
+              <VilkårHeadingSection lovreferanse={vilkår?.lovReferanse} />
+              <BodyShort size="small">{`Deltaker meldt ut ${formatDate(periodeMedOpphør.periode.tom)}`}</BodyShort>
             </VStack>
           </HStack>
         )}
-        {oppstartsperiode && (
+        {periodeMedEndretStartdato && oppfyltPeriode && (
+          <HStack gap="4">
+            <InformationSquareFillIcon
+              title="Startdato er endret"
+              fontSize="1.75rem"
+              style={{ color: 'var(--a-lightblue-700)' }}
+            />
+            <VStack gap="2">
+              <VilkårHeadingSection lovreferanse={vilkår?.lovReferanse} />
+              <BodyShort size="small">{`Startdato er endret fra ${formatDate(periodeMedEndretStartdato.periode.fom)} til ${formatDate(oppfyltPeriode?.periode.fom)}`}</BodyShort>
+            </VStack>
+          </HStack>
+        )}
+        {oppfyltPeriode && (
           <HStack gap="4">
             <CheckmarkCircleFillIcon
               title="Vilkåret er oppfylt"
@@ -50,19 +78,8 @@ export const Ungdomsvilkår = ({ vilkår }: UngdomsvilkårProps) => {
               style={{ color: 'var(--a-surface-success)' }}
             />
             <VStack gap="2">
-              <HStack gap="4" align="baseline">
-                <Heading size="small" level="2">
-                  I ungdomsprogrammet
-                </Heading>
-                {vilkår?.lovReferanse && (
-                  <Box>
-                    <Detail className={styles.lovreferanse}>
-                      <Lovreferanse>{vilkår.lovReferanse}</Lovreferanse>
-                    </Detail>
-                  </Box>
-                )}
-              </HStack>
-              {oppstartsdato && <BodyShort size="small">{`Deltaker meldt inn ${formatDate(oppstartsdato)}`}</BodyShort>}
+              <VilkårHeadingSection lovreferanse={vilkår?.lovReferanse} />
+              <BodyShort size="small">{`Deltaker meldt inn ${formatDate(periodeMedEndretStartdato?.periode.fom || oppfyltPeriode.periode.fom)}`}</BodyShort>
             </VStack>
           </HStack>
         )}


### PR DESCRIPTION
### **Behov / Bakgrunn**
Inngangsvilkåret for ungdomsytelsen håndterer ikke visning av endret startdato.
https://jira.adeo.no/browse/TSFF-1696

### **Løsning**
Legger inn håndtering av endret startdato, med tilhørende stories og tester.

### **Andre endringer**


### **Skjermbilder** (hvis relevant)
