### PR TITLE
historikk: Auke tidsforsinkelse for samanlikningssjekk.

### DIFF
--- a/packages/sak-app/src/behandlingsupport/historikk/HistorikkIndex.tsx
+++ b/packages/sak-app/src/behandlingsupport/historikk/HistorikkIndex.tsx
@@ -281,7 +281,7 @@ const HistorikkIndex = ({ saksnummer, behandlingId, behandlingVersjon, kjønn }:
             compareDone.current = true;
           }
         }
-      }, 1_000);
+      }, 3_000);
     }
   }, [isLoading, etablerteHistorikkInnslag, nyeHistorikkInnslag, etablerteHistorikkElementer, nyeHistorikkElementer]); // Ønsker bevisst å berre køyre samanlikningssjekk ein gang.
 


### PR DESCRIPTION
### **Behov / Bakgrunn**

Det har blitt rapportert falske differanser i tal element av og til. Ser ut til å vere ein race condition når det nettopp har skjedd endring på sak som blir vist, for ved ny visning er der ingen differanse.

### **Løsning**

Auke derfor tidsforsinkelse for start av samanlikningssjekk for å sjå om dette kan hjelpe for å unngå falske feilrapporter.
