### PR TITLE
TSFF-1606: Bruk felt fra backend for å sjekke redigerbarhet

### DIFF
--- a/packages/v2/backend/package.json
+++ b/packages/v2/backend/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@navikt/k9-klage-typescript-client": "3.1.20250806103540",
-    "@navikt/k9-sak-typescript-client": "2.0.20250731124543",
+    "@navikt/k9-sak-typescript-client": "2.0.20250808140458",
     "@navikt/ung-sak-typescript-client": "0.2.20250728105557"
   },
   "devDependencies": {

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/2-sykdom/SykdomUperiodisertContainer.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/2-sykdom/SykdomUperiodisertContainer.tsx
@@ -2,19 +2,19 @@ import dayjs from 'dayjs';
 import SykdomUperiodisertForm, { type UperiodisertSykdom } from './SykdomUperiodisertForm';
 import { CalendarIcon, PencilIcon } from '@navikt/aksel-icons';
 import { useContext, useEffect, useState } from 'react';
-import { Button, BodyShort } from '@navikt/ds-react';
+import { BodyShort, Button } from '@navikt/ds-react';
 import SykdomUperiodisertFerdigvisning from './SykdomUperiodisertFerdigvisning';
 import { DetailView } from '../../../shared/detailView/DetailView';
 import { SykdomOgOpplæringContext } from '../FaktaSykdomOgOpplæringIndex';
 
 const SykdomUperiodisertContainer = ({ vurdering }: { vurdering: UperiodisertSykdom }) => {
-  const { readOnly, behandlingUuid, aksjonspunkter } = useContext(SykdomOgOpplæringContext);
+  const { readOnly, aksjonspunkter } = useContext(SykdomOgOpplæringContext);
   const [redigering, setRedigering] = useState(false);
 
   const harAksjonspunkt9301 = !!aksjonspunkter.find(akspunkt => akspunkt.definisjon.kode === '9301');
 
   useEffect(() => {
-    if (!vurdering.vurdertTidspunkt || vurdering.kanOppdateres !== true) {
+    if (!vurdering.vurdertTidspunkt || !vurdering.kanOppdateres) {
       setRedigering(false);
     }
   }, [vurdering]);

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/2-sykdom/SykdomUperiodisertContainer.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/2-sykdom/SykdomUperiodisertContainer.tsx
@@ -17,7 +17,7 @@ const SykdomUperiodisertContainer = ({ vurdering }: { vurdering: UperiodisertSyk
     if (!vurdering.vurdertTidspunkt || vurdering.kanOppdateres !== true) {
       setRedigering(false);
     }
-  }, [vurdering, behandlingUuid]);
+  }, [vurdering]);
 
   useEffect(() => {
     if (redigering) {

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/2-sykdom/SykdomUperiodisertContainer.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/2-sykdom/SykdomUperiodisertContainer.tsx
@@ -14,7 +14,7 @@ const SykdomUperiodisertContainer = ({ vurdering }: { vurdering: UperiodisertSyk
   const harAksjonspunkt9301 = !!aksjonspunkter.find(akspunkt => akspunkt.definisjon.kode === '9301');
 
   useEffect(() => {
-    if (!vurdering.vurdertTidspunkt || vurdering.behandlingUuid !== behandlingUuid) {
+    if (!vurdering.vurdertTidspunkt || vurdering.kanOppdateres !== true) {
       setRedigering(false);
     }
   }, [vurdering, behandlingUuid]);

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/2-sykdom/SykdomUperiodisertContainer.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/2-sykdom/SykdomUperiodisertContainer.tsx
@@ -40,7 +40,7 @@ const SykdomUperiodisertContainer = ({ vurdering }: { vurdering: UperiodisertSyk
       contentAfterTitleRenderer={() =>
         !readOnly &&
         harAksjonspunkt9301 &&
-        vurdering.behandlingUuid === behandlingUuid && (
+        vurdering.kanOppdateres && (
           <RedigerKnapp redigering={redigering} setRedigering={setRedigering} vurdering={vurdering} />
         )
       }

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/2-sykdom/SykdomUperiodisertForm.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/2-sykdom/SykdomUperiodisertForm.tsx
@@ -11,7 +11,10 @@ import { useContext, useEffect } from 'react';
 import { SykdomOgOpplæringContext } from '../FaktaSykdomOgOpplæringIndex';
 
 export type UperiodisertSykdom = Pick<LangvarigSykdomVurderingDto, 'diagnosekoder' | 'begrunnelse'> &
-  Pick<Partial<LangvarigSykdomVurderingDto>, 'uuid' | 'behandlingUuid' | 'vurdertTidspunkt' | 'vurdertAv'> & {
+  Pick<
+    Partial<LangvarigSykdomVurderingDto>,
+    'uuid' | 'behandlingUuid' | 'vurdertTidspunkt' | 'vurdertAv' | 'kanOppdateres'
+  > & {
     godkjent: 'ja' | 'nei' | 'mangler_dokumentasjon' | '';
   };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2980,7 +2980,7 @@ __metadata:
   resolution: "@k9-sak-web/backend@workspace:packages/v2/backend"
   dependencies:
     "@navikt/k9-klage-typescript-client": "npm:3.1.20250806103540"
-    "@navikt/k9-sak-typescript-client": "npm:2.0.20250731124543"
+    "@navikt/k9-sak-typescript-client": "npm:2.0.20250808140458"
     "@navikt/ung-sak-typescript-client": "npm:0.2.20250728105557"
     "@tanstack/eslint-plugin-query": "npm:^5.81.2"
   languageName: unknown
@@ -4367,10 +4367,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/k9-sak-typescript-client@npm:2.0.20250731124543":
-  version: 2.0.20250731124543
-  resolution: "@navikt/k9-sak-typescript-client@npm:2.0.20250731124543::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-sak-typescript-client%2F2.0.20250731124543%2F69272de5c0d077b0a86213eaf4770576a894ece4"
-  checksum: 10/a4a43505f824908cf40809130e7a0836def7bb9e927f568cb2f4f05d3847342cac6dfc06b0c0a21b51cb7435a61b0b9af935565374929eaa4c80e6565075a856
+"@navikt/k9-sak-typescript-client@npm:2.0.20250808140458":
+  version: 2.0.20250808140458
+  resolution: "@navikt/k9-sak-typescript-client@npm:2.0.20250808140458::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-sak-typescript-client%2F2.0.20250808140458%2F687d0833d70a1e505e9f6fad63ef01c4653c7816"
+  checksum: 10/01ae31c8f4581fbf7bf5b5804dcc4b4ba9f3cb226b05d747c104485b7ec556eee85976241155bba3f321a8242989fd437d411f2fb85720905d0610dec892e74e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### **Behov / Bakgrunn**

Når sykdomsvurdering deles på tvers må alle behandlinger hvor vurderingen er i bruk sjekkes for å bestemme redigerbarhet. Dette gjøres i backend, og resultatet sendes som en felt til frontend

### **Løsning**

Endre sjekk for å vise redigeringknapp til å ta i bruk det nye feltet