### PR TITLE
Nødvendig opplæring andreiterasjon

### DIFF
--- a/packages/assets/styles/global.css
+++ b/packages/assets/styles/global.css
@@ -1,5 +1,6 @@
 @import url('tailwindcss/base');
 @import url('@navikt/ds-css');
+@import url('@navikt/ds-tokens/darkside-css');
 @import url('tailwindcss/components');
 @import url('tailwindcss/utilities');
 @import url('dayPicker.css');

--- a/packages/v2/backend/package.json
+++ b/packages/v2/backend/package.json
@@ -22,9 +22,9 @@
     "./ungsak/kodeverk/*": "./src/ungsak/kodeverk/*"
   },
   "dependencies": {
-    "@navikt/k9-klage-typescript-client": "3.0.20250530164140",
-    "@navikt/k9-sak-typescript-client": "2.0.20250806134814",
-    "@navikt/ung-sak-typescript-client": "0.2.20250728105557"
+    "@navikt/k9-klage-typescript-client": "3.1.20250806103540",
+    "@navikt/k9-sak-typescript-client": "2.0.20250811133704",
+    "@navikt/ung-sak-typescript-client": "0.2.20250808091711"
   },
   "devDependencies": {
     "@tanstack/eslint-plugin-query": "^5.81.2"

--- a/packages/v2/backend/package.json
+++ b/packages/v2/backend/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@navikt/k9-klage-typescript-client": "3.0.20250530164140",
-    "@navikt/k9-sak-typescript-client": "2.0.20250731124543",
+    "@navikt/k9-sak-typescript-client": "2.0.20250806134814",
     "@navikt/ung-sak-typescript-client": "0.2.20250728105557"
   },
   "devDependencies": {

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/1-institusjon/FaktaInstitusjonIndex.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/1-institusjon/FaktaInstitusjonIndex.tsx
@@ -14,6 +14,8 @@ import { useInstitusjonInfo } from '../SykdomOgOpplæringQueries.js';
 import { SykdomOgOpplæringContext } from '../FaktaSykdomOgOpplæringIndex.js';
 import VurderingsperiodeNavigasjon from '../../../shared/vurderingsperiode-navigasjon/VurderingsperiodeNavigasjon.js';
 import { CenteredLoader } from '../CenteredLoader.js';
+import { Alert } from '@navikt/ds-react';
+
 export interface FaktaInstitusjonProps {
   perioder: InstitusjonPeriodeDto[];
   vurderinger: InstitusjonVurderingDto[];
@@ -73,6 +75,11 @@ const FaktaInstitusjonIndex = () => {
 
   return (
     <div>
+      {valgtVurdering?.resultat === InstitusjonVurderingDtoResultat.MÅ_VURDERES && !readOnly && (
+        <Alert variant="warning" size="small" contentMaxWidth={false} className="mb-4">
+          {`Vurder om opplæringen er utført ved godkjent helseinstitusjon eller kompetansesenter i perioden ${valgtVurdering.perioder.map(periode => periode.prettifyPeriod()).join(', ')}.`}
+        </Alert>
+      )}
       <NavigationWithDetailView
         navigationSection={() => (
           <VurderingsperiodeNavigasjon<InstitusjonPerioderDtoMedResultat>

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/1-institusjon/components/InstitusjonDetails.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/1-institusjon/components/InstitusjonDetails.tsx
@@ -1,12 +1,12 @@
 import { useEffect, useState } from 'react';
-import { Button, BodyShort } from '@navikt/ds-react';
+import { Button } from '@navikt/ds-react';
 import { InstitusjonVurderingDtoResultat } from '@k9-sak-web/backend/k9sak/generated';
 
 import type { InstitusjonVurderingDtoMedPerioder } from '../types/InstitusjonVurderingDtoMedPerioder.js';
 import InstitusjonFerdigVisning from './InstitusjonFerdigVisning.js';
 import InstitusjonForm from './InstitusjonForm.js';
 import DetailView from '../../../../shared/detailView/DetailView.js';
-import { PencilIcon, CalendarIcon } from '@navikt/aksel-icons';
+import { PencilIcon } from '@navikt/aksel-icons';
 
 interface OwnProps {
   vurdering: InstitusjonVurderingDtoMedPerioder;
@@ -16,11 +16,6 @@ interface OwnProps {
 const InstitusjonDetails = ({ vurdering, readOnly }: OwnProps) => {
   const [redigering, setRedigering] = useState(false);
   const visEndreLink = !readOnly && vurdering.resultat !== InstitusjonVurderingDtoResultat.MÅ_VURDERES;
-  const perioder = vurdering.perioder.map(periode => (
-    <div key={periode.prettifyPeriod()} data-testid="Periode" className="flex gap-2">
-      <CalendarIcon fontSize="20" /> <BodyShort size="small">{periode.prettifyPeriod()}</BodyShort>
-    </div>
-  ));
 
   useEffect(() => {
     if (redigering) {
@@ -45,7 +40,7 @@ const InstitusjonDetails = ({ vurdering, readOnly }: OwnProps) => {
           </Button>
         ) : null
       }
-      belowTitleContent={perioder}
+      perioder={vurdering.perioder}
     >
       {vurdering.resultat !== InstitusjonVurderingDtoResultat.MÅ_VURDERES && !redigering ? (
         <InstitusjonFerdigVisning vurdering={vurdering} />

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/InstitusjonOgSykdomInfo.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/InstitusjonOgSykdomInfo.tsx
@@ -48,10 +48,9 @@ const InstitusjonOgSykdomInfo = ({ perioder }: { perioder: PeriodType[] }) => {
         {isLoadingLangvarigSykdom || isLoadingVurdertLangvarigSykdom ? (
           <Skeleton variant="text" width="50%" height="24px" />
         ) : (
-          diagnosekoder?.map((kode, index, array) => (
+          diagnosekoder?.map((kode, index) => (
             <BodyShort size="small" key={index}>
               {ICD10.find(icd => icd.code === kode)?.text}
-              {index < array.length - 1 && ', '}
             </BodyShort>
           ))
         )}

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/InstitusjonOgSykdomInfo.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/InstitusjonOgSykdomInfo.tsx
@@ -1,0 +1,63 @@
+import { BodyShort, Label, Skeleton } from '@navikt/ds-react';
+import {
+  useInstitusjonInfo,
+  useLangvarigSykVurderingerFagsak,
+  useVurdertLangvarigSykdom,
+} from '../SykdomOgOpplæringQueries';
+import { useContext } from 'react';
+import { SykdomOgOpplæringContext } from '../FaktaSykdomOgOpplæringIndex';
+import type { Period as PeriodType } from '@navikt/ft-utils';
+import { Period } from '@navikt/ft-utils';
+import { ICD10 } from '@navikt/diagnosekoder';
+
+const InstitusjonOgSykdomInfo = ({ perioder }: { perioder: PeriodType[] }) => {
+  const periode = perioder[0];
+  const { behandlingUuid } = useContext(SykdomOgOpplæringContext);
+  const { data: institusjonData, isLoading: isLoadingInstitusjon } = useInstitusjonInfo(behandlingUuid);
+  const { data: langvarigSykdomData, isLoading: isLoadingLangvarigSykdom } =
+    useLangvarigSykVurderingerFagsak(behandlingUuid);
+  const { data: vurdertLangvarigSykdomData, isLoading: isLoadingVurdertLangvarigSykdom } =
+    useVurdertLangvarigSykdom(behandlingUuid);
+
+  if (!periode) return null;
+
+  const redigertInstitusjonNavn = institusjonData?.vurderinger.find(vurdering =>
+    vurdering.perioder.some(p => new Period(p.fom, p.tom).covers(periode)),
+  )?.redigertInstitusjonNavn;
+
+  const institusjonNavn = institusjonData?.perioder.find(v =>
+    new Period(v.periode.fom, v.periode.tom).covers(periode),
+  )?.institusjon;
+
+  const diagnosekoder = langvarigSykdomData?.find(
+    v => v.uuid === vurdertLangvarigSykdomData?.vurderingUuid,
+  )?.diagnosekoder;
+
+  return (
+    <div className="grid grid-cols-2 gap-4 bg-[var(--ax-bg-info-moderate)] py-2.5 px-4 rounded-md">
+      <div className="flex flex-col gap-2">
+        <Label size="small">Institusjon:</Label>
+        {isLoadingInstitusjon ? (
+          <Skeleton variant="text" width="50%" height="24px" />
+        ) : (
+          <BodyShort size="small">{redigertInstitusjonNavn || institusjonNavn}</BodyShort>
+        )}
+      </div>
+      <div className="flex flex-col gap-2">
+        <Label size="small">{diagnosekoder?.length && diagnosekoder.length > 1 ? 'Diagnoser:' : 'Diagnose:'}</Label>
+        {isLoadingLangvarigSykdom || isLoadingVurdertLangvarigSykdom ? (
+          <Skeleton variant="text" width="50%" height="24px" />
+        ) : (
+          diagnosekoder?.map((kode, index, array) => (
+            <BodyShort size="small" key={index}>
+              {ICD10.find(icd => icd.code === kode)?.text}
+              {index < array.length - 1 && ', '}
+            </BodyShort>
+          ))
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default InstitusjonOgSykdomInfo;

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringContainer.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringContainer.tsx
@@ -3,9 +3,9 @@ import type { OpplæringVurderingDto } from '@k9-sak-web/backend/k9sak/generated
 import { Period } from '@navikt/ft-utils';
 import NødvendigOpplæringForm from './NødvendigOpplæringForm';
 import DetailView from '../../../shared/detailView/DetailView';
-import { CalendarIcon, PencilIcon } from '@navikt/aksel-icons';
+import { PencilIcon } from '@navikt/aksel-icons';
 import { useEffect, useState, useContext } from 'react';
-import { BodyShort, Button } from '@navikt/ds-react';
+import { Button } from '@navikt/ds-react';
 import { SykdomOgOpplæringContext } from '../FaktaSykdomOgOpplæringIndex';
 
 const NødvendigOpplæringContainer = ({ vurdering }: { vurdering: OpplæringVurderingDto & { perioder: Period[] } }) => {
@@ -43,18 +43,10 @@ const Wrapper = ({
   redigering: boolean;
 }) => {
   const { readOnly } = useContext(SykdomOgOpplæringContext);
-  const enkeltdag = vurdering.perioder[0]?.asListOfDays().length === 1;
-  const perioder = (
-    <div data-testid="Periode" className="flex gap-2">
-      <CalendarIcon fontSize="20" />
-      <BodyShort size="small">
-        {enkeltdag ? vurdering.perioder[0]?.prettifyPeriod().split(' - ')[0] : vurdering.perioder[0]?.prettifyPeriod()}
-      </BodyShort>
-    </div>
-  );
+
   return (
     <DetailView
-      title="Vurdering av nødvendig opplæring"
+      title="Dokumentasjon"
       border
       contentAfterTitleRenderer={() => {
         if (vurdering.resultat === 'MÅ_VURDERES' || redigering || readOnly) {
@@ -66,7 +58,7 @@ const Wrapper = ({
           </Button>
         );
       }}
-      belowTitleContent={perioder}
+      perioder={vurdering.perioder}
     >
       <div className="mt-6">{children}</div>
     </DetailView>

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringFerdigvisning.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringFerdigvisning.tsx
@@ -4,11 +4,7 @@ import type { Period } from '@navikt/ft-utils';
 import { LabelledContent } from '../../../shared/labelled-content/LabelledContent';
 import { Lovreferanse } from '../../../shared/lovreferanse/Lovreferanse';
 import { VurdertAv } from '../../../shared/vurdert-av/VurdertAv';
-const NødvendigOpplæringFerdigvisning = ({
-  vurdering,
-}: {
-  vurdering: OpplæringVurderingDto & { perioder: Period[] };
-}) => {
+const NødvendigOpplæringFerdigvisning = ({ vurdering }: { vurdering: OpplæringVurderingDto & { perioder: Period[] } }) => {
   return (
     <div className="flex flex-col gap-6">
       <LabelledContent

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringFerdigvisning.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringFerdigvisning.tsx
@@ -10,7 +10,7 @@ import { VurdertAv } from '../../../shared/vurdert-av/VurdertAv';
 import { K9KodeverkoppslagContext } from '../../../kodeverk/oppslag/K9KodeverkoppslagContext';
 import { useContext } from 'react';
 import { Periodevisning } from '../../../shared/detailView/DetailView';
-import { Period } from '@fpsak-frontend/utils';
+import { Period } from '@navikt/ft-utils';
 
 const NødvendigOpplæringFerdigvisning = ({
   vurdering,

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringFerdigvisning.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringFerdigvisning.tsx
@@ -1,16 +1,33 @@
-import type { OpplæringVurderingDto } from '@k9-sak-web/backend/k9sak/generated';
-import { BodyShort } from '@navikt/ds-react';
-import type { Period } from '@navikt/ft-utils';
+import {
+  OpplæringVurderingDtoAvslagsårsak,
+  OpplæringVurderingDtoResultat,
+  type OpplæringVurderingDto,
+} from '@k9-sak-web/backend/k9sak/generated';
+import { Alert, BodyShort } from '@navikt/ds-react';
 import { LabelledContent } from '../../../shared/labelled-content/LabelledContent';
 import { Lovreferanse } from '../../../shared/lovreferanse/Lovreferanse';
 import { VurdertAv } from '../../../shared/vurdert-av/VurdertAv';
-const NødvendigOpplæringFerdigvisning = ({ vurdering }: { vurdering: OpplæringVurderingDto & { perioder: Period[] } }) => {
+import { K9KodeverkoppslagContext } from '../../../kodeverk/oppslag/K9KodeverkoppslagContext';
+import { useContext } from 'react';
+const NødvendigOpplæringFerdigvisning = ({ vurdering }: { vurdering: OpplæringVurderingDto }) => {
+  if (vurdering.resultat === OpplæringVurderingDtoResultat.VURDERES_SOM_REISETID) {
+    return (
+      <Alert variant="info" size="small">
+        Dag eller periode er flyttet til vurdering av reisetid.
+      </Alert>
+    );
+  }
+
   return (
     <div className="flex flex-col gap-6">
       <LabelledContent
         label="Er nødvendig opplæring dokumentert med legeerklæring?"
         size="small"
-        content={<BodyShort size="small">{vurdering.dokumentertOpplæring ? 'Ja' : 'Nei'}</BodyShort>}
+        content={
+          <BodyShort size="small">
+            {vurdering.resultat === OpplæringVurderingDtoResultat.GODKJENT ? 'Ja' : 'Nei'}
+          </BodyShort>
+        }
       />
       <div>
         <LabelledContent
@@ -35,10 +52,29 @@ const NødvendigOpplæringFerdigvisning = ({ vurdering }: { vurdering: Opplærin
       <LabelledContent
         label="Har søker hatt opplæring som er nødvendig for å kunne ta seg av og behandle barnet?"
         size="small"
-        content={<BodyShort size="small">{vurdering.nødvendigOpplæring ? 'Ja' : 'Nei'}</BodyShort>}
+        content={
+          <BodyShort size="small">
+            {vurdering.resultat === OpplæringVurderingDtoResultat.GODKJENT ? 'Ja' : 'Nei'}
+          </BodyShort>
+        }
       />
+      {vurdering.avslagsårsak && vurdering.avslagsårsak !== OpplæringVurderingDtoAvslagsårsak.UDEFINERT && (
+        <LabelledContent
+          label="Avslagsårsak"
+          size="small"
+          content={<AvslagårsakTekst avslagsårsak={vurdering.avslagsårsak} />}
+        />
+      )}
     </div>
   );
+};
+
+const AvslagårsakTekst = ({ avslagsårsak }: { avslagsårsak: OpplæringVurderingDtoAvslagsårsak }) => {
+  const k9Kodeverkoppslag = useContext(K9KodeverkoppslagContext);
+  if (!avslagsårsak) {
+    return null;
+  }
+  return <BodyShort size="small">{(k9Kodeverkoppslag as any).k9sak.avslagsårsaker(avslagsårsak).navn}</BodyShort>;
 };
 
 export default NødvendigOpplæringFerdigvisning;

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringFerdigvisning.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringFerdigvisning.tsx
@@ -3,14 +3,20 @@ import {
   OpplæringVurderingDtoResultat,
   type OpplæringVurderingDto,
 } from '@k9-sak-web/backend/k9sak/generated';
-import { Alert, BodyShort } from '@navikt/ds-react';
+import { Alert, BodyShort, Heading } from '@navikt/ds-react';
 import { LabelledContent } from '../../../shared/labelled-content/LabelledContent';
 import { Lovreferanse } from '../../../shared/lovreferanse/Lovreferanse';
 import { VurdertAv } from '../../../shared/vurdert-av/VurdertAv';
 import { K9KodeverkoppslagContext } from '../../../kodeverk/oppslag/K9KodeverkoppslagContext';
 import { useContext } from 'react';
+import { Periodevisning } from '../../../shared/detailView/DetailView';
+import { Period } from '@fpsak-frontend/utils';
 
-const NødvendigOpplæringFerdigvisning = ({ vurdering }: { vurdering: OpplæringVurderingDto }) => {
+const NødvendigOpplæringFerdigvisning = ({
+  vurdering,
+}: {
+  vurdering: OpplæringVurderingDto & { perioder: Period[] };
+}) => {
   if (vurdering.resultat === OpplæringVurderingDtoResultat.VURDERES_SOM_REISETID) {
     return (
       <Alert variant="info" size="small">
@@ -22,7 +28,8 @@ const NødvendigOpplæringFerdigvisning = ({ vurdering }: { vurdering: Opplærin
   return (
     <div className="flex flex-col gap-6">
       <LabelledContent
-        label="Er nødvendig opplæring dokumentert med legeerklæring?"
+        label="Har vi fått legeerklæring?"
+        description="Legeerklæringen skal dokumentere om opplæringen er nødvendig for at søker skal kunne ta seg av og behandle barnet."
         size="small"
         content={
           <BodyShort size="small">
@@ -30,12 +37,19 @@ const NødvendigOpplæringFerdigvisning = ({ vurdering }: { vurdering: Opplærin
           </BodyShort>
         }
       />
+      <div className="mt-4">
+        <Heading size="small" level="2" className="!mb-0">
+          Vurdering av nødvendig opplæring
+        </Heading>
+        <Periodevisning perioder={vurdering.perioder} />
+      </div>
+      <div className="border-none bg-border-subtle h-[2px]" />
       <div>
         <LabelledContent
           label={
             <>
               Vurder om opplæringen er nødvendig for at søker skal kunne ta seg av og behandle barnet etter
-              <Lovreferanse> § 9-14</Lovreferanse>
+              <Lovreferanse> § 9-14, første ledd</Lovreferanse>
             </>
           }
           indentContent
@@ -51,7 +65,7 @@ const NødvendigOpplæringFerdigvisning = ({ vurdering }: { vurdering: Opplærin
         <VurdertAv ident={vurdering.vurdertAv} date={vurdering.vurdertTidspunkt} size="small" />
       </div>
       <LabelledContent
-        label="Har søker hatt opplæring som er nødvendig for å kunne ta seg av og behandle barnet?"
+        label="Har søker opplæring som er nødvendig?"
         size="small"
         content={
           <BodyShort size="small">

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringFerdigvisning.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringFerdigvisning.tsx
@@ -9,6 +9,7 @@ import { Lovreferanse } from '../../../shared/lovreferanse/Lovreferanse';
 import { VurdertAv } from '../../../shared/vurdert-av/VurdertAv';
 import { K9KodeverkoppslagContext } from '../../../kodeverk/oppslag/K9KodeverkoppslagContext';
 import { useContext } from 'react';
+
 const NødvendigOpplæringFerdigvisning = ({ vurdering }: { vurdering: OpplæringVurderingDto }) => {
   if (vurdering.resultat === OpplæringVurderingDtoResultat.VURDERES_SOM_REISETID) {
     return (

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringForm.stories.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringForm.stories.tsx
@@ -66,17 +66,20 @@ export const Avslagsårsaker: Story = {
     redigering: true,
   },
   play: async ({ canvas }) => {
-    const erNødvendigOpplæringDokumentertGroup = canvas.getByRole('group', {
-      name: /Er nødvendig opplæring dokumentert/i,
+    const harViFåttLegeerklæringGroup = canvas.getByRole('group', {
+      name: /Har vi fått legeerklæring/i,
     });
-    const jaKnapp = within(erNødvendigOpplæringDokumentertGroup).getByLabelText('Ja');
+    const jaKnapp = within(harViFåttLegeerklæringGroup).getByLabelText('Ja');
     await expect(jaKnapp).toBeInTheDocument();
     await userEvent.click(jaKnapp);
-    const vurderingTextInput = canvas.getByLabelText('Vurder om opplæringen er nødvendig', { exact: false });
+    const vurderingTextInput = canvas.getByLabelText(
+      'Vurder om opplæringen er nødvendig for at søker skal kunne ta seg av og behandle barnet etter § 9-14, første ledd',
+      { exact: false },
+    );
     await expect(vurderingTextInput).toBeVisible();
     await userEvent.type(vurderingTextInput, 'Testbegrunnelse');
-    const harSøkerHattOpplæringGroup = canvas.getByRole('group', { name: /Har søker hatt opplæring/ });
-    const neiKnapp = within(harSøkerHattOpplæringGroup).getByLabelText('Nei');
+    const harSøkerOpplæringGroup = canvas.getByRole('group', { name: /Har søker opplæring som er nødvendig/ });
+    const neiKnapp = within(harSøkerOpplæringGroup).getByLabelText('Nei');
     await userEvent.click(neiKnapp);
     const opplæringIkkeNødvendigRadio = canvas.getByText(
       sakKodeverkOppslag.avslagsårsaker(KodeverdiSomObjektAvslagsårsakKilde.IKKE_NØDVENDIG_OPPLÆRING).navn,

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringForm.stories.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringForm.stories.tsx
@@ -77,6 +77,7 @@ export const Avslagsårsaker: Story = {
       { exact: false },
     );
     await expect(vurderingTextInput).toBeVisible();
+    await userEvent.clear(vurderingTextInput);
     await userEvent.type(vurderingTextInput, 'Testbegrunnelse');
     const harSøkerOpplæringGroup = canvas.getByRole('group', { name: /Har søker opplæring som er nødvendig/ });
     const neiKnapp = within(harSøkerOpplæringGroup).getByLabelText('Nei');
@@ -93,11 +94,14 @@ export const Avslagsårsaker: Story = {
     const bekreftKnapp = canvas.getByRole('button', { name: 'Bekreft og fortsett' });
     await userEvent.click(bekreftKnapp);
     const expectedSubmitData = {
-      periode: { fom: '2025-02-14', tom: '2025-02-23' },
-      begrunnelse: 'Testbegrunnelse',
-      nødvendigOpplæring: false,
-      dokumentertOpplæring: true,
-      avslagsårsak: '1101',
+      perioder: [
+        {
+          periode: { fom: '2025-02-14', tom: '2025-02-23' },
+          begrunnelse: 'Testbegrunnelse',
+          resultat: OpplæringVurderingDtoResultat.IKKE_GODKJENT,
+          avslagsårsak: '1101',
+        },
+      ],
     };
     await expect(løsAksjonspunkt9302).toHaveBeenCalledWith(expectedSubmitData);
   },

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringForm.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringForm.tsx
@@ -198,7 +198,7 @@ const NødvendigOpplæringForm = ({
                 {...field}
                 readOnly={readOnly}
                 size="small"
-                error={formMethods.formState.errors.harLegeerklæring?.message as string | undefined}
+                error={formMethods.formState.errors.harLegeerklæring?.message}
               >
                 <Radio value={JA}>Ja</Radio>
                 <Radio value={NEI}>Nei</Radio>
@@ -232,7 +232,7 @@ const NødvendigOpplæringForm = ({
               }
               minRows={3}
               id="begrunnelse"
-              error={formMethods.formState.errors.begrunnelse?.message as string | undefined}
+              error={formMethods.formState.errors.begrunnelse?.message}
               disabled={opplæringIkkeDokumentertMedLegeerklæring}
               description={
                 <ReadMore header="Hva skal vurderingen inneholde?" size="small">
@@ -281,7 +281,7 @@ const NødvendigOpplæringForm = ({
                   {...field}
                   readOnly={readOnly}
                   size="small"
-                  error={formMethods.formState.errors.harNødvendigOpplæring?.message as string | undefined}
+                  error={formMethods.formState.errors.harNødvendigOpplæring?.message}
                 >
                   <Radio value={JA}>Ja</Radio>
                   {periodeErEnkeltdag ? (

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringForm.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringForm.tsx
@@ -10,6 +10,7 @@ import {
   Alert,
   BodyShort,
   Button,
+  Detail,
   Heading,
   Label,
   Link,
@@ -62,7 +63,7 @@ const utledHarLegeerklæring = (resultat: OpplæringVurderingDtoResultat): 'JA' 
   if (resultat === OpplæringVurderingDtoResultat.MÅ_VURDERES) {
     return '';
   }
-  return 'JA';
+  return JA;
 };
 
 const utledNødvendigOpplæring = (
@@ -198,6 +199,12 @@ const NødvendigOpplæringForm = ({
                 {...field}
                 readOnly={readOnly}
                 size="small"
+                description={
+                  <Detail>
+                    Legeerklæringen skal dokumentere om opplæringen er nødvendig for at søker skal kunne ta seg av og
+                    behandle barnet.
+                  </Detail>
+                }
                 error={formMethods.formState.errors.harLegeerklæring?.message}
               >
                 <Radio value={JA}>Ja</Radio>
@@ -284,11 +291,7 @@ const NødvendigOpplæringForm = ({
                   error={formMethods.formState.errors.harNødvendigOpplæring?.message}
                 >
                   <Radio value={JA}>Ja</Radio>
-                  {periodeErEnkeltdag ? (
-                    <Radio value={VURDERES_SOM_REISETID}>Vurderes som reisetid</Radio>
-                  ) : (
-                    <Radio value={DELVIS}>Deler av perioden</Radio>
-                  )}
+                  {!periodeErEnkeltdag && <Radio value={DELVIS}>Deler av perioden</Radio>}
                   <Radio value={NEI}>Nei</Radio>
                 </RadioGroup>
               );

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringForm.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringForm.tsx
@@ -4,16 +4,7 @@ import {
   type OpplæringVurderingDto,
 } from '@k9-sak-web/backend/k9sak/generated';
 import { Form } from '@navikt/ft-form-hooks';
-import {
-  Controller,
-  useFieldArray,
-  useForm,
-  useFormContext,
-  type ControllerProps,
-  type FieldArrayWithId,
-  type UseFieldArrayRemove,
-  type UseFieldArrayReplace,
-} from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import { Period } from '@navikt/ft-utils';
 import {
   Alert,
@@ -23,51 +14,88 @@ import {
   Label,
   Link,
   List,
-  Modal,
   Radio,
   RadioGroup,
   ReadMore,
   Textarea,
-  DatePicker,
 } from '@navikt/ds-react';
 import { Lovreferanse } from '../../../shared/lovreferanse/Lovreferanse';
 import { ListItem } from '@navikt/ds-react/List';
-import React, { useContext, useEffect, useState } from 'react';
+import { useContext, useEffect } from 'react';
 import { SykdomOgOpplæringContext } from '../FaktaSykdomOgOpplæringIndex';
 import dayjs from 'dayjs';
-import { KodeverdiSomObjektAvslagsårsakKilde } from '@k9-sak-web/backend/k9sak/generated';
-import { K9KodeverkoppslagContext } from '../../../kodeverk/oppslag/K9KodeverkoppslagContext.jsx';
 import { Periodevisning } from '../../../shared/detailView/DetailView.js';
-import { Datepicker as RHFDatepicker } from '@navikt/ft-form-hooks';
-import { PlusCircleIcon, ScissorsFillIcon, TrashIcon } from '@navikt/aksel-icons';
-import {
-  checkIfPeriodsAreEdgeToEdge,
-  combineConsecutivePeriods,
-  findUncoveredDays,
-  formatPeriod,
-  getDaysInPeriod,
-} from '@k9-sak-web/lib/dateUtils/dateUtils.js';
 import InstitusjonOgSykdomInfo from './components/InstitusjonOgSykdomInfo.js';
 import type { nødvendigOpplæringPayload } from '../FaktaSykdomOgOpplæringIndex.js';
+import { DelvisOpplæring } from './components/DelvisOpplæring';
+import { Avslagsårsak } from './components/Avslagsårsak';
 
-const utledNødvendigOpplæring = (resultat: OpplæringVurderingDtoResultat): 'JA' | 'DELVIS' | 'NEI' | '' => {
-  if (resultat === OpplæringVurderingDtoResultat.GODKJENT) {
-    return 'JA';
-  }
-  if (resultat === OpplæringVurderingDtoResultat.IKKE_GODKJENT) {
-    return 'NEI';
-  }
-  return '';
+const JA = 'JA' as const;
+const DELVIS = 'DELVIS' as const;
+const NEI = 'NEI' as const;
+const VURDERES_SOM_REISETID = 'VURDERES_SOM_REISETID' as const;
+
+type NødvendigOpplæringFormFields = {
+  begrunnelse: string;
+  resultat: OpplæringVurderingDtoResultat | '';
+  harLegeerklæring: 'JA' | 'NEI' | '';
+  harNødvendigOpplæring: 'JA' | 'DELVIS' | 'NEI' | 'VURDERES_SOM_REISETID' | '';
+  avslagsårsak?: OpplæringVurderingDtoAvslagsårsak;
+  perioder: {
+    resultat: OpplæringVurderingDtoResultat | '';
+    avslagsårsak: OpplæringVurderingDtoAvslagsårsak | '';
+    fom: string;
+    tom: string;
+  }[];
+  perioderUtenNødvendigOpplæring: {
+    fom: string;
+    tom: string;
+    resultat: OpplæringVurderingDtoResultat | '';
+    avslagsårsak: OpplæringVurderingDtoAvslagsårsak | '';
+  }[];
 };
 
 const utledHarLegeerklæring = (resultat: OpplæringVurderingDtoResultat): 'JA' | 'NEI' | '' => {
   if (resultat === OpplæringVurderingDtoResultat.IKKE_DOKUMENTERT) {
-    return 'NEI';
+    return NEI;
   }
   if (resultat === OpplæringVurderingDtoResultat.MÅ_VURDERES) {
     return '';
   }
   return 'JA';
+};
+
+const utledNødvendigOpplæring = (
+  resultat: OpplæringVurderingDtoResultat,
+): 'JA' | 'DELVIS' | 'NEI' | 'VURDERES_SOM_REISETID' | '' => {
+  if (resultat === OpplæringVurderingDtoResultat.GODKJENT) {
+    return JA;
+  }
+  if (resultat === OpplæringVurderingDtoResultat.IKKE_GODKJENT) {
+    return NEI;
+  }
+
+  if (resultat === OpplæringVurderingDtoResultat.VURDERES_SOM_REISETID) {
+    return VURDERES_SOM_REISETID;
+  }
+
+  return '';
+};
+
+const nødvendigOpplæringTilResultat = (nødvendigOpplæring: 'JA' | 'DELVIS' | 'NEI' | 'VURDERES_SOM_REISETID' | '') => {
+  if (nødvendigOpplæring === JA) {
+    return OpplæringVurderingDtoResultat.GODKJENT;
+  }
+  if (nødvendigOpplæring === DELVIS) {
+    return OpplæringVurderingDtoResultat.GODKJENT;
+  }
+  if (nødvendigOpplæring === NEI) {
+    return OpplæringVurderingDtoResultat.IKKE_GODKJENT;
+  }
+  if (nødvendigOpplæring === VURDERES_SOM_REISETID) {
+    return OpplæringVurderingDtoResultat.VURDERES_SOM_REISETID;
+  }
+  return '';
 };
 
 const defaultValues = (vurdering: OpplæringVurderingDto & { perioder: Period[] }) => {
@@ -85,27 +113,34 @@ const defaultValues = (vurdering: OpplæringVurderingDto & { perioder: Period[] 
         tom: vurdering.perioder[0]!.tom,
       },
     ],
+    perioderUtenNødvendigOpplæring: [],
   };
 };
 
-type NødvendigOpplæringFormFields = {
-  begrunnelse: string;
-  resultat: OpplæringVurderingDtoResultat | '';
-  harLegeerklæring: 'JA' | 'NEI' | '';
-  harNødvendigOpplæring: 'JA' | 'DELVIS' | 'NEI' | '';
-  avslagsårsak?: OpplæringVurderingDtoAvslagsårsak;
-  perioder: {
-    resultat: OpplæringVurderingDtoResultat | '';
-    avslagsårsak: OpplæringVurderingDtoAvslagsårsak | '';
-    fom: string;
-    tom: string;
-  }[];
-  perioderUtenNødvendigOpplæring: {
-    fom: string;
-    tom: string;
-    resultat: OpplæringVurderingDtoResultat | '';
-    avslagsårsak: OpplæringVurderingDtoAvslagsårsak | '';
-  }[];
+const onSubmit = (data: NødvendigOpplæringFormFields) => {
+  const perioder = data.perioder.map(periode => ({
+    begrunnelse: data.begrunnelse,
+    resultat: nødvendigOpplæringTilResultat(data.harNødvendigOpplæring),
+    avslagsårsak: data.avslagsårsak || null,
+    periode: {
+      fom: dayjs(periode.fom).format('YYYY-MM-DD'),
+      tom: dayjs(periode.tom).format('YYYY-MM-DD'),
+    },
+  }));
+
+  const perioderUtenNødvendigOpplæring = data.perioderUtenNødvendigOpplæring.map(periode => ({
+    begrunnelse: data.begrunnelse,
+    resultat: periode.resultat,
+    avslagsårsak: periode.avslagsårsak || null,
+    periode: {
+      fom: dayjs(periode.fom).format('YYYY-MM-DD'),
+      tom: dayjs(periode.tom).format('YYYY-MM-DD'),
+    },
+  }));
+
+  return {
+    perioder: [...perioder, ...perioderUtenNødvendigOpplæring],
+  };
 };
 
 const NødvendigOpplæringForm = ({
@@ -134,44 +169,16 @@ const NødvendigOpplæringForm = ({
     if (opplæringIkkeDokumentertMedLegeerklæring) {
       formMethods.setValue('begrunnelse', '');
       formMethods.setValue('harNødvendigOpplæring', '');
-    } else {
-      formMethods.setValue('harNødvendigOpplæring', '');
     }
   }, [opplæringIkkeDokumentertMedLegeerklæring, formMethods]);
 
   const nødvendigOpplæring = formMethods.watch('harNødvendigOpplæring');
+  const periodeErEnkeltdag = vurdering.perioder[0]!.fom === vurdering.perioder[0]!.tom;
   return (
     <>
       <Form
         formMethods={formMethods}
-        onSubmit={data => {
-          const perioder = data.perioder.map(periode => ({
-            begrunnelse: data.begrunnelse,
-            resultat:
-              data.harNødvendigOpplæring === 'JA' || data.harNødvendigOpplæring === 'DELVIS'
-                ? OpplæringVurderingDtoResultat.GODKJENT
-                : OpplæringVurderingDtoResultat.IKKE_GODKJENT,
-            avslagsårsak: data.avslagsårsak || null,
-            periode: {
-              fom: dayjs(periode.fom).format('YYYY-MM-DD'),
-              tom: dayjs(periode.tom).format('YYYY-MM-DD'),
-            },
-          }));
-
-          const perioderUtenNødvendigOpplæring = data.perioderUtenNødvendigOpplæring.map(periode => ({
-            begrunnelse: data.begrunnelse,
-            resultat: periode.resultat,
-            avslagsårsak: periode.avslagsårsak || null,
-            periode: {
-              fom: dayjs(periode.fom).format('YYYY-MM-DD'),
-              tom: dayjs(periode.tom).format('YYYY-MM-DD'),
-            },
-          }));
-
-          løsAksjonspunkt9302({
-            perioder: [...perioder, ...perioderUtenNødvendigOpplæring],
-          } as nødvendigOpplæringPayload);
-        }}
+        onSubmit={data => løsAksjonspunkt9302(onSubmit(data) as nødvendigOpplæringPayload)}
       >
         <div className="flex flex-col gap-6">
           <Controller
@@ -193,8 +200,8 @@ const NødvendigOpplæringForm = ({
                 size="small"
                 error={formMethods.formState.errors.harLegeerklæring?.message as string | undefined}
               >
-                <Radio value="JA">Ja</Radio>
-                <Radio value="NEI">Nei</Radio>
+                <Radio value={JA}>Ja</Radio>
+                <Radio value={NEI}>Nei</Radio>
               </RadioGroup>
             )}
           />
@@ -267,22 +274,28 @@ const NødvendigOpplæringForm = ({
                   }
             }
             disabled={opplæringIkkeDokumentertMedLegeerklæring}
-            render={({ field }) => (
-              <RadioGroup
-                legend="Har søker opplæring som er nødvendig?"
-                {...field}
-                readOnly={readOnly}
-                size="small"
-                error={formMethods.formState.errors.harNødvendigOpplæring?.message as string | undefined}
-              >
-                <Radio value="JA">Ja</Radio>
-                <Radio value="DELVIS">Deler av perioden</Radio>
-                <Radio value="NEI">Nei</Radio>
-              </RadioGroup>
-            )}
+            render={({ field }) => {
+              return (
+                <RadioGroup
+                  legend="Har søker opplæring som er nødvendig?"
+                  {...field}
+                  readOnly={readOnly}
+                  size="small"
+                  error={formMethods.formState.errors.harNødvendigOpplæring?.message as string | undefined}
+                >
+                  <Radio value={JA}>Ja</Radio>
+                  {periodeErEnkeltdag ? (
+                    <Radio value={VURDERES_SOM_REISETID}>Vurderes som reisetid</Radio>
+                  ) : (
+                    <Radio value={DELVIS}>Deler av perioden</Radio>
+                  )}
+                  <Radio value={NEI}>Nei</Radio>
+                </RadioGroup>
+              );
+            }}
           />
-          {nødvendigOpplæring === 'DELVIS' && <DelvisOpplæring vurdering={vurdering} />}
-          {nødvendigOpplæring === 'NEI' && <Avslagsårsak name="avslagsårsak" />}
+          {nødvendigOpplæring === DELVIS && <DelvisOpplæring vurdering={vurdering} />}
+          {nødvendigOpplæring === NEI && <Avslagsårsak name="avslagsårsak" />}
           {opplæringIkkeDokumentertMedLegeerklæring && (
             <Alert variant="info" size="small">
               Behandlingen vil gå videre til avslag for manglende dokumentasjon av nødvendig opplæring etter{' '}
@@ -304,397 +317,6 @@ const NødvendigOpplæringForm = ({
           )}
         </div>
       </Form>
-    </>
-  );
-};
-
-const DelvisOpplæring = ({ vurdering }: { vurdering: OpplæringVurderingDto & { perioder: Period[] } }) => {
-  const opprinneligPeriode = vurdering.perioder[0]!;
-  const formMethods = useFormContext<NødvendigOpplæringFormFields>();
-  const readOnly = useContext(SykdomOgOpplæringContext).readOnly;
-  const { fields, append, remove, update } = useFieldArray({
-    control: formMethods.control,
-    name: 'perioder',
-  });
-
-  const uncoveredDays = findUncoveredDays(
-    opprinneligPeriode,
-    fields.map(periode => ({ fom: periode.fom, tom: periode.tom })),
-  );
-  const uncoveredPeriods = combineConsecutivePeriods(uncoveredDays);
-
-  return (
-    <div id="delvis-opplæring">
-      <div className="flex flex-col gap-4">
-        <Label size="small">I hvilken periode er det nødvendig opplæring?</Label>
-        {fields.map((v, index) => (
-          <div className="flex gap-4" key={v.id}>
-            <Controller
-              control={formMethods.control}
-              name={`perioder.${index}.fom`}
-              render={({ field }) => (
-                <RHFDatepicker
-                  {...field}
-                  label="Fra"
-                  size="small"
-                  disabled={readOnly}
-                  validate={[
-                    (value: string) => (value && dayjs(value).isValid() ? undefined : 'Fra er påkrevd'),
-                    (value: string) =>
-                      value && dayjs(value).isSameOrBefore(dayjs(v.tom)) ? undefined : 'Fra må være før til',
-                  ]}
-                  fromDate={new Date(opprinneligPeriode.fom)}
-                  toDate={new Date(opprinneligPeriode.tom)}
-                  onChange={value => {
-                    field.onChange(value);
-                    update(index, { ...v, fom: value });
-                  }}
-                />
-              )}
-            />
-            <Controller
-              control={formMethods.control}
-              name={`perioder.${index}.tom`}
-              render={({ field }) => (
-                <RHFDatepicker
-                  {...field}
-                  label="Til"
-                  size="small"
-                  disabled={readOnly}
-                  validate={[
-                    (value: string) => (value && dayjs(value).isValid() ? undefined : 'Til er påkrevd'),
-                    (value: string) =>
-                      value && dayjs(v.fom).isSameOrBefore(dayjs(value)) ? undefined : 'Til må være etter fra',
-                  ]}
-                  fromDate={new Date(vurdering.opplæring.fom)}
-                  toDate={new Date(vurdering.opplæring.tom)}
-                  onChange={value => {
-                    field.onChange(value);
-                    update(index, { ...v, tom: value });
-                  }}
-                />
-              )}
-            />
-            {index > 0 && (
-              <Button variant="tertiary" size="small" type="button" onClick={() => remove(index)} icon={<TrashIcon />}>
-                Fjern
-              </Button>
-            )}
-          </div>
-        ))}
-        <div>
-          <Button
-            variant="tertiary"
-            size="small"
-            type="button"
-            icon={<PlusCircleIcon />}
-            iconPosition="left"
-            onClick={() => {
-              append({
-                fom: '',
-                tom: '',
-                resultat: '',
-                avslagsårsak: '',
-              });
-            }}
-          >
-            Legg til ny periode
-          </Button>
-          <div>
-            <PerioderUtenNødvendigOpplæring perioder={uncoveredPeriods} />
-          </div>
-        </div>
-      </div>
-    </div>
-  );
-};
-
-const PerioderUtenNødvendigOpplæring = ({ perioder }: { perioder: { fom: string; tom: string }[] }) => {
-  const formMethods = useFormContext<NødvendigOpplæringFormFields>();
-  const { fields, append, remove, update, replace } = useFieldArray<
-    NødvendigOpplæringFormFields,
-    'perioderUtenNødvendigOpplæring',
-    'id'
-  >({
-    control: formMethods.control,
-    name: 'perioderUtenNødvendigOpplæring',
-  });
-  const [periodeSomMåDekkes, setPeriodeSomMåDekkes] = useState<{ fom: string; tom: string } | null>(null);
-
-  useEffect(() => {
-    if (perioder.length > 0) {
-      setPeriodeSomMåDekkes(perioder[0]!);
-    }
-  }, [JSON.stringify(perioder)]);
-
-  useEffect(() => {
-    remove();
-    perioder.forEach(period => {
-      append({
-        fom: period.fom,
-        tom: period.tom,
-        resultat: '',
-        avslagsårsak: '',
-      });
-    });
-  }, [JSON.stringify(perioder)]);
-
-  const checkWhichExistingPeriodToPutPeriodIn = (
-    fields: FieldArrayWithId<NødvendigOpplæringFormFields, 'perioderUtenNødvendigOpplæring', 'id'>[],
-    uncoveredPeriod: { fom: string; tom: string },
-  ) => {
-    return fields.find(field => checkIfPeriodsAreEdgeToEdge(field, uncoveredPeriod));
-  };
-
-  const expandPeriod = (
-    existingPeriod: FieldArrayWithId<NødvendigOpplæringFormFields, 'perioderUtenNødvendigOpplæring', 'id'>,
-    newPeriod: { fom: string; tom: string },
-  ) => {
-    const isBefore = dayjs(newPeriod.fom).isBefore(dayjs(existingPeriod?.fom));
-    if (isBefore) {
-      return {
-        ...existingPeriod,
-        fom: newPeriod.fom,
-      };
-    }
-
-    return { ...existingPeriod, tom: newPeriod.tom };
-  };
-
-  useEffect(() => {
-    if (!periodeSomMåDekkes) return;
-    const uncoveredDays = findUncoveredDays(
-      periodeSomMåDekkes,
-      fields.map(periode => ({ fom: periode.fom, tom: periode.tom })),
-    );
-    if (uncoveredDays.length === 0) return;
-    const uncoveredPeriods = combineConsecutivePeriods(uncoveredDays);
-    const existingPeriod = checkWhichExistingPeriodToPutPeriodIn(fields, uncoveredPeriods[0]!);
-    if (existingPeriod) {
-      replace(
-        [
-          ...fields.filter(field => field.id !== existingPeriod.id),
-          expandPeriod(existingPeriod, uncoveredPeriods[0]!),
-        ].sort((a, b) => dayjs(a.fom).diff(dayjs(b.fom))),
-      );
-    }
-  }, [fields.length, fields, periodeSomMåDekkes, remove, replace]);
-
-  return (
-    <>
-      {fields.map((periodeUtenNødvendigOpplæring, index, array) => {
-        return (
-          <React.Fragment key={periodeUtenNødvendigOpplæring.id}>
-            <div className="mt-4">
-              <Controller
-                control={formMethods.control}
-                name={`perioderUtenNødvendigOpplæring.${index}.resultat`}
-                render={({ field }) => (
-                  <RadioGroup
-                    {...field}
-                    onChange={value => {
-                      field.onChange(value);
-                      update(index, { ...periodeUtenNødvendigOpplæring, resultat: value });
-                    }}
-                    legend={
-                      <div>
-                        Hva vil du gjøre med dagene{' '}
-                        {formatPeriod(periodeUtenNødvendigOpplæring.fom, periodeUtenNødvendigOpplæring.tom)}?{' '}
-                        <PeriodeHandlinger
-                          periodeUtenNødvendigOpplæring={periodeUtenNødvendigOpplæring}
-                          index={index}
-                          replace={replace}
-                          remove={remove}
-                          kanSlette={array.length > 1}
-                        />
-                      </div>
-                    }
-                    size="small"
-                  >
-                    <Radio value={OpplæringVurderingDtoResultat.IKKE_GODKJENT}>Avslag</Radio>
-                    <Radio value={OpplæringVurderingDtoResultat.VURDERES_SOM_REISETID}>Vurder som reisetid</Radio>
-                  </RadioGroup>
-                )}
-              />
-            </div>
-            {periodeUtenNødvendigOpplæring.resultat === OpplæringVurderingDtoResultat.IKKE_GODKJENT && (
-              <div className="mt-4">
-                <Avslagsårsak
-                  name={`perioderUtenNødvendigOpplæring.${index}.avslagsårsak`}
-                  fieldValue={periodeUtenNødvendigOpplæring}
-                  update={update}
-                  index={index}
-                />
-              </div>
-            )}
-          </React.Fragment>
-        );
-      })}
-    </>
-  );
-};
-
-const Avslagsårsak = ({
-  name,
-  update,
-  index,
-  fieldValue,
-}: {
-  name: ControllerProps<NødvendigOpplæringFormFields>['name'];
-  update?: (index: number, value: any) => void;
-  index?: number;
-  fieldValue?: NødvendigOpplæringFormFields['perioderUtenNødvendigOpplæring'][number];
-}) => {
-  const formMethods = useFormContext<NødvendigOpplæringFormFields>();
-  const readOnly = useContext(SykdomOgOpplæringContext).readOnly;
-  const k9Kodeverkoppslag = useContext(K9KodeverkoppslagContext);
-
-  const opplæringIkkeDokumentertMedLegeerklæring = formMethods.watch('harLegeerklæring') === 'NEI';
-
-  return (
-    <Controller
-      control={formMethods.control}
-      name={name}
-      rules={
-        opplæringIkkeDokumentertMedLegeerklæring
-          ? undefined
-          : {
-              validate: value => {
-                return value === KodeverdiSomObjektAvslagsårsakKilde.IKKE_NØDVENDIG_OPPLÆRING ||
-                  value === KodeverdiSomObjektAvslagsårsakKilde.IKKE_OPPLÆRING_I_PERIODEN
-                  ? undefined
-                  : 'Avslagsårsak er påkrevd';
-              },
-            }
-      }
-      render={({ field, fieldState }) => {
-        return (
-          <RadioGroup
-            {...field}
-            legend="Avslagsårsak"
-            readOnly={readOnly}
-            size="small"
-            error={fieldState.error?.message as string | undefined}
-            onChange={value => {
-              field.onChange(value);
-              if (index !== undefined && update) {
-                update(index, { ...fieldValue, avslagsårsak: value });
-              }
-            }}
-          >
-            <Radio value={KodeverdiSomObjektAvslagsårsakKilde.IKKE_NØDVENDIG_OPPLÆRING}>
-              {
-                k9Kodeverkoppslag.k9sak.avslagsårsaker(KodeverdiSomObjektAvslagsårsakKilde.IKKE_NØDVENDIG_OPPLÆRING)
-                  .navn
-              }
-            </Radio>
-            <Radio value={KodeverdiSomObjektAvslagsårsakKilde.IKKE_OPPLÆRING_I_PERIODEN}>
-              {
-                k9Kodeverkoppslag.k9sak.avslagsårsaker(KodeverdiSomObjektAvslagsårsakKilde.IKKE_OPPLÆRING_I_PERIODEN)
-                  .navn
-              }
-            </Radio>
-          </RadioGroup>
-        );
-      }}
-    />
-  );
-};
-
-const PeriodeHandlinger = ({
-  periodeUtenNødvendigOpplæring,
-  replace,
-  remove,
-  index,
-  kanSlette,
-}: {
-  periodeUtenNødvendigOpplæring: NødvendigOpplæringFormFields['perioderUtenNødvendigOpplæring'][number];
-  replace: UseFieldArrayReplace<NødvendigOpplæringFormFields, 'perioderUtenNødvendigOpplæring'>;
-  remove: UseFieldArrayRemove;
-  index: number;
-  kanSlette: boolean;
-}) => {
-  const [visModal, setVisModal] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [klippetPeriode, setKlippetPeriode] = useState<{ fom: string; tom: string } | null>(null);
-
-  const handleCloseModal = () => {
-    setVisModal(false);
-    setError(null);
-    setKlippetPeriode(null);
-  };
-  const antallDager = getDaysInPeriod(periodeUtenNødvendigOpplæring).length;
-
-  const handleSubmit = () => {
-    if (!klippetPeriode) {
-      setError('Du må spesifisere en periode');
-      return;
-    }
-    const uncoveredDays = findUncoveredDays(
-      { fom: periodeUtenNødvendigOpplæring.fom, tom: periodeUtenNødvendigOpplæring.tom },
-      [{ fom: klippetPeriode.fom, tom: klippetPeriode.tom }],
-    );
-
-    const combinedPeriods = combineConsecutivePeriods(uncoveredDays);
-    const newPeriods = [...combinedPeriods, { fom: klippetPeriode.fom, tom: klippetPeriode.tom }]
-      .sort((a, b) => dayjs(a.fom).diff(dayjs(b.fom)))
-      .map(period => ({
-        fom: period.fom,
-        tom: period.tom,
-        resultat: '' as const,
-        avslagsårsak: '' as const,
-      }));
-    replace(newPeriods);
-
-    handleCloseModal();
-  };
-
-  return (
-    <>
-      {antallDager > 1 && (
-        <Button
-          variant="tertiary"
-          size="small"
-          type="button"
-          icon={<ScissorsFillIcon />}
-          onClick={() => setVisModal(true)}
-        />
-      )}
-
-      {kanSlette && (
-        <Button variant="tertiary" size="small" type="button" icon={<TrashIcon />} onClick={() => remove(index)} />
-      )}
-
-      <Modal open={visModal} onClose={() => setVisModal(false)} aria-label="Klipp periode">
-        <Modal.Header>Spesifiser periode</Modal.Header>
-        <Modal.Body>
-          <DatePicker.Standalone
-            mode="range"
-            onSelect={value => {
-              if (value && value.from && value.to) {
-                setKlippetPeriode({
-                  fom: dayjs(value.from).format('YYYY-MM-DD'),
-                  tom: dayjs(value.to).format('YYYY-MM-DD'),
-                });
-              } else {
-                setKlippetPeriode(null);
-              }
-            }}
-            dropdownCaption
-            fromDate={new Date(periodeUtenNødvendigOpplæring.fom)}
-            toDate={new Date(periodeUtenNødvendigOpplæring.tom)}
-          />
-          {error && <Alert variant="error">{error}</Alert>}
-          <div className="flex justify-between mt-4">
-            <Button variant="tertiary" type="button" onClick={handleCloseModal}>
-              Avbryt
-            </Button>
-            <Button variant="primary" type="button" onClick={handleSubmit}>
-              Legg til
-            </Button>
-          </div>
-        </Modal.Body>
-      </Modal>
     </>
   );
 };

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringForm.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringForm.tsx
@@ -11,8 +11,8 @@ import {
   useFormContext,
   type ControllerProps,
   type FieldArrayWithId,
-  type UseFieldArrayAppend,
   type UseFieldArrayRemove,
+  type UseFieldArrayReplace,
 } from 'react-hook-form';
 import { Period } from '@navikt/ft-utils';
 import {
@@ -411,7 +411,11 @@ const DelvisOpplæring = ({ vurdering }: { vurdering: OpplæringVurderingDto & {
 
 const PerioderUtenNødvendigOpplæring = ({ perioder }: { perioder: { fom: string; tom: string }[] }) => {
   const formMethods = useFormContext<NødvendigOpplæringFormFields>();
-  const { fields, append, remove, update, replace } = useFieldArray({
+  const { fields, append, remove, update, replace } = useFieldArray<
+    NødvendigOpplæringFormFields,
+    'perioderUtenNødvendigOpplæring',
+    'id'
+  >({
     control: formMethods.control,
     name: 'perioderUtenNødvendigOpplæring',
   });
@@ -460,7 +464,7 @@ const PerioderUtenNødvendigOpplæring = ({ perioder }: { perioder: { fom: strin
   useEffect(() => {
     if (!periodeSomMåDekkes) return;
     const uncoveredDays = findUncoveredDays(
-      periodeSomMåDekkes!,
+      periodeSomMåDekkes,
       fields.map(periode => ({ fom: periode.fom, tom: periode.tom })),
     );
     if (uncoveredDays.length === 0) return;
@@ -474,7 +478,7 @@ const PerioderUtenNødvendigOpplæring = ({ perioder }: { perioder: { fom: strin
         ].sort((a, b) => dayjs(a.fom).diff(dayjs(b.fom))),
       );
     }
-  }, [fields.length, fields, periodeSomMåDekkes, remove, append]);
+  }, [fields.length, fields, periodeSomMåDekkes, remove, replace]);
 
   return (
     <>
@@ -499,7 +503,7 @@ const PerioderUtenNødvendigOpplæring = ({ perioder }: { perioder: { fom: strin
                         <PeriodeHandlinger
                           periodeUtenNødvendigOpplæring={periodeUtenNødvendigOpplæring}
                           index={index}
-                          append={append}
+                          replace={replace}
                           remove={remove}
                           kanSlette={array.length > 1}
                         />
@@ -599,13 +603,13 @@ const Avslagsårsak = ({
 
 const PeriodeHandlinger = ({
   periodeUtenNødvendigOpplæring,
-  append,
+  replace,
   remove,
   index,
   kanSlette,
 }: {
   periodeUtenNødvendigOpplæring: NødvendigOpplæringFormFields['perioderUtenNødvendigOpplæring'][number];
-  append: UseFieldArrayAppend<NødvendigOpplæringFormFields, 'perioderUtenNødvendigOpplæring'>;
+  replace: UseFieldArrayReplace<NødvendigOpplæringFormFields, 'perioderUtenNødvendigOpplæring'>;
   remove: UseFieldArrayRemove;
   index: number;
   kanSlette: boolean;
@@ -632,7 +636,6 @@ const PeriodeHandlinger = ({
     );
 
     const combinedPeriods = combineConsecutivePeriods(uncoveredDays);
-    remove();
     const newPeriods = [...combinedPeriods, { fom: klippetPeriode.fom, tom: klippetPeriode.tom }]
       .sort((a, b) => dayjs(a.fom).diff(dayjs(b.fom)))
       .map(period => ({
@@ -641,7 +644,7 @@ const PeriodeHandlinger = ({
         resultat: '' as const,
         avslagsårsak: '' as const,
       }));
-    newPeriods.forEach(period => append(period));
+    replace(newPeriods);
 
     handleCloseModal();
   };

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringIndex.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringIndex.tsx
@@ -5,7 +5,7 @@ import { useVurdertOpplæring } from '../SykdomOgOpplæringQueries';
 import { useContext, useState } from 'react';
 import { SykdomOgOpplæringContext } from '../FaktaSykdomOgOpplæringIndex';
 import { Period } from '@navikt/ft-utils';
-import type { OpplæringVurderingDto } from '@k9-sak-web/backend/k9sak/generated';
+import { OpplæringVurderingDtoResultat, type OpplæringVurderingDto } from '@k9-sak-web/backend/k9sak/generated';
 import NødvendigOpplæringContainer from './NødvendigOpplæringContainer';
 import { NavigationWithDetailView } from '../../../shared/navigation-with-detail-view/NavigationWithDetailView';
 import { CenteredLoader } from '../CenteredLoader';
@@ -16,8 +16,7 @@ interface OpplæringVurderingselement extends Omit<Vurderingselement, 'resultat'
 }
 
 const NødvendigOpplæring = () => {
-  const { behandlingUuid, aksjonspunkter, readOnly } = useContext(SykdomOgOpplæringContext);
-  const aksjonspunkt9302 = aksjonspunkter.find(akspunkt => akspunkt.definisjon.kode === '9302');
+  const { behandlingUuid, readOnly } = useContext(SykdomOgOpplæringContext);
   const { data: vurdertOpplæring, isLoading: isLoadingVurdertOpplæring } = useVurdertOpplæring(behandlingUuid);
   const [valgtVurdering, setValgtVurdering] = useState<OpplæringVurderingselement | null>(null);
   const vurderingsliste = vurdertOpplæring?.vurderinger.map(vurdering => ({
@@ -30,7 +29,7 @@ const NødvendigOpplæring = () => {
   }
   return (
     <div>
-      {aksjonspunkt9302?.status.kode === 'OPPRETTET' && !readOnly && (
+      {valgtVurdering?.resultat === OpplæringVurderingDtoResultat.MÅ_VURDERES && !readOnly && (
         <Alert className="mb-4" variant="warning" size="small">
           Vurder om opplæringen er nødvendig for at søker skal kunne ta seg av og behandlet barnet.
         </Alert>

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringIndex.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringIndex.tsx
@@ -9,13 +9,15 @@ import type { OpplæringVurderingDto } from '@k9-sak-web/backend/k9sak/generated
 import NødvendigOpplæringContainer from './NødvendigOpplæringContainer';
 import { NavigationWithDetailView } from '../../../shared/navigation-with-detail-view/NavigationWithDetailView';
 import { CenteredLoader } from '../CenteredLoader';
+import { Alert } from '@navikt/ds-react';
 
 interface OpplæringVurderingselement extends Omit<Vurderingselement, 'resultat'>, OpplæringVurderingDto {
   perioder: Period[];
 }
 
 const NødvendigOpplæring = () => {
-  const { behandlingUuid } = useContext(SykdomOgOpplæringContext);
+  const { behandlingUuid, aksjonspunkter, readOnly } = useContext(SykdomOgOpplæringContext);
+  const harAksjonspunkt9302 = !!aksjonspunkter.find(akspunkt => akspunkt.definisjon.kode === '9302');
   const { data: vurdertOpplæring, isLoading: isLoadingVurdertOpplæring } = useVurdertOpplæring(behandlingUuid);
   const [valgtVurdering, setValgtVurdering] = useState<OpplæringVurderingselement | null>(null);
   const vurderingsliste = vurdertOpplæring?.vurderinger.map(vurdering => ({
@@ -28,6 +30,11 @@ const NødvendigOpplæring = () => {
   }
   return (
     <div>
+      {harAksjonspunkt9302 && !readOnly && (
+        <Alert className="mb-4" variant="warning" size="small">
+          Vurder om opplæringen er nødvendig for at søker skal kunne ta seg av og behandlet barnet.
+        </Alert>
+      )}
       <NavigationWithDetailView
         navigationSection={() => (
           <>

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringIndex.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringIndex.tsx
@@ -17,7 +17,7 @@ interface OpplæringVurderingselement extends Omit<Vurderingselement, 'resultat'
 
 const NødvendigOpplæring = () => {
   const { behandlingUuid, aksjonspunkter, readOnly } = useContext(SykdomOgOpplæringContext);
-  const harAksjonspunkt9302 = !!aksjonspunkter.find(akspunkt => akspunkt.definisjon.kode === '9302');
+  const aksjonspunkt9302 = aksjonspunkter.find(akspunkt => akspunkt.definisjon.kode === '9302');
   const { data: vurdertOpplæring, isLoading: isLoadingVurdertOpplæring } = useVurdertOpplæring(behandlingUuid);
   const [valgtVurdering, setValgtVurdering] = useState<OpplæringVurderingselement | null>(null);
   const vurderingsliste = vurdertOpplæring?.vurderinger.map(vurdering => ({
@@ -30,7 +30,7 @@ const NødvendigOpplæring = () => {
   }
   return (
     <div>
-      {harAksjonspunkt9302 && !readOnly && (
+      {aksjonspunkt9302?.status.kode === 'OPPRETTET' && !readOnly && (
         <Alert className="mb-4" variant="warning" size="small">
           Vurder om opplæringen er nødvendig for at søker skal kunne ta seg av og behandlet barnet.
         </Alert>

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/components/Avslagsårsak.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/components/Avslagsårsak.tsx
@@ -1,0 +1,105 @@
+import {
+  OpplæringVurderingDtoAvslagsårsak,
+  OpplæringVurderingDtoResultat,
+} from '@k9-sak-web/backend/k9sak/generated';
+import {
+  Controller,
+  useFormContext,
+  type ControllerProps,
+} from 'react-hook-form';
+import {
+  Radio,
+  RadioGroup,
+} from '@navikt/ds-react';
+import { useContext } from 'react';
+import { SykdomOgOpplæringContext } from '../../FaktaSykdomOgOpplæringIndex';
+import { KodeverdiSomObjektAvslagsårsakKilde } from '@k9-sak-web/backend/k9sak/generated';
+import { K9KodeverkoppslagContext } from '../../../../kodeverk/oppslag/K9KodeverkoppslagContext.jsx';
+
+type NødvendigOpplæringFormFields = {
+  begrunnelse: string;
+  resultat: OpplæringVurderingDtoResultat | '';
+  harLegeerklæring: 'JA' | 'NEI' | '';
+  harNødvendigOpplæring: 'JA' | 'DELVIS' | 'NEI' | '';
+  avslagsårsak?: OpplæringVurderingDtoAvslagsårsak;
+  perioder: {
+    resultat: OpplæringVurderingDtoResultat | '';
+    avslagsårsak: OpplæringVurderingDtoAvslagsårsak | '';
+    fom: string;
+    tom: string;
+  }[];
+  perioderUtenNødvendigOpplæring: {
+    fom: string;
+    tom: string;
+    resultat: OpplæringVurderingDtoResultat | '';
+    avslagsårsak: OpplæringVurderingDtoAvslagsårsak | '';
+  }[];
+};
+
+export const Avslagsårsak = ({
+  name,
+  update,
+  index,
+  fieldValue,
+}: {
+  name: ControllerProps<NødvendigOpplæringFormFields>['name'];
+  update?: (index: number, value: any) => void;
+  index?: number;
+  fieldValue?: NødvendigOpplæringFormFields['perioderUtenNødvendigOpplæring'][number];
+}) => {
+  const formMethods = useFormContext<NødvendigOpplæringFormFields>();
+  const context = useContext(SykdomOgOpplæringContext);
+  const readOnly = context.readOnly;
+  const k9Kodeverkoppslag = useContext(K9KodeverkoppslagContext);
+
+  const opplæringIkkeDokumentertMedLegeerklæring = formMethods.watch('harLegeerklæring') === 'NEI';
+
+  return (
+    <Controller
+      control={formMethods.control}
+      name={name}
+      rules={
+        opplæringIkkeDokumentertMedLegeerklæring
+          ? undefined
+          : {
+              validate: value => {
+                return value === KodeverdiSomObjektAvslagsårsakKilde.IKKE_NØDVENDIG_OPPLÆRING ||
+                  value === KodeverdiSomObjektAvslagsårsakKilde.IKKE_OPPLÆRING_I_PERIODEN
+                  ? undefined
+                  : 'Avslagsårsak er påkrevd';
+              },
+            }
+      }
+      render={({ field, fieldState }) => {
+        return (
+          <RadioGroup
+            {...field}
+            legend="Avslagsårsak"
+            readOnly={readOnly}
+            size="small"
+            error={fieldState.error?.message as string | undefined}
+            onChange={value => {
+              field.onChange(value);
+              if (index !== undefined && update) {
+                update(index, { ...fieldValue, avslagsårsak: value });
+              }
+            }}
+          >
+            <Radio value={KodeverdiSomObjektAvslagsårsakKilde.IKKE_NØDVENDIG_OPPLÆRING}>
+              {
+                (k9Kodeverkoppslag as any).k9sak.avslagsårsaker(KodeverdiSomObjektAvslagsårsakKilde.IKKE_NØDVENDIG_OPPLÆRING)
+                  .navn
+              }
+            </Radio>
+            <Radio value={KodeverdiSomObjektAvslagsårsakKilde.IKKE_OPPLÆRING_I_PERIODEN}>
+              {
+                (k9Kodeverkoppslag as any).k9sak.avslagsårsaker(KodeverdiSomObjektAvslagsårsakKilde.IKKE_OPPLÆRING_I_PERIODEN)
+                  .navn
+              }
+            </Radio>
+          </RadioGroup>
+        );
+      }}
+    />
+  );
+};

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/components/DelvisOpplæring.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/components/DelvisOpplæring.tsx
@@ -180,6 +180,8 @@ export const PerioderUtenNødvendigOpplæring = ({ perioder }: { perioder: { fom
         };
       }),
     );
+    // perioder er faktisk i dependency arrayet så disabler warning her. Må ha stringify så vi ikke får infinite loop.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [JSON.stringify(perioder), replace]);
 
   const checkWhichExistingPeriodToPutPeriodIn = (

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/components/DelvisOpplæring.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/components/DelvisOpplæring.tsx
@@ -163,13 +163,11 @@ export const PerioderUtenNødvendigOpplæring = ({ perioder }: { perioder: { fom
 
   useEffect(() => {
     if (perioder.length > 0) {
-      console.log('perioder', perioder);
       setPeriodeSomMåDekkes(perioder[0]!);
     }
   }, [perioder]);
 
   useEffect(() => {
-    console.log('replace', perioder);
     replace(
       perioder.map(period => {
         return {

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/components/DelvisOpplæring.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/components/DelvisOpplæring.tsx
@@ -1,0 +1,381 @@
+     import {
+  OpplæringVurderingDtoResultat,
+  type OpplæringVurderingDto,
+  type OpplæringVurderingDtoAvslagsårsak,
+} from '@k9-sak-web/backend/k9sak/generated';
+import {
+  Controller,
+  useFieldArray,
+  useFormContext,
+  type FieldArrayWithId,
+  type UseFieldArrayRemove,
+  type UseFieldArrayReplace,
+} from 'react-hook-form';
+import { Period } from '@navikt/ft-utils';
+import {
+  Alert,
+  Button,
+  Label,
+  Modal,
+  Radio,
+  RadioGroup,
+  DatePicker,
+} from '@navikt/ds-react';
+import React, { useContext, useEffect, useState } from 'react';
+import { SykdomOgOpplæringContext } from '../../FaktaSykdomOgOpplæringIndex';
+import dayjs from 'dayjs';
+import { Datepicker as RHFDatepicker } from '@navikt/ft-form-hooks';
+import { PlusCircleIcon, ScissorsFillIcon, TrashIcon } from '@navikt/aksel-icons';
+import {
+  checkIfPeriodsAreEdgeToEdge,
+  combineConsecutivePeriods,
+  findUncoveredDays,
+  formatPeriod,
+  getDaysInPeriod,
+} from '@k9-sak-web/lib/dateUtils/dateUtils.js';
+import { Avslagsårsak } from './Avslagsårsak';
+
+type NødvendigOpplæringFormFields = {
+  begrunnelse: string;
+  resultat: OpplæringVurderingDtoResultat | '';
+  harLegeerklæring: 'JA' | 'NEI' | '';
+  harNødvendigOpplæring: 'JA' | 'DELVIS' | 'NEI' | '';
+  avslagsårsak?: OpplæringVurderingDtoAvslagsårsak;
+  perioder: {
+    resultat: OpplæringVurderingDtoResultat | '';
+    avslagsårsak: OpplæringVurderingDtoAvslagsårsak | '';
+    fom: string;
+    tom: string;
+  }[];
+  perioderUtenNødvendigOpplæring: {
+    fom: string;
+    tom: string;
+    resultat: OpplæringVurderingDtoResultat | '';
+    avslagsårsak: OpplæringVurderingDtoAvslagsårsak | '';
+  }[];
+};
+
+export const DelvisOpplæring = ({ vurdering }: { vurdering: OpplæringVurderingDto & { perioder: Period[] } }) => {
+  const opprinneligPeriode = vurdering.perioder[0]!;
+  const formMethods = useFormContext<NødvendigOpplæringFormFields>();
+      const context = useContext(SykdomOgOpplæringContext);
+    const readOnly = context.readOnly;
+  const { fields, append, remove, update } = useFieldArray({
+    control: formMethods.control,
+    name: 'perioder',
+  });
+
+  const uncoveredDays = findUncoveredDays(
+    opprinneligPeriode,
+    fields.map(periode => ({ fom: periode.fom, tom: periode.tom })),
+  );
+  const uncoveredPeriods = combineConsecutivePeriods(uncoveredDays);
+
+  return (
+    <div id="delvis-opplæring">
+      <div className="flex flex-col gap-4">
+        <Label size="small">I hvilken periode er det nødvendig opplæring?</Label>
+        {fields.map((v, index) => (
+          <div className="flex gap-4" key={v.id}>
+            <Controller
+              control={formMethods.control}
+              name={`perioder.${index}.fom`}
+              render={({ field }) => (
+                <RHFDatepicker
+                  {...field}
+                  label="Fra"
+                  size="small"
+                  disabled={readOnly}
+                  validate={[
+                    (value: string) => (value && dayjs(value).isValid() ? undefined : 'Fra er påkrevd'),
+                    (value: string) =>
+                      value && dayjs(value).isSameOrBefore(dayjs(v.tom)) ? undefined : 'Fra må være før til',
+                  ]}
+                  fromDate={new Date(opprinneligPeriode.fom)}
+                  toDate={new Date(opprinneligPeriode.tom)}
+                  onChange={value => {
+                    field.onChange(value);
+                    update(index, { ...v, fom: value });
+                  }}
+                />
+              )}
+            />
+            <Controller
+              control={formMethods.control}
+              name={`perioder.${index}.tom`}
+              render={({ field }) => (
+                <RHFDatepicker
+                  {...field}
+                  label="Til"
+                  size="small"
+                  disabled={readOnly}
+                  validate={[
+                    (value: string) => (value && dayjs(value).isValid() ? undefined : 'Til er påkrevd'),
+                    (value: string) =>
+                      value && dayjs(v.fom).isSameOrBefore(dayjs(value)) ? undefined : 'Til må være etter fra',
+                  ]}
+                  fromDate={new Date(vurdering.opplæring.fom)}
+                  toDate={new Date(vurdering.opplæring.tom)}
+                  onChange={value => {
+                    field.onChange(value);
+                    update(index, { ...v, tom: value });
+                  }}
+                />
+              )}
+            />
+            {index > 0 && (
+              <Button variant="tertiary" size="small" type="button" onClick={() => remove(index)} icon={<TrashIcon />}>
+                Fjern
+              </Button>
+            )}
+          </div>
+        ))}
+        <div>
+          <Button
+            variant="tertiary"
+            size="small"
+            type="button"
+            icon={<PlusCircleIcon />}
+            iconPosition="left"
+            onClick={() => {
+              append({
+                fom: '',
+                tom: '',
+                resultat: '',
+                avslagsårsak: '',
+              });
+            }}
+          >
+            Legg til ny periode
+          </Button>
+          <div>
+            <PerioderUtenNødvendigOpplæring perioder={uncoveredPeriods} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export const PerioderUtenNødvendigOpplæring = ({ perioder }: { perioder: { fom: string; tom: string }[] }) => {
+  const formMethods = useFormContext<NødvendigOpplæringFormFields>();
+  const { fields, append, remove, update, replace } = useFieldArray<
+    NødvendigOpplæringFormFields,
+    'perioderUtenNødvendigOpplæring',
+    'id'
+  >({
+    control: formMethods.control,
+    name: 'perioderUtenNødvendigOpplæring',
+  });
+  const [periodeSomMåDekkes, setPeriodeSomMåDekkes] = useState<{ fom: string; tom: string } | null>(null);
+
+  useEffect(() => {
+    if (perioder.length > 0) {
+      setPeriodeSomMåDekkes(perioder[0]!);
+    }
+  }, [perioder]);
+
+  useEffect(() => {
+    remove();
+    perioder.forEach(period => {
+      append({
+        fom: period.fom,
+        tom: period.tom,
+        resultat: '',
+        avslagsårsak: '',
+      });
+    });
+  }, [perioder, remove, append]);
+
+  const checkWhichExistingPeriodToPutPeriodIn = (
+    fields: FieldArrayWithId<NødvendigOpplæringFormFields, 'perioderUtenNødvendigOpplæring', 'id'>[],
+    uncoveredPeriod: { fom: string; tom: string },
+  ) => {
+    return fields.find(field => checkIfPeriodsAreEdgeToEdge(field, uncoveredPeriod));
+  };
+
+  const expandPeriod = (
+    existingPeriod: FieldArrayWithId<NødvendigOpplæringFormFields, 'perioderUtenNødvendigOpplæring', 'id'>,
+    newPeriod: { fom: string; tom: string },
+  ) => {
+    const isBefore = dayjs(newPeriod.fom).isBefore(dayjs(existingPeriod?.fom));
+    if (isBefore) {
+      return {
+        ...existingPeriod,
+        fom: newPeriod.fom,
+      };
+    }
+
+    return { ...existingPeriod, tom: newPeriod.tom };
+  };
+
+  useEffect(() => {
+    if (!periodeSomMåDekkes) return;
+    const uncoveredDays = findUncoveredDays(
+      periodeSomMåDekkes,
+      fields.map(periode => ({ fom: periode.fom, tom: periode.tom })),
+    );
+    if (uncoveredDays.length === 0) return;
+    const uncoveredPeriods = combineConsecutivePeriods(uncoveredDays);
+    const existingPeriod = checkWhichExistingPeriodToPutPeriodIn(fields, uncoveredPeriods[0]!);
+    if (existingPeriod) {
+      replace(
+        [
+          ...fields.filter(field => field.id !== existingPeriod.id),
+          expandPeriod(existingPeriod, uncoveredPeriods[0]!),
+        ].sort((a, b) => dayjs(a.fom).diff(dayjs(b.fom))),
+      );
+    }
+  }, [fields.length, fields, periodeSomMåDekkes, remove, replace]);
+
+  return (
+    <>
+      {fields.map((periodeUtenNødvendigOpplæring, index, array) => {
+        return (
+          <React.Fragment key={periodeUtenNødvendigOpplæring.id}>
+            <div className="mt-4">
+              <Controller
+                control={formMethods.control}
+                name={`perioderUtenNødvendigOpplæring.${index}.resultat`}
+                render={({ field }) => (
+                  <RadioGroup
+                    {...field}
+                    onChange={value => {
+                      field.onChange(value);
+                      update(index, { ...periodeUtenNødvendigOpplæring, resultat: value });
+                    }}
+                    legend={
+                      <div>
+                        Hva vil du gjøre med dagene{' '}
+                        {formatPeriod(periodeUtenNødvendigOpplæring.fom, periodeUtenNødvendigOpplæring.tom)}?{' '}
+                        <PeriodeHandlinger
+                          periodeUtenNødvendigOpplæring={periodeUtenNødvendigOpplæring}
+                          index={index}
+                          replace={replace}
+                          remove={remove}
+                          kanSlette={array.length > 1}
+                        />
+                      </div>
+                    }
+                    size="small"
+                  >
+                    <Radio value={OpplæringVurderingDtoResultat.IKKE_GODKJENT}>Avslag</Radio>
+                    <Radio value={OpplæringVurderingDtoResultat.VURDERES_SOM_REISETID}>Vurder som reisetid</Radio>
+                  </RadioGroup>
+                )}
+              />
+            </div>
+            {periodeUtenNødvendigOpplæring.resultat === OpplæringVurderingDtoResultat.IKKE_GODKJENT && (
+              <div className="mt-4">
+                <Avslagsårsak
+                  name={`perioderUtenNødvendigOpplæring.${index}.avslagsårsak`}
+                  fieldValue={periodeUtenNødvendigOpplæring}
+                  update={update}
+                  index={index}
+                />
+              </div>
+            )}
+          </React.Fragment>
+        );
+      })}
+    </>
+  );
+};
+
+const PeriodeHandlinger = ({
+  periodeUtenNødvendigOpplæring,
+  replace,
+  remove,
+  index,
+  kanSlette,
+}: {
+  periodeUtenNødvendigOpplæring: NødvendigOpplæringFormFields['perioderUtenNødvendigOpplæring'][number];
+  replace: UseFieldArrayReplace<NødvendigOpplæringFormFields, 'perioderUtenNødvendigOpplæring'>;
+  remove: UseFieldArrayRemove;
+  index: number;
+  kanSlette: boolean;
+}) => {
+  const [visModal, setVisModal] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [klippetPeriode, setKlippetPeriode] = useState<{ fom: string; tom: string } | null>(null);
+
+  const handleCloseModal = () => {
+    setVisModal(false);
+    setError(null);
+    setKlippetPeriode(null);
+  };
+  const antallDager = getDaysInPeriod(periodeUtenNødvendigOpplæring).length;
+
+  const handleSubmit = () => {
+    if (!klippetPeriode) {
+      setError('Du må spesifisere en periode');
+      return;
+    }
+    const uncoveredDays = findUncoveredDays(
+      { fom: periodeUtenNødvendigOpplæring.fom, tom: periodeUtenNødvendigOpplæring.tom },
+      [{ fom: klippetPeriode.fom, tom: klippetPeriode.tom }],
+    );
+
+    const combinedPeriods = combineConsecutivePeriods(uncoveredDays);
+    const newPeriods = [...combinedPeriods, { fom: klippetPeriode.fom, tom: klippetPeriode.tom }]
+      .sort((a, b) => dayjs(a.fom).diff(dayjs(b.fom)))
+      .map(period => ({
+        fom: period.fom,
+        tom: period.tom,
+        resultat: '' as const,
+        avslagsårsak: '' as const,
+      }));
+    replace(newPeriods);
+
+    handleCloseModal();
+  };
+
+  return (
+    <>
+      {antallDager > 1 && (
+        <Button
+          variant="tertiary"
+          size="small"
+          type="button"
+          icon={<ScissorsFillIcon />}
+          onClick={() => setVisModal(true)}
+        />
+      )}
+
+      {kanSlette && (
+        <Button variant="tertiary" size="small" type="button" icon={<TrashIcon />} onClick={() => remove(index)} />
+      )}
+
+      <Modal open={visModal} onClose={() => setVisModal(false)} aria-label="Klipp periode">
+        <Modal.Header>Spesifiser periode</Modal.Header>
+        <Modal.Body>
+          <DatePicker.Standalone
+            mode="range"
+            onSelect={value => {
+              if (value && value.from && value.to) {
+                setKlippetPeriode({
+                  fom: dayjs(value.from).format('YYYY-MM-DD'),
+                  tom: dayjs(value.to).format('YYYY-MM-DD'),
+                });
+              } else {
+                setKlippetPeriode(null);
+              }
+            }}
+            dropdownCaption
+            fromDate={new Date(periodeUtenNødvendigOpplæring.fom)}
+            toDate={new Date(periodeUtenNødvendigOpplæring.tom)}
+          />
+          {error && <Alert variant="error">{error}</Alert>}
+          <div className="flex justify-between mt-4">
+            <Button variant="tertiary" type="button" onClick={handleCloseModal}>
+              Avbryt
+            </Button>
+            <Button variant="primary" type="button" onClick={handleSubmit}>
+              Legg til
+            </Button>
+          </div>
+        </Modal.Body>
+      </Modal>
+    </>
+  );
+};

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/components/DelvisOpplæring.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/components/DelvisOpplæring.tsx
@@ -1,4 +1,4 @@
-     import {
+import {
   OpplæringVurderingDtoResultat,
   type OpplæringVurderingDto,
   type OpplæringVurderingDtoAvslagsårsak,
@@ -12,15 +12,7 @@ import {
   type UseFieldArrayReplace,
 } from 'react-hook-form';
 import { Period } from '@navikt/ft-utils';
-import {
-  Alert,
-  Button,
-  Label,
-  Modal,
-  Radio,
-  RadioGroup,
-  DatePicker,
-} from '@navikt/ds-react';
+import { Alert, Button, Label, Modal, Radio, RadioGroup, DatePicker } from '@navikt/ds-react';
 import React, { useContext, useEffect, useState } from 'react';
 import { SykdomOgOpplæringContext } from '../../FaktaSykdomOgOpplæringIndex';
 import dayjs from 'dayjs';
@@ -58,8 +50,8 @@ type NødvendigOpplæringFormFields = {
 export const DelvisOpplæring = ({ vurdering }: { vurdering: OpplæringVurderingDto & { perioder: Period[] } }) => {
   const opprinneligPeriode = vurdering.perioder[0]!;
   const formMethods = useFormContext<NødvendigOpplæringFormFields>();
-      const context = useContext(SykdomOgOpplæringContext);
-    const readOnly = context.readOnly;
+  const context = useContext(SykdomOgOpplæringContext);
+  const readOnly = context.readOnly;
   const { fields, append, remove, update } = useFieldArray({
     control: formMethods.control,
     name: 'perioder',
@@ -159,7 +151,7 @@ export const DelvisOpplæring = ({ vurdering }: { vurdering: OpplæringVurdering
 
 export const PerioderUtenNødvendigOpplæring = ({ perioder }: { perioder: { fom: string; tom: string }[] }) => {
   const formMethods = useFormContext<NødvendigOpplæringFormFields>();
-  const { fields, append, remove, update, replace } = useFieldArray<
+  const { fields, remove, update, replace } = useFieldArray<
     NødvendigOpplæringFormFields,
     'perioderUtenNødvendigOpplæring',
     'id'
@@ -171,21 +163,24 @@ export const PerioderUtenNødvendigOpplæring = ({ perioder }: { perioder: { fom
 
   useEffect(() => {
     if (perioder.length > 0) {
+      console.log('perioder', perioder);
       setPeriodeSomMåDekkes(perioder[0]!);
     }
   }, [perioder]);
 
   useEffect(() => {
-    remove();
-    perioder.forEach(period => {
-      append({
-        fom: period.fom,
-        tom: period.tom,
-        resultat: '',
-        avslagsårsak: '',
-      });
-    });
-  }, [perioder, remove, append]);
+    console.log('replace', perioder);
+    replace(
+      perioder.map(period => {
+        return {
+          fom: period.fom,
+          tom: period.tom,
+          resultat: '',
+          avslagsårsak: '',
+        };
+      }),
+    );
+  }, [JSON.stringify(perioder), replace]);
 
   const checkWhichExistingPeriodToPutPeriodIn = (
     fields: FieldArrayWithId<NødvendigOpplæringFormFields, 'perioderUtenNødvendigOpplæring', 'id'>[],

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/components/InstitusjonOgSykdomInfo.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/components/InstitusjonOgSykdomInfo.tsx
@@ -1,14 +1,15 @@
 import { BodyShort, Label, Skeleton } from '@navikt/ds-react';
+
+import { useContext } from 'react';
+import type { Period as PeriodType } from '@navikt/ft-utils';
+import { Period } from '@navikt/ft-utils';
+import { ICD10 } from '@navikt/diagnosekoder';
+import { SykdomOgOpplæringContext } from '../../FaktaSykdomOgOpplæringIndex';
 import {
   useInstitusjonInfo,
   useLangvarigSykVurderingerFagsak,
   useVurdertLangvarigSykdom,
-} from '../SykdomOgOpplæringQueries';
-import { useContext } from 'react';
-import { SykdomOgOpplæringContext } from '../FaktaSykdomOgOpplæringIndex';
-import type { Period as PeriodType } from '@navikt/ft-utils';
-import { Period } from '@navikt/ft-utils';
-import { ICD10 } from '@navikt/diagnosekoder';
+} from '../../SykdomOgOpplæringQueries';
 
 const InstitusjonOgSykdomInfo = ({ perioder }: { perioder: PeriodType[] }) => {
   const periode = perioder[0];

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/FaktaSykdomOgOpplæringIndex.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/FaktaSykdomOgOpplæringIndex.tsx
@@ -17,7 +17,20 @@ import {
   VilkårMedPerioderDtoVilkarType,
   VilkårPeriodeDtoVilkarStatus,
   type OpprettLangvarigSykdomsVurderingData,
+  OpplæringVurderingDtoAvslagsårsak,
 } from '@k9-sak-web/backend/k9sak/generated';
+
+export type nødvendigOpplæringPayload = {
+  perioder: {
+    periode: {
+      fom: string;
+      tom: string;
+    };
+    begrunnelse: string | null;
+    resultat: OpplæringVurderingDtoResultat;
+    avslagsårsak?: OpplæringVurderingDtoAvslagsårsak;
+  }[];
+};
 
 const finnTabMedAksjonspunkt = (aksjonspunkter: Aksjonspunkt[]) => {
   if (
@@ -65,18 +78,7 @@ type payloads =
       vurderingData?: OpprettLangvarigSykdomsVurderingData['requestBody'];
     }
   | { behandlingUuid?: string }
-  | {
-      perioder: {
-        periode: {
-          fom: string;
-          tom: string;
-        };
-        begrunnelse: string | null;
-        nødvendigOpplæring: boolean;
-        dokumentertOpplæring: boolean;
-        avslagsårsak?: string;
-      }[];
-    }
+  | nødvendigOpplæringPayload
   | {
       reisetid: {
         periode: {
@@ -103,17 +105,7 @@ type SykdomOgOpplæringContext = {
     langvarigsykdomsvurderingUuid?: string,
     vurderingData?: OpprettLangvarigSykdomsVurderingData['requestBody'],
   ) => void;
-  løsAksjonspunkt9302: (payload: {
-    perioder: {
-      periode: {
-        fom: string;
-        tom: string;
-      };
-      begrunnelse: string | null;
-      avslagsårsak?: string;
-      vurdertOpplæringResultat: OpplæringVurderingDtoResultat;
-    };
-  }) => void;
+  løsAksjonspunkt9302: (payload: nødvendigOpplæringPayload) => void;
   løsAksjonspunkt9303: (payload: {
     periode: {
       fom: string;
@@ -186,29 +178,12 @@ const FaktaSykdomOgOpplæringIndex = ({
     }
   };
 
-  const løsAksjonspunkt9302 = (payload: {
-    periode: {
-      fom: string;
-      tom: string;
-    };
-    begrunnelse: string | null;
-    nødvendigOpplæring: boolean;
-    dokumentertOpplæring: boolean;
-    avslagsårsak?: string;
-  }) => {
+  const løsAksjonspunkt9302 = (payload: nødvendigOpplæringPayload) => {
     submitCallback([
       {
         kode: aksjonspunktCodes.VURDER_OPPLÆRING,
-        begrunnelse: payload.begrunnelse,
-        perioder: [
-          {
-            periode: payload.periode,
-            begrunnelse: payload.begrunnelse,
-            nødvendigOpplæring: payload.nødvendigOpplæring,
-            dokumentertOpplæring: payload.dokumentertOpplæring,
-            avslagsårsak: payload.avslagsårsak,
-          },
-        ],
+        begrunnelse: payload.perioder[0]?.begrunnelse,
+        perioder: [...payload.perioder],
       },
     ]);
   };

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/FaktaSykdomOgOpplæringIndex.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/FaktaSykdomOgOpplæringIndex.tsx
@@ -13,6 +13,7 @@ import { useSearchParams } from 'react-router';
 import tabCodes from './tabCodes';
 import { useVilkår } from './SykdomOgOpplæringQueries.js';
 import {
+  OpplæringVurderingDtoResultat,
   VilkårMedPerioderDtoVilkarType,
   VilkårPeriodeDtoVilkarStatus,
   type OpprettLangvarigSykdomsVurderingData,
@@ -103,14 +104,15 @@ type SykdomOgOpplæringContext = {
     vurderingData?: OpprettLangvarigSykdomsVurderingData['requestBody'],
   ) => void;
   løsAksjonspunkt9302: (payload: {
-    periode: {
-      fom: string;
-      tom: string;
+    perioder: {
+      periode: {
+        fom: string;
+        tom: string;
+      };
+      begrunnelse: string | null;
+      avslagsårsak?: string;
+      vurdertOpplæringResultat: OpplæringVurderingDtoResultat;
     };
-    begrunnelse: string | null;
-    nødvendigOpplæring: boolean;
-    dokumentertOpplæring: boolean;
-    avslagsårsak?: string;
   }) => void;
   løsAksjonspunkt9303: (payload: {
     periode: {

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/FaktaSykdomOgOpplæringIndex.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/FaktaSykdomOgOpplæringIndex.tsx
@@ -279,23 +279,43 @@ const SykdomOgOpplæring = () => {
             {harAksjonspunkt9300 || institusjonVilkårErVurdert ? (
               <FaktaInstitusjonIndex />
             ) : (
-              <Alert variant="info">Ikke vurdert</Alert>
+              <Alert variant="info" size="small">
+                Ikke vurdert
+              </Alert>
             )}
           </div>
         </Tabs.Panel>
         <Tabs.Panel value={tabCodes.SYKDOM} lazy={false}>
           <div className="mt-4">
-            {harAksjonspunkt9301 ? <SykdomUperiodisertIndex /> : <Alert variant="info">Ikke vurdert</Alert>}
+            {harAksjonspunkt9301 ? (
+              <SykdomUperiodisertIndex />
+            ) : (
+              <Alert variant="info" size="small">
+                Ikke vurdert
+              </Alert>
+            )}
           </div>
         </Tabs.Panel>
         <Tabs.Panel value={tabCodes.OPPLÆRING} lazy={false}>
           <div className="mt-4">
-            {harAksjonspunkt9302 ? <NødvendigOpplæringIndex /> : <Alert variant="info">Ikke vurdert</Alert>}
+            {harAksjonspunkt9302 ? (
+              <NødvendigOpplæringIndex />
+            ) : (
+              <Alert variant="info" size="small">
+                Ikke vurdert
+              </Alert>
+            )}
           </div>
         </Tabs.Panel>
         <Tabs.Panel value={tabCodes.REISETID} lazy={false}>
           <div className="mt-4">
-            {harAksjonspunkt9303 ? <ReisetidIndex /> : <Alert variant="info">Ikke vurdert</Alert>}
+            {harAksjonspunkt9303 ? (
+              <ReisetidIndex />
+            ) : (
+              <Alert variant="info" size="small">
+                Ikke vurdert
+              </Alert>
+            )}
           </div>
         </Tabs.Panel>
       </Tabs>

--- a/packages/v2/gui/src/shared/detailView/DetailView.tsx
+++ b/packages/v2/gui/src/shared/detailView/DetailView.tsx
@@ -1,6 +1,8 @@
 import React from 'react';
 
-import { Heading } from '@navikt/ds-react';
+import { BodyShort, Heading } from '@navikt/ds-react';
+import { CalendarIcon } from '@navikt/aksel-icons';
+import type { Period } from '@navikt/ft-utils';
 
 export interface DetailViewProps {
   title: string;
@@ -9,6 +11,7 @@ export interface DetailViewProps {
   belowTitleContent?: React.ReactNode;
   className?: string;
   border?: boolean;
+  perioder?: Period[];
 }
 
 export const DetailView = ({
@@ -19,6 +22,7 @@ export const DetailView = ({
   className,
   // Vi vil egentlig ha en border alle stedene denne er brukt. Men mange steder er den allerede implementert i "children"
   border = false,
+  perioder,
 }: DetailViewProps) => {
   const cls = `border border-solid border-[#c6c2bf] rounded p-6 bg-[#cce1f342] ${className ?? ''}`;
   return (
@@ -27,11 +31,31 @@ export const DetailView = ({
         <Heading size="small" level="2">
           {title}
         </Heading>
+
         {contentAfterTitleRenderer && contentAfterTitleRenderer()}
       </div>
+      {perioder && <div className="mt-1">{<Periodevisning perioder={perioder} />}</div>}
       {belowTitleContent && <div className="mt-1">{belowTitleContent}</div>}
       {border && <div className="border-none bg-border-subtle h-[2px] mt-4" />}
       {children}
+    </div>
+  );
+};
+
+export const Periodevisning = ({ perioder }: { perioder: Period[] }) => {
+  return (
+    <div data-testid="Periode" className="flex gap-2">
+      <CalendarIcon fontSize="20" />
+      {perioder.map(periode => {
+        const enkeltdag = periode.asListOfDays().length === 1;
+        return (
+          <div key={periode.fom + periode.tom}>
+            <BodyShort size="small">
+              {enkeltdag ? periode.prettifyPeriod().split(' - ')[0] : periode.prettifyPeriod()}
+            </BodyShort>
+          </div>
+        );
+      })}
     </div>
   );
 };

--- a/packages/v2/gui/src/shared/labelled-content/LabelledContent.tsx
+++ b/packages/v2/gui/src/shared/labelled-content/LabelledContent.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Label } from '@navikt/ds-react';
+import { Detail, Label } from '@navikt/ds-react';
 import classNames from 'classnames';
 
 export interface LabelledContentProps {
@@ -10,6 +10,7 @@ export interface LabelledContentProps {
   indentContent?: boolean;
   size?: 'medium' | 'small';
   hideLabel?: boolean;
+  description?: string;
 }
 
 export const LabelledContent = ({
@@ -19,6 +20,7 @@ export const LabelledContent = ({
   indentContent,
   size = 'small',
   hideLabel = false,
+  description,
 }: LabelledContentProps) => {
   const cl = classNames('mt-2', {
     'border-solid border-t-0 border-r-0 border-b-0 border-l-4 border-[#c9c9c9] py-[3px] pl-[13px]':
@@ -31,6 +33,7 @@ export const LabelledContent = ({
           {label}
         </Label>
       )}
+      {description && <Detail className="mt-1">{description}</Detail>}
       <div className={cl}>{content}</div>
     </div>
   );

--- a/packages/v2/gui/src/shared/vurderingsperiode-navigasjon/PeriodeRad.tsx
+++ b/packages/v2/gui/src/shared/vurderingsperiode-navigasjon/PeriodeRad.tsx
@@ -1,6 +1,7 @@
 import { Period } from '@navikt/ft-utils';
 
 import {
+  AirplaneIcon,
   CheckmarkCircleFillIcon,
   ChevronRightIcon,
   ExclamationmarkTriangleFillIcon,
@@ -25,6 +26,14 @@ const renderStatusIcon = (resultat?: ResultatType) => {
         fontSize="1.5rem"
         style={{ color: 'var(--ac-alert-icon-warning-color,var(--a-icon-warning))' }}
       />
+    );
+  }
+
+  if (resultat === Resultat.VURDERES_SOM_REISETID) {
+    return (
+      <Tooltip content="Perioden vurderes som reisetid">
+        <AirplaneIcon fontSize={26} />
+      </Tooltip>
     );
   }
 

--- a/packages/v2/lib/src/dateUtils/dateUtils.spec.ts
+++ b/packages/v2/lib/src/dateUtils/dateUtils.spec.ts
@@ -15,6 +15,8 @@ import {
   isValidDate,
   splitWeeksAndDays,
   timeFormat,
+  combineConsecutivePeriods,
+  type DateOrPeriod,
 } from './dateUtils';
 
 describe('dateUtils', () => {
@@ -234,5 +236,89 @@ describe('dateUtils', () => {
     it('should return input if period is invalid', () => {
       expect(formatereLukketPeriode('invalid-period')).toBe('invalid-period');
     });
+  });
+});
+
+describe('combineConsecutivePeriods', () => {
+  it('should return empty array for empty input', () => {
+    expect(combineConsecutivePeriods([])).toEqual([]);
+  });
+
+  it('should handle single dates', () => {
+    const dates: DateOrPeriod[] = ['2023-01-01', '2023-01-03', '2023-01-02'];
+    const result = combineConsecutivePeriods(dates);
+    expect(result).toEqual([{ fom: '2023-01-01', tom: '2023-01-03' }]);
+  });
+
+  it('should handle periods', () => {
+    const periods: DateOrPeriod[] = [
+      { fom: '2023-01-01', tom: '2023-01-05' },
+      { fom: '2023-01-03', tom: '2023-01-07' },
+      { fom: '2023-01-10', tom: '2023-01-12' },
+    ];
+    const result = combineConsecutivePeriods(periods);
+    expect(result).toEqual([
+      { fom: '2023-01-01', tom: '2023-01-07' },
+      { fom: '2023-01-10', tom: '2023-01-12' },
+    ]);
+  });
+
+  it('should handle mixed dates and periods', () => {
+    const mixed: DateOrPeriod[] = [
+      '2023-01-01',
+      { fom: '2023-01-02', tom: '2023-01-04' },
+      '2023-01-05',
+      { fom: '2023-01-08', tom: '2023-01-10' },
+    ];
+    const result = combineConsecutivePeriods(mixed);
+    expect(result).toEqual([
+      { fom: '2023-01-01', tom: '2023-01-05' },
+      { fom: '2023-01-08', tom: '2023-01-10' },
+    ]);
+  });
+
+  it('should handle consecutive periods', () => {
+    const periods: DateOrPeriod[] = [
+      { fom: '2023-01-01', tom: '2023-01-05' },
+      { fom: '2023-01-06', tom: '2023-01-10' },
+    ];
+    const result = combineConsecutivePeriods(periods);
+    expect(result).toEqual([{ fom: '2023-01-01', tom: '2023-01-10' }]);
+  });
+
+  it('should handle overlapping periods', () => {
+    const periods: DateOrPeriod[] = [
+      { fom: '2023-01-01', tom: '2023-01-05' },
+      { fom: '2023-01-03', tom: '2023-01-07' },
+      { fom: '2023-01-06', tom: '2023-01-10' },
+    ];
+    const result = combineConsecutivePeriods(periods);
+    expect(result).toEqual([{ fom: '2023-01-01', tom: '2023-01-10' }]);
+  });
+
+  it('should handle non-overlapping periods', () => {
+    const periods: DateOrPeriod[] = [
+      { fom: '2023-01-01', tom: '2023-01-05' },
+      { fom: '2023-01-10', tom: '2023-01-15' },
+      { fom: '2023-01-20', tom: '2023-01-25' },
+    ];
+    const result = combineConsecutivePeriods(periods);
+    expect(result).toEqual([
+      { fom: '2023-01-01', tom: '2023-01-05' },
+      { fom: '2023-01-10', tom: '2023-01-15' },
+      { fom: '2023-01-20', tom: '2023-01-25' },
+    ]);
+  });
+
+  it('should handle single date', () => {
+    const dates: DateOrPeriod[] = ['2023-01-01'];
+    const result = combineConsecutivePeriods(dates);
+    expect(result).toEqual([{ fom: '2023-01-01', tom: '2023-01-01' }]);
+  });
+
+  it('should handle single period', () => {
+    const periods: DateOrPeriod[] = [{ fom: '2023-01-01', tom: '2023-01-05' }];
+    const result = combineConsecutivePeriods(periods);
+    expect(result).toEqual([{ fom: '2023-01-01', tom: '2023-01-05' }]);
   });
 });

--- a/packages/v2/lib/src/dateUtils/dateUtils.ts
+++ b/packages/v2/lib/src/dateUtils/dateUtils.ts
@@ -66,7 +66,7 @@ const sortPeriodsByFom = (periods: FomTom[]): FomTom[] => {
 };
 
 export const getDaysInPeriod = (period: FomTom): string[] => {
-  const days = [];
+  const days: string[] = [];
   const startDate = initializeDate(period.fom);
   const endDate = initializeDate(period.tom);
   for (let date = startDate; date.isSameOrBefore(endDate); date = date.add(1, 'day')) {

--- a/packages/v2/lib/src/dateUtils/dateUtils.ts
+++ b/packages/v2/lib/src/dateUtils/dateUtils.ts
@@ -6,13 +6,13 @@ export const TIDENES_ENDE = '9999-12-31';
 export const TIMER_PER_DAG = 7.5;
 
 // Type for periods that can be combined
-export type Period = { fom: string; tom: string };
+export type FomTom = { fom: string; tom: string };
 
 // Type for single dates or periods
-export type DateOrPeriod = string | Period;
+export type DateOrPeriod = string | FomTom;
 
 // Helper function to check if a date is within a period
-const isDateInPeriod = (date: string, period: Period): boolean => {
+const isDateInPeriod = (date: string, period: FomTom): boolean => {
   const dateObj = initializeDate(date);
   const fomObj = initializeDate(period.fom);
   const tomObj = initializeDate(period.tom);
@@ -20,14 +20,14 @@ const isDateInPeriod = (date: string, period: Period): boolean => {
 };
 
 // Helper function to check if two periods are consecutive (edge to edge)
-const arePeriodsConsecutive = (period1: Period, period2: Period): boolean => {
+const arePeriodsConsecutive = (period1: FomTom, period2: FomTom): boolean => {
   const period1Tom = initializeDate(period1.tom);
   const period2Fom = initializeDate(period2.fom);
   return period1Tom.add(1, 'day').isSame(period2Fom);
 };
 
 // Helper function to check if two periods can be combined
-const canCombinePeriods = (period1: Period, period2: Period): boolean => {
+const canCombinePeriods = (period1: FomTom, period2: FomTom): boolean => {
   // Check if periods overlap
   const hasOverlap = isDateInPeriod(period2.fom, period1) || isDateInPeriod(period1.tom, period2);
   // Check if periods are consecutive
@@ -36,7 +36,7 @@ const canCombinePeriods = (period1: Period, period2: Period): boolean => {
 };
 
 // Helper function to combine two periods
-const combineTwoPeriods = (period1: Period, period2: Period): Period => {
+const combineTwoPeriods = (period1: FomTom, period2: FomTom): FomTom => {
   const fom1 = initializeDate(period1.fom);
   const tom1 = initializeDate(period1.tom);
   const fom2 = initializeDate(period2.fom);
@@ -49,7 +49,7 @@ const combineTwoPeriods = (period1: Period, period2: Period): Period => {
 };
 
 // Helper function to convert single dates to periods
-const convertDateToPeriod = (dateOrPeriod: DateOrPeriod): Period => {
+const convertDateToPeriod = (dateOrPeriod: DateOrPeriod): FomTom => {
   if (typeof dateOrPeriod === 'string') {
     return { fom: dateOrPeriod, tom: dateOrPeriod };
   }
@@ -57,7 +57,7 @@ const convertDateToPeriod = (dateOrPeriod: DateOrPeriod): Period => {
 };
 
 // Helper function to sort periods by start date
-const sortPeriodsByFom = (periods: Period[]): Period[] => {
+const sortPeriodsByFom = (periods: FomTom[]): FomTom[] => {
   return periods.sort((a, b) => {
     const aFom = initializeDate(a.fom);
     const bFom = initializeDate(b.fom);
@@ -65,7 +65,7 @@ const sortPeriodsByFom = (periods: Period[]): Period[] => {
   });
 };
 
-export const getDaysInPeriod = (period: Period): string[] => {
+export const getDaysInPeriod = (period: FomTom): string[] => {
   const days = [];
   const startDate = initializeDate(period.fom);
   const endDate = initializeDate(period.tom);
@@ -75,11 +75,18 @@ export const getDaysInPeriod = (period: Period): string[] => {
   return days;
 };
 
-export const findUncoveredDays = (opprinneligPeriode: Period, perioder: Period[]): string[] => {
-  console.log(perioder);
+export const checkIfPeriodsAreEdgeToEdge = (period1: FomTom, period2: FomTom): boolean => {
+  const period1Tom = initializeDate(period1.tom);
+  const period2Fom = initializeDate(period2.fom);
+  const period1Fom = initializeDate(period1.fom);
+  const period2Tom = initializeDate(period2.tom);
+
+  return period1Tom.add(1, 'day').isSame(period2Fom) || period1Fom.isSame(period2Tom.add(1, 'day'));
+};
+
+export const findUncoveredDays = (opprinneligPeriode: FomTom, perioder: FomTom[]): string[] => {
   const opprinneligPeriodeDays = getDaysInPeriod(opprinneligPeriode);
   const perioderDays = perioder.map(periode => getDaysInPeriod(periode));
-  console.log(perioderDays);
   const uncoveredDays = opprinneligPeriodeDays.filter(day => !perioderDays.some(period => period.includes(day)));
   return uncoveredDays;
 };
@@ -91,17 +98,17 @@ export const findUncoveredDays = (opprinneligPeriode: Period, perioder: Period[]
  * @param datesOrPeriods - Array of dates (strings) or periods (objects with fom and tom)
  * @returns Array of combined periods
  */
-export const combineConsecutivePeriods = (datesOrPeriods: DateOrPeriod[]): Period[] => {
+export const combineConsecutivePeriods = (datesOrPeriods: DateOrPeriod[]): FomTom[] => {
   if (!datesOrPeriods || datesOrPeriods.length === 0) {
     return [];
   }
 
   // Convert all inputs to periods
-  const periods: Period[] = datesOrPeriods.map(convertDateToPeriod);
+  const periods: FomTom[] = datesOrPeriods.map(convertDateToPeriod);
 
   // Sort periods by start date
   const sortedPeriods = sortPeriodsByFom(periods);
-  const combinedPeriods: Period[] = [];
+  const combinedPeriods: FomTom[] = [];
 
   for (const currentPeriod of sortedPeriods) {
     const lastCombinedPeriod = combinedPeriods[combinedPeriods.length - 1];

--- a/packages/v2/lib/src/dateUtils/dateUtils.ts
+++ b/packages/v2/lib/src/dateUtils/dateUtils.ts
@@ -41,10 +41,10 @@ const combineTwoPeriods = (period1: Period, period2: Period): Period => {
   const tom1 = initializeDate(period1.tom);
   const fom2 = initializeDate(period2.fom);
   const tom2 = initializeDate(period2.tom);
-  
+
   const newFom = fom1.isBefore(fom2) ? period1.fom : period2.fom;
   const newTom = tom1.isAfter(tom2) ? period1.tom : period2.tom;
-  
+
   return { fom: newFom, tom: newTom };
 };
 
@@ -65,10 +65,29 @@ const sortPeriodsByFom = (periods: Period[]): Period[] => {
   });
 };
 
+export const getDaysInPeriod = (period: Period): string[] => {
+  const days = [];
+  const startDate = initializeDate(period.fom);
+  const endDate = initializeDate(period.tom);
+  for (let date = startDate; date.isSameOrBefore(endDate); date = date.add(1, 'day')) {
+    days.push(date.format(ISO_DATE_FORMAT));
+  }
+  return days;
+};
+
+export const findUncoveredDays = (opprinneligPeriode: Period, perioder: Period[]): string[] => {
+  console.log(perioder);
+  const opprinneligPeriodeDays = getDaysInPeriod(opprinneligPeriode);
+  const perioderDays = perioder.map(periode => getDaysInPeriod(periode));
+  console.log(perioderDays);
+  const uncoveredDays = opprinneligPeriodeDays.filter(day => !perioderDays.some(period => period.includes(day)));
+  return uncoveredDays;
+};
+
 /**
  * Combines consecutive and overlapping periods into a minimal set of non-overlapping periods.
  * Can handle both single dates (as strings) and periods (as objects with fom and tom).
- * 
+ *
  * @param datesOrPeriods - Array of dates (strings) or periods (objects with fom and tom)
  * @returns Array of combined periods
  */
@@ -79,14 +98,14 @@ export const combineConsecutivePeriods = (datesOrPeriods: DateOrPeriod[]): Perio
 
   // Convert all inputs to periods
   const periods: Period[] = datesOrPeriods.map(convertDateToPeriod);
-  
+
   // Sort periods by start date
   const sortedPeriods = sortPeriodsByFom(periods);
   const combinedPeriods: Period[] = [];
 
   for (const currentPeriod of sortedPeriods) {
     const lastCombinedPeriod = combinedPeriods[combinedPeriods.length - 1];
-    
+
     if (!lastCombinedPeriod) {
       combinedPeriods.push(currentPeriod);
       continue;
@@ -287,4 +306,3 @@ export const formatereLukketPeriode = (periode: string): string => {
   }
   return `${formatDate(fom)} - ${formatDate(tom)}`;
 };
-

--- a/packages/v2/lib/src/dateUtils/initializeDate.ts
+++ b/packages/v2/lib/src/dateUtils/initializeDate.ts
@@ -2,6 +2,7 @@ import dayjs, { Dayjs } from 'dayjs';
 import customParseFormat from 'dayjs/plugin/customParseFormat';
 import isoWeek from 'dayjs/plugin/isoWeek';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import isSameOrAfter from 'dayjs/plugin/isSameOrAfter';
 import utc from 'dayjs/plugin/utc';
 import { DDMMYYYY_DATE_FORMAT, ISO_DATE_FORMAT } from './formats';
 
@@ -9,6 +10,7 @@ dayjs.extend(customParseFormat);
 dayjs.extend(utc);
 dayjs.extend(isoWeek);
 dayjs.extend(isSameOrBefore);
+dayjs.extend(isSameOrAfter);
 
 const supportedFormats = [ISO_DATE_FORMAT, DDMMYYYY_DATE_FORMAT];
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2989,7 +2989,7 @@ __metadata:
   resolution: "@k9-sak-web/backend@workspace:packages/v2/backend"
   dependencies:
     "@navikt/k9-klage-typescript-client": "npm:3.0.20250530164140"
-    "@navikt/k9-sak-typescript-client": "npm:2.0.20250731124543"
+    "@navikt/k9-sak-typescript-client": "npm:2.0.20250806134814"
     "@navikt/ung-sak-typescript-client": "npm:0.2.20250728105557"
     "@tanstack/eslint-plugin-query": "npm:^5.81.2"
   languageName: unknown
@@ -4378,10 +4378,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/k9-sak-typescript-client@npm:2.0.20250731124543":
-  version: 2.0.20250731124543
-  resolution: "@navikt/k9-sak-typescript-client@npm:2.0.20250731124543::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-sak-typescript-client%2F2.0.20250731124543%2F69272de5c0d077b0a86213eaf4770576a894ece4"
-  checksum: 10/a4a43505f824908cf40809130e7a0836def7bb9e927f568cb2f4f05d3847342cac6dfc06b0c0a21b51cb7435a61b0b9af935565374929eaa4c80e6565075a856
+"@navikt/k9-sak-typescript-client@npm:2.0.20250806134814":
+  version: 2.0.20250806134814
+  resolution: "@navikt/k9-sak-typescript-client@npm:2.0.20250806134814::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-sak-typescript-client%2F2.0.20250806134814%2Fad869c0b9548f8b3cc08cf729818dc35219e9ea3"
+  checksum: 10/807ca3abf8bcc3ce859261505189d3408a96dce90a70340101c2f4d6c075e75598c4a732fc6cfa5d4ded50741409694fb92b08c669a9b378e55cc79bcbff5447
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2503,15 +2503,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@hey-api/client-fetch@npm:=0.10.0":
-  version: 0.10.0
-  resolution: "@hey-api/client-fetch@npm:0.10.0"
-  peerDependencies:
-    "@hey-api/openapi-ts": < 2
-  checksum: 10/f77dc512047f2fcbba4a1be079020c6c821391b34da426079e1e306ee2ee9f83e7f1130ad7a697a340f2e29bde1e0ce8af3b88a4f8631b849426bd7b2cc24fb9
-  languageName: node
-  linkType: hard
-
 "@hookform/error-message@npm:^2.0.1":
   version: 2.0.1
   resolution: "@hookform/error-message@npm:2.0.1"
@@ -2988,9 +2979,9 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@k9-sak-web/backend@workspace:packages/v2/backend"
   dependencies:
-    "@navikt/k9-klage-typescript-client": "npm:3.0.20250530164140"
-    "@navikt/k9-sak-typescript-client": "npm:2.0.20250806134814"
-    "@navikt/ung-sak-typescript-client": "npm:0.2.20250728105557"
+    "@navikt/k9-klage-typescript-client": "npm:3.1.20250806103540"
+    "@navikt/k9-sak-typescript-client": "npm:2.0.20250811133704"
+    "@navikt/ung-sak-typescript-client": "npm:0.2.20250808091711"
     "@tanstack/eslint-plugin-query": "npm:^5.81.2"
   languageName: unknown
   linkType: soft
@@ -4369,26 +4360,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/k9-klage-typescript-client@npm:3.0.20250530164140":
-  version: 3.0.20250530164140
-  resolution: "@navikt/k9-klage-typescript-client@npm:3.0.20250530164140::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-klage-typescript-client%2F3.0.20250530164140%2F29ef2f2a9cd2310dde4445b083d85ad15b3fae6b"
-  dependencies:
-    "@hey-api/client-fetch": "npm:=0.10.0"
-  checksum: 10/01f45605f6dccd37d744a490ae5860382604742701893c180f08c4771c96d5ebd0c83883fb48666690b639fac4443157cc6c8d63ea91a902ffef4344dd5003cf
+"@navikt/k9-klage-typescript-client@npm:3.1.20250806103540":
+  version: 3.1.20250806103540
+  resolution: "@navikt/k9-klage-typescript-client@npm:3.1.20250806103540::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-klage-typescript-client%2F3.1.20250806103540%2Ffd7078f3b9d28452774985ab9c08098e889c640d"
+  checksum: 10/f43fccb643f63b0c2f2d414a632802d7b65e5751da96540945c014ab0cb9804e41cfba5873ea256f7729dff024b80cc3d66cebe20717c604bfc4cf99de49f5d5
   languageName: node
   linkType: hard
 
-"@navikt/k9-sak-typescript-client@npm:2.0.20250806134814":
-  version: 2.0.20250806134814
-  resolution: "@navikt/k9-sak-typescript-client@npm:2.0.20250806134814::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-sak-typescript-client%2F2.0.20250806134814%2Fad869c0b9548f8b3cc08cf729818dc35219e9ea3"
-  checksum: 10/807ca3abf8bcc3ce859261505189d3408a96dce90a70340101c2f4d6c075e75598c4a732fc6cfa5d4ded50741409694fb92b08c669a9b378e55cc79bcbff5447
+"@navikt/k9-sak-typescript-client@npm:2.0.20250811133704":
+  version: 2.0.20250811133704
+  resolution: "@navikt/k9-sak-typescript-client@npm:2.0.20250811133704::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-sak-typescript-client%2F2.0.20250811133704%2Fce8b56587fe9839a6336bd9fab823044872eeb8d"
+  checksum: 10/ce1ec29da1e124540951568420328665800c6a310b9a1f5113547d85fdb83808e7f2d44ce6b1857641c54fdb834e9a49018a923d7f22a760edff565d83f400ca
   languageName: node
   linkType: hard
 
-"@navikt/ung-sak-typescript-client@npm:0.2.20250728105557":
-  version: 0.2.20250728105557
-  resolution: "@navikt/ung-sak-typescript-client@npm:0.2.20250728105557::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fung-sak-typescript-client%2F0.2.20250728105557%2Fd988dbab4db8799c1b5eea32cd0e0482d41a817a"
-  checksum: 10/fc97dcfd6e5c2738f4dd02cf44af742657953233d3716133d892b15c27a3fa94cb850cadcbc27779ba433837b631fd7b2657c82d3b9f6df27f879a5b756d3ec8
+"@navikt/ung-sak-typescript-client@npm:0.2.20250808091711":
+  version: 0.2.20250808091711
+  resolution: "@navikt/ung-sak-typescript-client@npm:0.2.20250808091711::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fung-sak-typescript-client%2F0.2.20250808091711%2Fc6622a3905963a3239ef2e973710f600abac1b17"
+  checksum: 10/231b4e69e00f1b53368f8bd72af5e262dac460f4a61cae90eb68c1b6ea50346c41327eb3bacb03acf8b7a8269971819210f6bb35c42af5aed2dbabb76c80c0c7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Visuelt delt opp komponenten i dokumentasjon av sykdom og nødvendig opplæring så det blir litt lettere for saksbehandlerne å se skillet.

Er også behov for å kunne gjøre delvise vurderinger på en periode. Altså gi forskjellige vurderinger i en periode som i utgangspunktet er sammenhengende.  

### **Løsning**
Implementerer klipping av perioder og gjør det mulig å flytte perioder til reisetid. Mye logikk som går på perioder, så er en del nye funksjoner i dateUtils med funksjonalitet som vi har hatt i Period-klassen. Men jeg syns det er fint å kunne bruke de uten å måtte benytte den klassen overalt 


### **Skjermbilder** (hvis relevant)
<img width="1385" height="548" alt="image" src="https://github.com/user-attachments/assets/c8b59e74-2fb6-488d-9d5e-28459de8d97a" />
<img width="1035" height="529" alt="image" src="https://github.com/user-attachments/assets/2f17aa94-c52d-400c-a9c5-e730f1489647" />
<img width="847" height="753" alt="image" src="https://github.com/user-attachments/assets/b3e5bdbc-9173-4095-ac80-b3b9e227237a" />
<img width="1214" height="1127" alt="image" src="https://github.com/user-attachments/assets/e4d91324-8ae0-4045-8eac-0d19ebff6062" />

