### PR TITLE
fix/ung-beregning fikser formattering i inputfelt ved preutfylling

### DIFF
--- a/packages/v2/gui/src/prosess/ung-beregning/ArbeidOgInntekt.tsx
+++ b/packages/v2/gui/src/prosess/ung-beregning/ArbeidOgInntekt.tsx
@@ -8,7 +8,7 @@ import { aksjonspunktCodes } from '@k9-sak-web/backend/ungsak/kodeverk/Aksjonspu
 import { CheckmarkCircleFillIcon, ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';
 import { Bleed, BodyShort, Box, HStack, Label, Table } from '@navikt/ds-react';
 import { Form } from '@navikt/ft-form-hooks';
-import { removeSpacesFromNumber } from '@navikt/ft-utils';
+import { parseCurrencyInput, removeSpacesFromNumber } from '@navikt/ft-utils';
 import { useState } from 'react';
 import { useFieldArray, useForm } from 'react-hook-form';
 import PeriodLabel from '../../shared/periodLabel/PeriodLabel';
@@ -36,7 +36,7 @@ const buildInitialValues = (inntektKontrollperioder: Array<KontrollerInntektPeri
     perioder:
       inntektKontrollperioder.map(periode => {
         return {
-          fastsattInntekt: periode.fastsattInntekt != null ? `${periode.fastsattInntekt}` : '',
+          fastsattInntekt: periode.fastsattInntekt != null ? `${parseCurrencyInput(periode.fastsattInntekt)}` : '',
           valg: periode.valg ?? '',
           begrunnelse: periode.begrunnelse ?? '',
           periode: periode.periode,

--- a/packages/v2/gui/src/prosess/ung-beregning/UngBeregning.stories.tsx
+++ b/packages/v2/gui/src/prosess/ung-beregning/UngBeregning.stories.tsx
@@ -14,7 +14,7 @@ type Story = StoryObj<typeof meta>;
 
 export const DefaultStory: Story = {
   args: {
-    behandling: { uuid: '123' },
+    behandling: { uuid: '123', versjon: 1 },
     api,
     barn: [
       {

--- a/packages/v2/gui/src/prosess/ung-beregning/UngBeregning.tsx
+++ b/packages/v2/gui/src/prosess/ung-beregning/UngBeregning.tsx
@@ -14,7 +14,7 @@ import type { Barn } from './types/Barn';
 import type { UngBeregningBackendApiType } from './UngBeregningBackendApiType';
 
 interface Props {
-  behandling: { uuid: string };
+  behandling: { uuid: string; versjon: number };
   api: UngBeregningBackendApiType;
   barn: Barn[];
   submitCallback: (data: unknown) => Promise<any>;
@@ -47,7 +47,7 @@ const UngBeregning = ({ api, behandling, barn, submitCallback, aksjonspunkter, i
     isLoading: kontrollInntektIsLoading,
     isError: kontrollInntektIsError,
   } = useQuery({
-    queryKey: ['kontrollInntekt', behandling.uuid],
+    queryKey: ['kontrollInntekt', behandling.uuid, behandling.versjon],
     queryFn: () => api.getKontrollerInntekt(behandling.uuid),
     select: sortInntekt,
   });


### PR DESCRIPTION
### **Behov / Bakgrunn**
Preutfylte tall blir ikke formatert i inputfelt før man begynner å redigere

### **Løsning**
Fikser at det alltid er formatert

### **Andre endringer**
Tall i inputfelt ble ikke oppdatert når man gikk tilbake til panelet etter submit. Rettet dette ved å hente data på nytt dersom versjonsnummeret i behandling er endret.

### **Skjermbilder** (hvis relevant)
