### PR TITLE
Tsff 1677: Kunne bekrefte aksjonspunkter i manuelle revurderinger

### DIFF
--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/1-institusjon/components/InstitusjonForm.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/1-institusjon/components/InstitusjonForm.tsx
@@ -7,9 +7,13 @@ import { maxLength, minLength, required } from '@navikt/ft-form-validators';
 import type { InstitusjonVurderingDtoMedPerioder } from '../types/InstitusjonVurderingDtoMedPerioder.js';
 import { useContext, useEffect } from 'react';
 import { SykdomOgOpplæringContext } from '../../FaktaSykdomOgOpplæringIndex.js';
-import { k9_sak_web_app_tjenester_behandling_opplæringspenger_visning_institusjon_InstitusjonResultat as InstitusjonVurderingDtoResultat } from '@k9-sak-web/backend/k9sak/generated';
 import InstitusjonVelger from './InstitusjonVelger.js';
 import { InstitusjonFormFields } from '../types/InstitusjonFormFields.js';
+import {
+  utledGodkjentInstitusjon,
+  utledOmDetErValgfriSkriftligVurdering,
+  utledRedigertInstitusjonNavn,
+} from '../utils.js';
 
 interface InstitusjonFormValues {
   [InstitusjonFormFields.BEGRUNNELSE]: string;
@@ -37,43 +41,6 @@ interface OwnProps {
   erRedigering: boolean;
   avbrytRedigering: () => void;
 }
-
-const utledGodkjentInstitusjon = (resultat: InstitusjonVurderingDtoResultat) => {
-  if (resultat === InstitusjonVurderingDtoResultat.GODKJENT_MANUELT) {
-    return 'ja';
-  }
-  if (resultat === InstitusjonVurderingDtoResultat.IKKE_GODKJENT_MANUELT) {
-    return 'nei';
-  }
-  return '';
-};
-
-const utledOmDetErValgfriSkriftligVurdering = (begrunnelse: string, resultat: InstitusjonVurderingDtoResultat) => {
-  if (begrunnelse && resultat === InstitusjonVurderingDtoResultat.GODKJENT_MANUELT) {
-    return 'ja';
-  }
-  return 'nei';
-};
-
-const utledRedigertInstitusjonNavn = (
-  helseinstitusjonEllerKompetansesenterFritekst: string,
-  institusjonFraOrganisasjonsnummer: string,
-  redigertInstitusjonNavn: string,
-  annenInstitusjon: boolean,
-) => {
-  // Har søkt opp institusjon fra organisasjonsnummer
-  if (institusjonFraOrganisasjonsnummer) {
-    return institusjonFraOrganisasjonsnummer;
-  }
-
-  // Har skrevet inn navn på institusjonen/kompetansesenteret i fritekst
-  if (annenInstitusjon && helseinstitusjonEllerKompetansesenterFritekst) {
-    return helseinstitusjonEllerKompetansesenterFritekst;
-  }
-
-  // Har valgt institusjon fra listen, eller beholdt institusjon som er satt fra tidligere vurdering.
-  return redigertInstitusjonNavn;
-};
 
 const defaultValues = (vurdering: InstitusjonVurderingDtoMedPerioder) => {
   return {

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/1-institusjon/utils.ts
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/1-institusjon/utils.ts
@@ -1,0 +1,44 @@
+import { k9_sak_web_app_tjenester_behandling_opplæringspenger_visning_institusjon_InstitusjonResultat as InstitusjonVurderingDtoResultat } from '@k9-sak-web/backend/k9sak/generated';
+
+export const utledGodkjentInstitusjon = (resultat?: InstitusjonVurderingDtoResultat): 'ja' | 'nei' | '' => {
+  if (
+    resultat === InstitusjonVurderingDtoResultat.GODKJENT_MANUELT ||
+    resultat === InstitusjonVurderingDtoResultat.GODKJENT_AUTOMATISK
+  ) {
+    return 'ja';
+  }
+  if (resultat === InstitusjonVurderingDtoResultat.IKKE_GODKJENT_MANUELT) {
+    return 'nei';
+  }
+  return '';
+};
+
+export const utledOmDetErValgfriSkriftligVurdering = (
+  begrunnelse: string,
+  resultat: InstitusjonVurderingDtoResultat,
+): 'ja' | 'nei' => {
+  if (begrunnelse && resultat === InstitusjonVurderingDtoResultat.GODKJENT_MANUELT) {
+    return 'ja';
+  }
+  return 'nei';
+};
+
+export const utledRedigertInstitusjonNavn = (
+  helseinstitusjonEllerKompetansesenterFritekst: string,
+  institusjonFraOrganisasjonsnummer: string,
+  redigertInstitusjonNavn: string,
+  annenInstitusjon: boolean,
+) => {
+  // Har søkt opp institusjon fra organisasjonsnummer
+  if (institusjonFraOrganisasjonsnummer) {
+    return institusjonFraOrganisasjonsnummer;
+  }
+
+  // Har skrevet inn navn på institusjonen/kompetansesenteret i fritekst
+  if (annenInstitusjon && helseinstitusjonEllerKompetansesenterFritekst) {
+    return helseinstitusjonEllerKompetansesenterFritekst;
+  }
+
+  // Har valgt institusjon fra listen, eller beholdt institusjon som er satt fra tidligere vurdering.
+  return redigertInstitusjonNavn;
+};

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/2-sykdom/SykdomUperiodisertIndex.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/2-sykdom/SykdomUperiodisertIndex.tsx
@@ -20,6 +20,7 @@ import {
 } from '@k9-sak-web/backend/k9sak/generated';
 import { CenteredLoader } from '../CenteredLoader';
 import type { UperiodisertSykdom } from './SykdomUperiodisertForm';
+import { isAksjonspunktOpen } from '../../../utils/aksjonspunktUtils';
 
 export const SykdomUperiodisertContext = createContext<{
   setNyVurdering: (nyVurdering: boolean) => void;
@@ -143,28 +144,55 @@ const Warning = ({
   vurderinger: LangvarigSykdomVurderingDto[] | undefined;
   vurderingBruktIAksjonspunkt: ValgtLangvarigSykdomVurderingDto | undefined;
 }) => {
-  const { readOnly, behandlingUuid, aksjonspunkter } = useContext(SykdomOgOpplæringContext);
-  const harAksjonspunkt9301 = !!aksjonspunkter.find(akspunkt => akspunkt.definisjon.kode === '9301');
+  const { readOnly, behandlingUuid, aksjonspunkter, løsAksjonspunkt9301 } = useContext(SykdomOgOpplæringContext);
+  const aksjonspunkt9301 = aksjonspunkter.find(akspunkt => akspunkt.definisjon.kode === '9301');
+  const vurdering = vurderinger.find(v => v.uuid === vurderingBruktIAksjonspunkt?.vurderingUuid);
+
+  const løsAksjonspunktUtenEndringer = () => {
+    if (vurderingBruktIAksjonspunkt && vurdering) {
+      løsAksjonspunkt9301(vurderingBruktIAksjonspunkt.vurderingUuid);
+    }
+  };
 
   const harVurderingFraTidligereBehandling = vurderinger.some(v => v.behandlingUuid !== behandlingUuid);
-  if (vurderingBruktIAksjonspunkt?.resultat !== 'MÅ_VURDERES' || readOnly || !harAksjonspunkt9301) {
-    return null;
+
+  if (
+    isAksjonspunktOpen(aksjonspunkt9301?.status.kode || '') &&
+    vurderingBruktIAksjonspunkt?.resultat !== 'MÅ_VURDERES' &&
+    !readOnly
+  ) {
+    return (
+      <Alert className="mb-4 p-4" variant="info" size="small">
+        <div className="flex flex-col gap-2">
+          <span>Sykdom er ferdig vurdert og du kan gå videre i behandlingen.</span>
+          <div>
+            <Button variant="secondary" size="small" onClick={løsAksjonspunktUtenEndringer}>
+              Bekreft og fortsett
+            </Button>
+          </div>
+        </div>
+      </Alert>
+    );
   }
 
-  if (harVurderingFraTidligereBehandling) {
+  if (isAksjonspunktOpen(aksjonspunkt9301?.status.kode) && harVurderingFraTidligereBehandling && !readOnly) {
     return (
-      <Alert className="my-5" variant="warning">
+      <Alert className="mb-4 p-4" variant="warning" size="small">
         Det er tidligere vurdert om barnet har en funksjonshemning eller en langvarig sykdom. Bekreft om tidligere
         sykdomsvurdering gjelder for ny periode eller legg til en ny sykdomsvurdering.
       </Alert>
     );
   }
 
-  return (
-    <Alert className="my-5" variant="warning">
-      Vurder om barnet har en funksjonshemning eller en langvarig sykdom.
-    </Alert>
-  );
+  if (isAksjonspunktOpen(aksjonspunkt9301?.status.kode) && !readOnly) {
+    return (
+      <Alert className="mb-4 p-4" variant="warning" size="small">
+        Vurder om barnet har en funksjonshemning eller en langvarig sykdom.
+      </Alert>
+    );
+  }
+
+  return null;
 };
 
 export default SykdomUperiodisertIndex;

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringIndex.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/3-nødvendig-opplæring/NødvendigOpplæringIndex.tsx
@@ -12,20 +12,39 @@ import {
 import NødvendigOpplæringContainer from './NødvendigOpplæringContainer';
 import { NavigationWithDetailView } from '../../../shared/navigation-with-detail-view/NavigationWithDetailView';
 import { CenteredLoader } from '../CenteredLoader';
-import { Alert } from '@navikt/ds-react';
+import { Alert, Button } from '@navikt/ds-react';
+import { isAksjonspunktOpen } from '../../../utils/aksjonspunktUtils';
 
 interface OpplæringVurderingselement extends Omit<Vurderingselement, 'resultat'>, OpplæringVurderingDto {
   perioder: Period[];
 }
 
 const NødvendigOpplæring = () => {
-  const { behandlingUuid, readOnly } = useContext(SykdomOgOpplæringContext);
+  const { behandlingUuid, readOnly, løsAksjonspunkt9302, aksjonspunkter } = useContext(SykdomOgOpplæringContext);
   const { data: vurdertOpplæring, isLoading: isLoadingVurdertOpplæring } = useVurdertOpplæring(behandlingUuid);
   const [valgtVurdering, setValgtVurdering] = useState<OpplæringVurderingselement | null>(null);
   const vurderingsliste = vurdertOpplæring?.vurderinger.map(vurdering => ({
     ...vurdering,
     perioder: [new Period(vurdering.opplæring.fom, vurdering.opplæring.tom)],
   }));
+  const aksjonspunkt9302 = aksjonspunkter.find(akspunkt => akspunkt.definisjon.kode === '9302');
+  const alleVurderingerFerdigVurdert = vurderingsliste?.every(
+    vurdering => vurdering.resultat !== OpplæringVurderingDtoResultat.MÅ_VURDERES,
+  );
+  const løsAksjonspunktUtenEndringer = () => {
+    if (!vurderingsliste) return;
+    løsAksjonspunkt9302({
+      perioder: vurderingsliste?.map(vurdering => ({
+        periode: {
+          fom: vurdering.opplæring.fom,
+          tom: vurdering.opplæring.tom,
+        },
+        begrunnelse: vurdering.begrunnelse || null,
+        resultat: vurdering.resultat,
+        avslagsårsak: vurdering.avslagsårsak,
+      })),
+    });
+  };
 
   if (isLoadingVurdertOpplæring) {
     return <CenteredLoader />;
@@ -35,6 +54,18 @@ const NødvendigOpplæring = () => {
       {valgtVurdering?.resultat === OpplæringVurderingDtoResultat.MÅ_VURDERES && !readOnly && (
         <Alert className="mb-4" variant="warning" size="small">
           Vurder om opplæringen er nødvendig for at søker skal kunne ta seg av og behandlet barnet.
+        </Alert>
+      )}
+      {isAksjonspunktOpen(aksjonspunkt9302?.status.kode) && alleVurderingerFerdigVurdert && !readOnly && (
+        <Alert className="mb-4 p-4" variant="info" size="small">
+          <div className="flex flex-col gap-2">
+            <span>Dokumentasjon og nødvendig opplæring er ferdig vurdert og du kan gå videre i behandlingen.</span>
+            <div>
+              <Button variant="secondary" size="small" onClick={løsAksjonspunktUtenEndringer}>
+                Bekreft og fortsett
+              </Button>
+            </div>
+          </div>
         </Alert>
       )}
       <NavigationWithDetailView

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/4-reisetid/ReisetidIndex.tsx
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/4-reisetid/ReisetidIndex.tsx
@@ -1,7 +1,8 @@
 import type {
-  k9_sak_web_app_tjenester_behandling_opplæringspenger_visning_reisetid_ReisetidResultat as ReisetidResultat,
+  k9_sak_web_app_tjenester_behandling_opplæringspenger_visning_reisetid_ReisetidResultat as ReisetidResultatType,
   k9_sak_web_app_tjenester_behandling_opplæringspenger_visning_reisetid_ReisetidVurderingDto as ReisetidVurderingDto,
 } from '@k9-sak-web/backend/k9sak/generated';
+import { k9_sak_web_app_tjenester_behandling_opplæringspenger_visning_reisetid_ReisetidResultat as ReisetidResultat } from '@k9-sak-web/backend/k9sak/generated';
 import { Period } from '@navikt/ft-utils';
 import { useContext, useState } from 'react';
 import { NavigationWithDetailView } from '../../../shared/navigation-with-detail-view/NavigationWithDetailView';
@@ -12,16 +13,19 @@ import { CenteredLoader } from '../CenteredLoader';
 import { SykdomOgOpplæringContext } from '../FaktaSykdomOgOpplæringIndex';
 import { useVurdertReisetid } from '../SykdomOgOpplæringQueries';
 import ReisetidContainer from './ReisetidContainer';
+import { Alert, Button } from '@navikt/ds-react';
+import { isAksjonspunktOpen } from '../../../utils/aksjonspunktUtils';
 
 interface ReisetidVurderingselement extends Omit<Vurderingselement, 'resultat'>, ReisetidVurderingDto {
   perioder: Period[];
-  resultat: ReisetidResultat;
+  resultat: ReisetidResultatType;
 }
 
 const ReisetidIndex = () => {
-  const { behandlingUuid } = useContext(SykdomOgOpplæringContext);
+  const { behandlingUuid, aksjonspunkter, readOnly, løsAksjonspunkt9303 } = useContext(SykdomOgOpplæringContext);
   const { data: vurdertReisetid, isLoading: isLoadingVurdertReisetid } = useVurdertReisetid(behandlingUuid);
   const [valgtVurdering, setValgtVurdering] = useState<ReisetidVurderingselement | null>(null);
+  const aksjonspunkt9303 = aksjonspunkter.find(akspunkt => akspunkt.definisjon.kode === '9303');
 
   const vurderingsliste = vurdertReisetid?.vurderinger.map(vurdering => ({
     ...vurdering,
@@ -29,12 +33,37 @@ const ReisetidIndex = () => {
     perioder: [new Period(vurdering.reisetid.periode.fom, vurdering.reisetid.periode.tom)],
   }));
 
+  const alleVurderingerFerdigVurdert = vurderingsliste?.every(
+    vurdering => vurdering.resultat !== ReisetidResultat.MÅ_VURDERES,
+  );
+
+  const løsAksjonspunktUtenEndringer = () => {
+    if (!vurdertReisetid?.vurderinger[0]) return;
+    løsAksjonspunkt9303({
+      periode: {
+        fom: vurdertReisetid.vurderinger[0].reisetid.periode.fom,
+        tom: vurdertReisetid.vurderinger[0].reisetid.periode.tom,
+      },
+      begrunnelse: vurdertReisetid.vurderinger[0].reisetid.begrunnelse,
+      godkjent: vurdertReisetid.vurderinger[0].reisetid.resultat === ReisetidResultat.GODKJENT,
+    });
+  };
   if (isLoadingVurdertReisetid) {
     return <CenteredLoader />;
   }
 
   return (
     <div>
+      {isAksjonspunktOpen(aksjonspunkt9303?.status.kode) && alleVurderingerFerdigVurdert && !readOnly && (
+        <Alert variant="info" size="small" className="mb-4 p-4">
+          Reisetid er ferdig vurdert og du kan gå videre i behandlingen.
+          <div className="mt-2">
+            <Button variant="secondary" size="small" onClick={løsAksjonspunktUtenEndringer}>
+              Bekreft og fortsett
+            </Button>
+          </div>
+        </Alert>
+      )}
       <NavigationWithDetailView
         navigationSection={() => (
           <>

--- a/packages/v2/gui/src/shared/detailView/DetailView.tsx
+++ b/packages/v2/gui/src/shared/detailView/DetailView.tsx
@@ -43,19 +43,18 @@ export const DetailView = ({
 };
 
 export const Periodevisning = ({ perioder }: { perioder: Period[] }) => {
+  if (perioder.length === 0) {
+    return null;
+  }
+
   return (
     <div data-testid="Periode" className="flex gap-2">
-      <CalendarIcon fontSize="20" />
-      {perioder.map(periode => {
-        const enkeltdag = periode.asListOfDays().length === 1;
-        return (
-          <div key={periode.fom + periode.tom}>
-            <BodyShort size="small">
-              {enkeltdag ? periode.prettifyPeriod().split(' - ')[0] : periode.prettifyPeriod()}
-            </BodyShort>
-          </div>
-        );
-      })}
+      <CalendarIcon fontSize="20" className="flex-shrink-0" />
+      {perioder.length === 1 ? (
+        <BodyShort size="small">{perioder[0]?.prettifyPeriod()}</BodyShort>
+      ) : (
+        <BodyShort size="small">{perioder.map(periode => periode.prettifyPeriod()).join(', ')}</BodyShort>
+      )}
     </div>
   );
 };

--- a/packages/v2/gui/src/utils/aksjonspunktUtils.ts
+++ b/packages/v2/gui/src/utils/aksjonspunktUtils.ts
@@ -1,3 +1,3 @@
 import { aksjonspunktStatus } from '@k9-sak-web/backend/k9sak/kodeverk/AksjonspunktStatus.js';
 
-export const isAksjonspunktOpen = (statusKode: string): boolean => statusKode === aksjonspunktStatus.OPPRETTET;
+export const isAksjonspunktOpen = (statusKode?: string): boolean => statusKode === aksjonspunktStatus.OPPRETTET;


### PR DESCRIPTION
### **Behov / Bakgrunn**
Manuelle revurderinger åpner aksjonpunkter som ble løst i forrige behandling slik at man kan gjøre endringer. Da må man ha mulighet til å fortsette uten å gjøre endringer.

### **Løsning**
Legger inn knapp for å fortsette dersom aksjonspunktene i sykdom og opplæring er åpne og alle vurderinger er gjort