### PR TITLE
Vise siste dato og ett år tilbake i tid som utgangspunkt. Utvide max zoom 

### DIFF
--- a/packages/prosess-tilkjent-ytelse/src/components/TilkjentYtelse.tsx
+++ b/packages/prosess-tilkjent-ytelse/src/components/TilkjentYtelse.tsx
@@ -17,22 +17,23 @@ export type PeriodeMedId = BeregningsresultatPeriodeDto & { id: number };
 const parseDateString = (dateString: string) => initializeDate(dateString, ISO_DATE_FORMAT).toDate();
 
 const getOptions = (nyePerioder: PeriodeMedId[]) => {
-  const firstPeriod = nyePerioder[0];
   const lastPeriod = nyePerioder[nyePerioder.length - 1];
+  const FIVE_YEARS_IN_MS = 1000 * 60 * 60 * 24 * 365 * 5;
+  const ONE_MONTH_IN_MS = 1000 * 60 * 60 * 24 * 30;
 
   return {
-    end: moment(lastPeriod?.tom).add(2, 'days').toDate(),
+    end: moment(lastPeriod?.tom).add(1, 'days').toDate(),
     locale: moment.locale('nb'),
     margin: { item: 10 },
     moment,
     orientation: { axis: 'top' },
     showCurrentTime: false,
     stack: false,
-    start: moment(firstPeriod?.fom).subtract(1, 'days').toDate(),
+    start: moment(lastPeriod?.fom).subtract(1, 'year').toDate(),
     tooltip: { followMouse: true },
     width: '100%',
-    zoomMax: 1000 * 60 * 60 * 24 * 31 * 40,
-    zoomMin: 1000 * 60 * 60 * 24 * 30,
+    zoomMax: FIVE_YEARS_IN_MS,
+    zoomMin: ONE_MONTH_IN_MS,
   };
 };
 


### PR DESCRIPTION
**Bakgrunn**
Bakgrunnen for disse endringene er at saksbehandlerne har meldt ifra om saker som strekker seg utenfor utenfor det som var max zoom ut på tidslinjen, og at man måtte sidescrolle for å finne de nye periodene. 

**Løsning**
Øke max zoom ut på tidslinje. Initielt vise siste periode og et år tilbake i tid, og så kan man heller zoome ut hvis man trenger å gå flere år bak i tid