### PR TITLE
Klage klient v3.1

### DIFF
--- a/packages/prosess-vedtak/src/components/VedtakHelper.spec.tsx
+++ b/packages/prosess-vedtak/src/components/VedtakHelper.spec.tsx
@@ -1,5 +1,5 @@
 import behandlingType from '@fpsak-frontend/kodeverk/src/behandlingType';
-import { BehandlingDtoBehandlingResultatType as klageBehandlingsresultat } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import { klage_kodeverk_behandling_BehandlingResultatType as klageBehandlingsresultat } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import { fagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
 import {
   AvslagsårsakPrPeriodeDto,

--- a/packages/prosess-vedtak/src/components/VedtakHelper.tsx
+++ b/packages/prosess-vedtak/src/components/VedtakHelper.tsx
@@ -1,6 +1,6 @@
 import {
-  BehandlingDtoType as KlageBehandlingDtoType,
-  BehandlingDtoBehandlingResultatType as klageBehandlingsresultat,
+  klage_kodeverk_behandling_BehandlingType as BehandlingType,
+  klage_kodeverk_behandling_BehandlingResultatType as BehandlingResultatType,
 } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import { FagsakYtelsesType, fagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
 import { erFagytelseTypeUtvidetRett } from '@k9-sak-web/gui/utils/utvidetRettHjelpfunksjoner.js';
@@ -18,12 +18,9 @@ import VedtakSimuleringResultat from '../types/VedtakSimuleringResultat';
 
 const erTilbakekrevingType = (type: string | undefined | { kode: string }) => {
   if (typeof type === 'string') {
-    return KlageBehandlingDtoType.TILBAKEKREVING === type || KlageBehandlingDtoType.REVURDERING_TILBAKEKREVING === type;
+    return BehandlingType.TILBAKEKREVING === type || BehandlingType.REVURDERING_TILBAKEKREVING === type;
   }
-  return (
-    KlageBehandlingDtoType.TILBAKEKREVING === type?.kode ||
-    KlageBehandlingDtoType.REVURDERING_TILBAKEKREVING === type?.kode
-  );
+  return BehandlingType.TILBAKEKREVING === type?.kode || BehandlingType.REVURDERING_TILBAKEKREVING === type?.kode;
 };
 
 const tilbakekrevingMedInntrekk = (
@@ -52,10 +49,10 @@ export const findTilbakekrevingText = (props: {
 };
 
 export const findDelvisInnvilgetResultatText = (behandlingResultatTypeKode: string, ytelseType: FagsakYtelsesType) => {
-  if (behandlingResultatTypeKode === klageBehandlingsresultat.KLAGE_YTELSESVEDTAK_STADFESTET) {
+  if (behandlingResultatTypeKode === BehandlingResultatType.KLAGE_YTELSESVEDTAK_STADFESTET) {
     return 'VedtakForm.ResultatOpprettholdVedtak';
   }
-  if (behandlingResultatTypeKode === klageBehandlingsresultat.KLAGE_MEDHOLD) {
+  if (behandlingResultatTypeKode === BehandlingResultatType.KLAGE_MEDHOLD) {
     return 'VedtakForm.ResultatKlageMedhold';
   }
 
@@ -83,10 +80,10 @@ export const findDelvisInnvilgetResultatText = (behandlingResultatTypeKode: stri
 };
 
 export const findInnvilgetResultatText = (behandlingResultatTypeKode: string, ytelseType: FagsakYtelsesType) => {
-  if (behandlingResultatTypeKode === klageBehandlingsresultat.KLAGE_YTELSESVEDTAK_STADFESTET) {
+  if (behandlingResultatTypeKode === BehandlingResultatType.KLAGE_YTELSESVEDTAK_STADFESTET) {
     return 'VedtakForm.ResultatOpprettholdVedtak';
   }
-  if (behandlingResultatTypeKode === klageBehandlingsresultat.KLAGE_MEDHOLD) {
+  if (behandlingResultatTypeKode === BehandlingResultatType.KLAGE_MEDHOLD) {
     return 'VedtakForm.ResultatKlageMedhold';
   }
 
@@ -114,10 +111,10 @@ export const findInnvilgetResultatText = (behandlingResultatTypeKode: string, yt
 };
 
 export const findAvslagResultatText = (behandlingResultatTypeKode: string, ytelseType: FagsakYtelsesType) => {
-  if (behandlingResultatTypeKode === klageBehandlingsresultat.KLAGE_YTELSESVEDTAK_OPPHEVET) {
+  if (behandlingResultatTypeKode === BehandlingResultatType.KLAGE_YTELSESVEDTAK_OPPHEVET) {
     return 'VedtakForm.ResultatKlageYtelsesvedtakOpphevet';
   }
-  if (behandlingResultatTypeKode === klageBehandlingsresultat.KLAGE_AVVIST) {
+  if (behandlingResultatTypeKode === BehandlingResultatType.KLAGE_AVVIST) {
     return 'VedtakForm.ResultatKlageAvvist';
   }
 

--- a/packages/sak-app/src/behandlingsupport/totrinnskontroll/BeslutterModalIndex.tsx
+++ b/packages/sak-app/src/behandlingsupport/totrinnskontroll/BeslutterModalIndex.tsx
@@ -5,7 +5,7 @@ import { FagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtel
 import { RestApiState } from '@k9-sak-web/rest-api-hooks';
 import { BehandlingAppKontekst } from '@k9-sak-web/types';
 
-import { BehandlingDtoType } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import { klage_kodeverk_behandling_BehandlingType as KlageBehandlingType } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import FatterVedtakTotrinnskontrollModalSakIndex from '@k9-sak-web/gui/sak/totrinnskontroll/FatterVedtakTotrinnskontrollModalSakIndex.js';
 import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 import { getPathToK9Los } from '../../app/paths';
@@ -38,7 +38,7 @@ const BeslutterModalIndex = ({ behandling, fagsakYtelseType, allAksjonspunktAppr
   }
 
   const v2Behandling = JSON.parse(JSON.stringify(behandling));
-  konverterKodeverkTilKode(v2Behandling, behandling.type.kode === BehandlingDtoType.TILBAKEKREVING);
+  konverterKodeverkTilKode(v2Behandling, behandling.type.kode === KlageBehandlingType.TILBAKEKREVING);
 
   return (
     <FatterVedtakTotrinnskontrollModalSakIndex

--- a/packages/sak-app/src/fagsakprofile/FagsakProfileIndex.tsx
+++ b/packages/sak-app/src/fagsakprofile/FagsakProfileIndex.tsx
@@ -1,5 +1,5 @@
 import { LoadingPanel, requireProps } from '@fpsak-frontend/shared-components';
-import { BehandlingDtoType } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import { klage_kodeverk_behandling_BehandlingType as KlageBehandlingType } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import { K9SakClientContext } from '@k9-sak-web/gui/app/K9SakClientContext.js';
 import BehandlingVelgerBackendClient from '@k9-sak-web/gui/sak/behandling-velger/BehandlingVelgerBackendClient.js';
 import BehandlingVelgerSakV2 from '@k9-sak-web/gui/sak/behandling-velger/BehandlingVelgerSakIndex.js';
@@ -119,7 +119,7 @@ export const FagsakProfileIndex = ({
             const behandlingerV2 = JSON.parse(JSON.stringify(alleBehandlinger));
             const fagsakV2 = JSON.parse(JSON.stringify(fagsak));
             behandlingerV2.forEach(behandling => {
-              const erTilbakekreving = behandling.type.kode === BehandlingDtoType.TILBAKEKREVING;
+              const erTilbakekreving = behandling.type.kode === KlageBehandlingType.TILBAKEKREVING;
               konverterKodeverkTilKode(behandling, erTilbakekreving);
             });
             konverterKodeverkTilKode(fagsakV2, false);

--- a/packages/ung/sak-app/behandlingsupport/totrinnskontroll/BeslutterModalIndex.tsx
+++ b/packages/ung/sak-app/behandlingsupport/totrinnskontroll/BeslutterModalIndex.tsx
@@ -5,7 +5,7 @@ import { FagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtel
 import { RestApiState } from '@k9-sak-web/rest-api-hooks';
 import { BehandlingAppKontekst } from '@k9-sak-web/types';
 
-import { BehandlingDtoType } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import { klage_kodeverk_behandling_BehandlingType as KlageBehandlingType } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import FatterVedtakTotrinnskontrollModalSakIndex from '@k9-sak-web/gui/sak/totrinnskontroll/FatterVedtakTotrinnskontrollModalSakIndex.js';
 import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 import { getPathToK9Los } from '../../app/paths';
@@ -38,7 +38,7 @@ const BeslutterModalIndex = ({ behandling, fagsakYtelseType, allAksjonspunktAppr
   }
 
   const v2Behandling = JSON.parse(JSON.stringify(behandling));
-  konverterKodeverkTilKode(v2Behandling, behandling.type.kode === BehandlingDtoType.TILBAKEKREVING);
+  konverterKodeverkTilKode(v2Behandling, behandling.type.kode === KlageBehandlingType.TILBAKEKREVING);
 
   return (
     <FatterVedtakTotrinnskontrollModalSakIndex

--- a/packages/ung/sak-app/fagsakprofile/FagsakProfileIndex.tsx
+++ b/packages/ung/sak-app/fagsakprofile/FagsakProfileIndex.tsx
@@ -1,5 +1,5 @@
 import { LoadingPanel, requireProps } from '@fpsak-frontend/shared-components';
-import { BehandlingDtoType } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import { klage_kodeverk_behandling_BehandlingType as KlageBehandlingType } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import { getUngSakClient } from '@k9-sak-web/backend/ungsak/client';
 import BehandlingVelgerBackendClient from '@k9-sak-web/gui/sak/behandling-velger/BehandlingVelgerBackendClient.js';
 import BehandlingVelgerSakV2 from '@k9-sak-web/gui/sak/behandling-velger/BehandlingVelgerSakIndex.js';
@@ -118,7 +118,7 @@ export const FagsakProfileIndex = ({
             const behandlingerV2 = JSON.parse(JSON.stringify(alleBehandlinger));
             const fagsakV2 = JSON.parse(JSON.stringify(fagsak));
             const erTilbakekreving = alleBehandlinger.some(
-              behandling => behandling.type.kode === BehandlingDtoType.TILBAKEKREVING,
+              behandling => behandling.type.kode === KlageBehandlingType.TILBAKEKREVING,
             );
             konverterKodeverkTilKode(behandlingerV2, erTilbakekreving);
             konverterKodeverkTilKode(fagsakV2, erTilbakekreving);

--- a/packages/v2/backend/package.json
+++ b/packages/v2/backend/package.json
@@ -22,7 +22,7 @@
     "./ungsak/kodeverk/*": "./src/ungsak/kodeverk/*"
   },
   "dependencies": {
-    "@navikt/k9-klage-typescript-client": "3.0.20250530164140",
+    "@navikt/k9-klage-typescript-client": "3.1.20250806103540",
     "@navikt/k9-sak-typescript-client": "2.0.20250731124543",
     "@navikt/ung-sak-typescript-client": "0.2.20250728105557"
   },

--- a/packages/v2/backend/src/k9klage/errorhandling/errorData.ts
+++ b/packages/v2/backend/src/k9klage/errorhandling/errorData.ts
@@ -1,4 +1,7 @@
-import { type FeilDto, type FeltFeilDto } from '../generated/types.js';
+import {
+  type klage_kontrakt_FeilDto as FeilDto,
+  type klage_kontrakt_FeltFeilDto as FeltFeilDto,
+} from '../generated/types.js';
 import { isObject } from '../../typecheck/isObject.js';
 import { isString } from '../../typecheck/isString.js';
 import { isArray } from '../../typecheck/isArray.js';

--- a/packages/v2/backend/src/k9klage/kodeverk/Klagevurdering.ts
+++ b/packages/v2/backend/src/k9klage/kodeverk/Klagevurdering.ts
@@ -1,4 +1,1 @@
-import { AbacKlageVurderingResultatAksjonspunktMellomlagringDtoKlageVurdering } from '@navikt/k9-klage-typescript-client/types';
-
-export type KlagevurderingType = AbacKlageVurderingResultatAksjonspunktMellomlagringDtoKlageVurdering;
-export const Klagevurdering = AbacKlageVurderingResultatAksjonspunktMellomlagringDtoKlageVurdering;
+export { klage_kodeverk_vedtak_KlageVurdering as Klagevurdering } from '@navikt/k9-klage-typescript-client/types';

--- a/packages/v2/backend/src/k9klage/kodeverk/KlagevurderingOmgjør.spec.ts
+++ b/packages/v2/backend/src/k9klage/kodeverk/KlagevurderingOmgjør.spec.ts
@@ -1,0 +1,13 @@
+import { isKlagevurderingOmgjørType, KlagevurderingOmgjør } from './KlagevurderingOmgjør.ts';
+
+describe('isKlagevurderingOmgjørType', () => {
+  it('skal returnere true for enum verdier', () => {
+    expect(isKlagevurderingOmgjørType(KlagevurderingOmgjør.GUNST_MEDHOLD_I_KLAGE)).toEqual(true);
+    expect(isKlagevurderingOmgjørType(KlagevurderingOmgjør.UDEFINERT)).toEqual(true);
+  });
+  it('skal returnere false for alt anna', () => {
+    expect(isKlagevurderingOmgjørType('ANNA')).toEqual(false);
+    expect(isKlagevurderingOmgjørType('')).toEqual(false);
+    expect(isKlagevurderingOmgjørType(undefined)).toEqual(false);
+  });
+});

--- a/packages/v2/backend/src/k9klage/kodeverk/KlagevurderingOmgjør.ts
+++ b/packages/v2/backend/src/k9klage/kodeverk/KlagevurderingOmgjør.ts
@@ -1,4 +1,11 @@
-import { AbacKlageVurderingResultatAksjonspunktMellomlagringDtoKlageVurderingOmgjoer } from '@navikt/k9-klage-typescript-client/types';
+import {
+  type klage_kodeverk_vedtak_KlageVurderingOmgjør as KlagevurderingOmgjørT,
+  klage_kodeverk_vedtak_KlageVurderingOmgjør as KlagevurderingOmgjørV,
+} from '@navikt/k9-klage-typescript-client/types';
 
-export type KlagevurderingOmgjørType = AbacKlageVurderingResultatAksjonspunktMellomlagringDtoKlageVurderingOmgjoer;
-export const KlagevurderingOmgjør = AbacKlageVurderingResultatAksjonspunktMellomlagringDtoKlageVurderingOmgjoer;
+export type KlagevurderingOmgjørType = KlagevurderingOmgjørT;
+
+export const KlagevurderingOmgjør = KlagevurderingOmgjørV;
+
+export const isKlagevurderingOmgjørType = (txt?: string): txt is KlagevurderingOmgjørT =>
+  txt != null && Object.values(KlagevurderingOmgjør).some(v => v === txt);

--- a/packages/v2/backend/src/k9klage/kodeverk/behandling/BehandlingType.ts
+++ b/packages/v2/backend/src/k9klage/kodeverk/behandling/BehandlingType.ts
@@ -1,8 +1,11 @@
 import type { Kodeverk } from '../../../shared/Kodeverk.js';
-import { type BehandlingDtoType as uniontype, BehandlingDtoType } from '../../generated/types.js';
+import {
+  type klage_kodeverk_behandling_BehandlingType as uniontype,
+  klage_kodeverk_behandling_BehandlingType,
+} from '../../generated/types.js';
 
 export type BehandlingType = uniontype;
 
 export type BehandlingTypeKodeverk = Kodeverk<BehandlingType, 'BEHANDLING_TYPE'>;
 
-export const behandlingType = BehandlingDtoType;
+export const behandlingType = klage_kodeverk_behandling_BehandlingType;

--- a/packages/v2/gui/src/kodeverk/oppslag/K9KlageKodeverkoppslag.spec.ts
+++ b/packages/v2/gui/src/kodeverk/oppslag/K9KlageKodeverkoppslag.spec.ts
@@ -1,7 +1,7 @@
 import { oppslagKodeverkSomObjektK9Klage } from '../mocks/oppslagKodeverkSomObjektK9Klage.js';
 import {
-  BehandlingDtoStatus,
-  type KodeverdiSomObjektBehandlingStatus,
+  klage_kodeverk_behandling_BehandlingStatus as BehandlingStatus,
+  type klage_web_app_tjenester_kodeverk_dto_KodeverdiSomObjektKlage_kodeverk_behandling_BehandlingStatus as KodeverdiSomObjektBehandlingStatus,
 } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import { K9KlageKodeverkoppslag } from './K9KlageKodeverkoppslag.js';
 import { OrUndefined } from './GeneriskKodeverkoppslag.js';
@@ -9,14 +9,14 @@ import { OrUndefined } from './GeneriskKodeverkoppslag.js';
 describe('Kodeverkoppslag', () => {
   const oppslag = new K9KlageKodeverkoppslag(oppslagKodeverkSomObjektK9Klage);
   const behandlingStatusOppslagResultat: KodeverdiSomObjektBehandlingStatus = {
-    kode: BehandlingDtoStatus.OPPRETTET,
+    kode: BehandlingStatus.OPPRETTET,
     kodeverk: 'BEHANDLING_STATUS',
     navn: 'Opprettet',
     kilde: 'OPPRE',
   };
   it('skal returnere kodeverdi objekt for gitt kodeverdi enum', () => {
     const found: KodeverdiSomObjektBehandlingStatus | undefined = oppslag.behandlingStatuser(
-      BehandlingDtoStatus.OPPRETTET,
+      BehandlingStatus.OPPRETTET,
       'or undefined',
     );
     expect(found).toEqual(behandlingStatusOppslagResultat);
@@ -34,7 +34,7 @@ describe('Kodeverkoppslag', () => {
   });
 
   it('skal ikkje ha undefined som retur type', () => {
-    const found: KodeverdiSomObjektBehandlingStatus = oppslag.behandlingStatuser(BehandlingDtoStatus.OPPRETTET);
+    const found: KodeverdiSomObjektBehandlingStatus = oppslag.behandlingStatuser(BehandlingStatus.OPPRETTET);
     expect(found).toEqual(behandlingStatusOppslagResultat);
   });
 

--- a/packages/v2/gui/src/sak/historikk/historikkTypeBerikning.ts
+++ b/packages/v2/gui/src/sak/historikk/historikkTypeBerikning.ts
@@ -1,15 +1,15 @@
 import type { HistorikkinnslagDtoV2 } from '@k9-sak-web/backend/k9sak/generated';
-import type { HistorikkinnslagDtoV2 as K9KlageHistorikkinnslagDtoV2 } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import type { klage_kontrakt_historikk_v2_HistorikkinnslagDtoV2 as K9KlageHistorikkinnslagDtoV2 } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import type { HistorikkinnslagV2 as TilbakeHistorikkinnslagV2 } from '@k9-sak-web/gui/sak/historikk/tilbake/historikkinnslagTsTypeV2.js';
 import type { Linje as GeneratedK9SakLinje } from '@k9-sak-web/backend/k9sak/generated';
-import type { Linje as GeneratedK9KlageLinje } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import type { klage_kontrakt_historikk_v2_HistorikkinnslagDtoV2_Linje as GeneratedK9KlageLinje } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import type {
   KodeverdiSomObjektSkjermlenkeType as K9SakKodeverdiSomObjektSkjermlenkeType,
   KodeverdiSomObjektHistorikkAktør as K9SakKodeverdiSomObjektHistorikkAktør,
 } from '@k9-sak-web/backend/k9sak/generated';
 import type {
-  KodeverdiSomObjektSkjermlenkeType as K9KlageKodeverdiSomObjektSkjermlenkeType,
-  KodeverdiSomObjektHistorikkAktør as K9KlageKodeverdiSomObjektHistorikkAktør,
+  klage_web_app_tjenester_kodeverk_dto_KodeverdiSomObjektKlage_kodeverk_behandling_aksjonspunkt_SkjermlenkeType as K9KlageKodeverdiSomObjektSkjermlenkeType,
+  klage_web_app_tjenester_kodeverk_dto_KodeverdiSomObjektKlage_kodeverk_historikk_HistorikkAktør as K9KlageKodeverdiSomObjektHistorikkAktør,
 } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import type { K9Kodeverkoppslag } from '../../kodeverk/oppslag/useK9Kodeverkoppslag.js';
 

--- a/packages/v2/gui/src/sak/historikk/snakkeboble/Avatar.tsx
+++ b/packages/v2/gui/src/sak/historikk/snakkeboble/Avatar.tsx
@@ -13,7 +13,7 @@ import {
   type HistorikkAktørDtoType,
   HistorikkAktørDtoType as historikkAktør,
 } from '@k9-sak-web/backend/k9sak/generated';
-import { type HistorikkAktørDtoType as KlageHistorikkAktørDtoType } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import { type klage_kodeverk_historikk_HistorikkAktør as KlageHistorikkAktørDtoType } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import { isLegacyTilbakeHistorikkAktor } from './snakkebobleUtils.jsx';
 
 interface Props {

--- a/packages/v2/gui/src/sak/meny/henlegg-behandling/MenyHenleggIndex.stories.tsx
+++ b/packages/v2/gui/src/sak/meny/henlegg-behandling/MenyHenleggIndex.stories.tsx
@@ -1,4 +1,4 @@
-import { BehandlingDtoBehandlingResultatType as behandlingResultatTypeK9Klage } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import { klage_kodeverk_behandling_BehandlingResultatType as behandlingResultatTypeK9Klage } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import { behandlingType as BehandlingTypeK9Klage } from '@k9-sak-web/backend/k9klage/kodeverk/behandling/BehandlingType.js';
 import {
   BehandlingsresultatDtoType as behandlingResultatTypeK9Sak,

--- a/packages/v2/gui/src/sak/meny/henlegg-behandling/components/HenleggBehandlingModal.spec.tsx
+++ b/packages/v2/gui/src/sak/meny/henlegg-behandling/components/HenleggBehandlingModal.spec.tsx
@@ -1,4 +1,4 @@
-import { BehandlingDtoBehandlingResultatType as behandlingResultatTypeK9Klage } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import { klage_kodeverk_behandling_BehandlingResultatType as behandlingResultatTypeK9Klage } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import { behandlingType as BehandlingTypeK9Klage } from '@k9-sak-web/backend/k9klage/kodeverk/behandling/BehandlingType.js';
 import {
   BehandlingDtoBehandlingResultatType as behandlingResultatTypeK9Sak,

--- a/packages/v2/gui/src/sak/meny/henlegg-behandling/components/HenleggBehandlingModal.tsx
+++ b/packages/v2/gui/src/sak/meny/henlegg-behandling/components/HenleggBehandlingModal.tsx
@@ -1,4 +1,4 @@
-import { BehandlingDtoBehandlingResultatType as behandlingResultatTypeK9Klage } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import { klage_kodeverk_behandling_BehandlingResultatType as behandlingResultatTypeK9Klage } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import { behandlingType as BehandlingTypeK9Klage } from '@k9-sak-web/backend/k9klage/kodeverk/behandling/BehandlingType.js';
 import {
   BehandlingDtoBehandlingResultatType as behandlingResultatTypeK9Sak,

--- a/packages/v2/gui/src/sak/totrinnskontroll/TotrinnskontrollSakIndex.tsx
+++ b/packages/v2/gui/src/sak/totrinnskontroll/TotrinnskontrollSakIndex.tsx
@@ -1,4 +1,7 @@
-import { BehandlingDtoType, type KlagebehandlingDto } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import {
+  klage_kodeverk_behandling_BehandlingType as BehandlingDtoType,
+  type klage_kontrakt_klage_KlagebehandlingDto as KlagebehandlingDto,
+} from '@k9-sak-web/backend/k9klage/generated/types.js';
 import { behandlingType } from '@k9-sak-web/backend/k9klage/kodeverk/behandling/BehandlingType.js';
 import { useKodeverkContext } from '@k9-sak-web/gui/kodeverk/index.js';
 import skjermlenkeCodes from '@k9-sak-web/gui/shared/constants/skjermlenkeCodes.js';

--- a/packages/v2/gui/src/sak/totrinnskontroll/components/AksjonspunktGodkjenningFieldArray.tsx
+++ b/packages/v2/gui/src/sak/totrinnskontroll/components/AksjonspunktGodkjenningFieldArray.tsx
@@ -1,4 +1,4 @@
-import type { KlagebehandlingDto } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import type { klage_kontrakt_klage_KlagebehandlingDto as KlagebehandlingDto } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import { aksjonspunktCodes } from '@k9-sak-web/backend/k9sak/kodeverk/AksjonspunktCodes.js';
 import FeatureTogglesContext from '@k9-sak-web/gui/featuretoggles/FeatureTogglesContext.js';
 import { skjermlenkeCodes } from '@k9-sak-web/konstanter';

--- a/packages/v2/gui/src/sak/totrinnskontroll/components/TotrinnskontrollBeslutterForm.tsx
+++ b/packages/v2/gui/src/sak/totrinnskontroll/components/TotrinnskontrollBeslutterForm.tsx
@@ -1,4 +1,4 @@
-import type { KlagebehandlingDto } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import type { klage_kontrakt_klage_KlagebehandlingDto as KlagebehandlingDto } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import AksjonspunktHelpText from '@k9-sak-web/gui/shared/aksjonspunktHelpText/AksjonspunktHelpText.js';
 import type { KodeverkObject, KodeverkV2 } from '@k9-sak-web/lib/kodeverk/types.js';
 import { Button } from '@navikt/ds-react';

--- a/packages/v2/gui/src/sak/totrinnskontroll/components/TotrinnskontrollSaksbehandlerPanel.tsx
+++ b/packages/v2/gui/src/sak/totrinnskontroll/components/TotrinnskontrollSaksbehandlerPanel.tsx
@@ -1,4 +1,4 @@
-import type { KlagebehandlingDto } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import type { klage_kontrakt_klage_KlagebehandlingDto as KlagebehandlingDto } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import type { KodeverkObject } from '@k9-sak-web/lib/kodeverk/types.js';
 import { CheckmarkIcon, XMarkOctagonIcon } from '@navikt/aksel-icons';
 import { BodyShort } from '@navikt/ds-react';

--- a/packages/v2/gui/src/sak/totrinnskontroll/components/aksjonspunktTekster/aksjonspunktTekstUtleder.spec.tsx
+++ b/packages/v2/gui/src/sak/totrinnskontroll/components/aksjonspunktTekster/aksjonspunktTekstUtleder.spec.tsx
@@ -1,4 +1,4 @@
-import { AksjonspunktDtoDefinisjon as KlageAksjonspunktDtoDefinisjon } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import { klage_kodeverk_behandling_aksjonspunkt_AksjonspunktDefinisjon as KlageAksjonspunktDtoDefinisjon } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import { Klagevurdering } from '@k9-sak-web/backend/k9klage/kodeverk/Klagevurdering.js';
 import { KlagevurderingOmgjør } from '@k9-sak-web/backend/k9klage/kodeverk/KlagevurderingOmgjør.js';
 import {

--- a/packages/v2/gui/src/sak/totrinnskontroll/components/aksjonspunktTekster/aksjonspunktTekstUtleder.tsx
+++ b/packages/v2/gui/src/sak/totrinnskontroll/components/aksjonspunktTekster/aksjonspunktTekstUtleder.tsx
@@ -1,5 +1,6 @@
 import { Klagevurdering } from '@k9-sak-web/backend/k9klage/kodeverk/Klagevurdering.js';
 import {
+  isKlagevurderingOmgjørType,
   KlagevurderingOmgjør,
   type KlagevurderingOmgjørType,
 } from '@k9-sak-web/backend/k9klage/kodeverk/KlagevurderingOmgjør.js';
@@ -7,7 +8,7 @@ import type { KodeverkObject } from '@k9-sak-web/lib/kodeverk/types.js';
 import AksjonspunktCodes from '@k9-sak-web/lib/kodeverk/types/AksjonspunktCodes.js';
 import { Label } from '@navikt/ds-react';
 
-import type { KlagebehandlingDto } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import type { klage_kontrakt_klage_KlagebehandlingDto as KlagebehandlingDto } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import {
   ArbeidsforholdOverstyringDtoHandling,
   BehandlingDtoStatus,
@@ -139,11 +140,10 @@ const getTextForKlageHelper = (
       break;
     case Klagevurdering.MEDHOLD_I_KLAGE:
       if (
-        klageVurderingResultat.klageVurderingOmgjoer &&
+        isKlagevurderingOmgjørType(klageVurderingResultat.klageVurderingOmgjoer) &&
         klageVurderingResultat.klageVurderingOmgjoer !== KlagevurderingOmgjør.UDEFINERT
       ) {
-        aksjonspunktText =
-          omgjoerTekstMap[klageVurderingResultat.klageVurderingOmgjoer as keyof typeof KlagevurderingOmgjør];
+        aksjonspunktText = omgjoerTekstMap[klageVurderingResultat.klageVurderingOmgjoer];
         break;
       }
       aksjonspunktText = 'Vedtaket er omgjort';

--- a/packages/v2/gui/src/sak/totrinnskontroll/types/Behandling.ts
+++ b/packages/v2/gui/src/sak/totrinnskontroll/types/Behandling.ts
@@ -1,4 +1,4 @@
-import type { BehandlingDto as KlageBehandlingDto } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import type { klage_kontrakt_behandling_BehandlingDto as KlageBehandlingDto } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import type { BehandlingDto } from '@navikt/k9-sak-typescript-client';
 
 export type Behandling = {

--- a/packages/v2/gui/src/storybook/mocks/FakeHistorikkBackend.ts
+++ b/packages/v2/gui/src/storybook/mocks/FakeHistorikkBackend.ts
@@ -7,7 +7,7 @@ import {
 } from '../../sak/historikk/historikkTypeBerikning.js';
 import { HistorikkInnslagTypeBeriker } from '../../sak/historikk/historikkTypeBerikning.js';
 import type { K9Kodeverkoppslag } from '../../kodeverk/oppslag/useK9Kodeverkoppslag.js';
-import type { HistorikkinnslagDtoV2 } from '@k9-sak-web/backend/k9klage/generated/types.js';
+import type { klage_kontrakt_historikk_v2_HistorikkinnslagDtoV2 as KlageHistorikkinnslagDtoV2 } from '@k9-sak-web/backend/k9klage/generated/types.js';
 
 // Kopi av respons frå k9-sak backend i dev
 const fakeK9SakResponse: HentAlleInnslagV2Response = [
@@ -268,7 +268,7 @@ const fakeK9SakResponse: HentAlleInnslagV2Response = [
   },
 ];
 
-const fakeK9KlageResponse: HistorikkinnslagDtoV2[] = [
+const fakeK9KlageResponse: KlageHistorikkinnslagDtoV2[] = [
   {
     behandlingId: 999952,
     aktør: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2503,15 +2503,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hey-api/client-fetch@npm:=0.10.0":
-  version: 0.10.0
-  resolution: "@hey-api/client-fetch@npm:0.10.0"
-  peerDependencies:
-    "@hey-api/openapi-ts": < 2
-  checksum: 10/f77dc512047f2fcbba4a1be079020c6c821391b34da426079e1e306ee2ee9f83e7f1130ad7a697a340f2e29bde1e0ce8af3b88a4f8631b849426bd7b2cc24fb9
-  languageName: node
-  linkType: hard
-
 "@hookform/error-message@npm:^2.0.1":
   version: 2.0.1
   resolution: "@hookform/error-message@npm:2.0.1"
@@ -2988,7 +2979,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@k9-sak-web/backend@workspace:packages/v2/backend"
   dependencies:
-    "@navikt/k9-klage-typescript-client": "npm:3.0.20250530164140"
+    "@navikt/k9-klage-typescript-client": "npm:3.1.20250806103540"
     "@navikt/k9-sak-typescript-client": "npm:2.0.20250731124543"
     "@navikt/ung-sak-typescript-client": "npm:0.2.20250728105557"
     "@tanstack/eslint-plugin-query": "npm:^5.81.2"
@@ -4369,12 +4360,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/k9-klage-typescript-client@npm:3.0.20250530164140":
-  version: 3.0.20250530164140
-  resolution: "@navikt/k9-klage-typescript-client@npm:3.0.20250530164140::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-klage-typescript-client%2F3.0.20250530164140%2F29ef2f2a9cd2310dde4445b083d85ad15b3fae6b"
-  dependencies:
-    "@hey-api/client-fetch": "npm:=0.10.0"
-  checksum: 10/01f45605f6dccd37d744a490ae5860382604742701893c180f08c4771c96d5ebd0c83883fb48666690b639fac4443157cc6c8d63ea91a902ffef4344dd5003cf
+"@navikt/k9-klage-typescript-client@npm:3.1.20250806103540":
+  version: 3.1.20250806103540
+  resolution: "@navikt/k9-klage-typescript-client@npm:3.1.20250806103540::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-klage-typescript-client%2F3.1.20250806103540%2Ffd7078f3b9d28452774985ab9c08098e889c640d"
+  checksum: 10/f43fccb643f63b0c2f2d414a632802d7b65e5751da96540945c014ab0cb9804e41cfba5873ea256f7729dff024b80cc3d66cebe20717c604bfc4cf99de49f5d5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### **Behov / Bakgrunn**

Oppgradering til ny generert k9-klage-typescript-client (versjon 3.1) 

### **Løsning**

Skriver om typenamn brukt frå k9-klage-typescript-klient lib.

### **Andre endringer**

Fjerna ein typecast i `aksjonspunktTekstUtleder.tsx`. Skriver om til å bruke type assert funksjon istadenfor.

