### PR TITLE
TSFF-1591: flipper rekkefølge for reisetid

### DIFF
--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/4-reisetid/ReisetidIndex.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/4-reisetid/ReisetidIndex.tsx
@@ -39,6 +39,7 @@ const ReisetidIndex = () => {
               valgtPeriode={valgtVurdering}
               perioder={vurderingsliste || []}
               onPeriodeClick={setValgtVurdering}
+              nyesteFørst={false}
             />
           </>
         )}

--- a/packages/v2/gui/src/shared/vurderingsperiode-navigasjon/PeriodeRad.tsx
+++ b/packages/v2/gui/src/shared/vurderingsperiode-navigasjon/PeriodeRad.tsx
@@ -3,7 +3,6 @@ import { Period } from '@navikt/ft-utils';
 import {
   Buildings3Icon,
   CheckmarkCircleFillIcon,
-  ChevronDownIcon,
   ChevronRightIcon,
   ExclamationmarkTriangleFillIcon,
   XMarkOctagonFillIcon,
@@ -88,7 +87,7 @@ export const RadDato = ({ perioder, active }: { perioder: Period[]; active: bool
 export const RadChevron = ({ active }: { active: boolean }) => {
   return (
     <div className="mr-4 float-right">
-      {active ? <ChevronRightIcon fontSize={24} /> : <ChevronDownIcon fontSize={24} />}
+      {active ? <ChevronRightIcon fontSize={24} /> : <ChevronRightIcon fontSize={24} className="opacity-50" />}
     </div>
   );
 };

--- a/packages/v2/gui/src/shared/vurderingsperiode-navigasjon/VurderingsperiodeNavigasjon.tsx
+++ b/packages/v2/gui/src/shared/vurderingsperiode-navigasjon/VurderingsperiodeNavigasjon.tsx
@@ -46,8 +46,25 @@ export interface VurderingslisteProps<T extends Vurderingselement = Vurderingsel
   customPeriodeRad?: (periode: T, onPeriodeClick: (periode: T) => void) => React.ReactNode;
   customPeriodeLabel?: string;
   title?: string;
+  nyesteFørst?: boolean;
 }
+const sortNyestFørst = (a: Vurderingselement, b: Vurderingselement) => {
+  const periodeA = a.perioder[0]?.fom;
+  const periodeB = b.perioder[0]?.fom;
+  if (periodeA && periodeB) {
+    return new Date(periodeB).getTime() - new Date(periodeA).getTime();
+  }
+  return 0;
+};
 
+const sortEldestFørst = (a: Vurderingselement, b: Vurderingselement) => {
+  const periodeA = a.perioder[0]?.fom;
+  const periodeB = b.perioder[0]?.fom;
+  if (periodeA && periodeB) {
+    return new Date(periodeA).getTime() - new Date(periodeB).getTime();
+  }
+  return 0;
+};
 /**
  * Navigasjon for perioder som må vurderes og er vurdert
  */
@@ -58,16 +75,10 @@ const Vurderingsnavigasjon = <T extends Vurderingselement = Vurderingselement>({
   customPeriodeRad,
   customPeriodeLabel,
   title = 'Alle perioder',
+  nyesteFørst = true,
 }: VurderingslisteProps<T>) => {
   // nyeste først
-  const sortedPerioder = perioder.sort((a, b) => {
-    const periodeA = a.perioder[0]?.fom;
-    const periodeB = b.perioder[0]?.fom;
-    if (periodeA && periodeB) {
-      return new Date(periodeB).getTime() - new Date(periodeA).getTime();
-    }
-    return 0;
-  });
+  const sortedPerioder = perioder.sort(nyesteFørst ? sortNyestFørst : sortEldestFørst);
   const perioderSomSkalVurderes = sortedPerioder.filter(periode => periode.resultat === Resultat.MÅ_VURDERES);
   const perioderSomErVurdert = sortedPerioder.filter(periode => periode.resultat !== Resultat.MÅ_VURDERES);
   const allePerioder = useMemo(


### PR DESCRIPTION
### **Behov / Bakgrunn**
Det ble nevnt på brukertest at det var ønskelig å sortere reisetid med eldste først

### **Løsning**
Viser reisetid-perioder eldste først


### **Andre endringer**
Chevron skal alltid peke til høyre

### **Skjermbilder** (hvis relevant)
