### PR TITLE
TSFF-1815 - Skjuler inntrekk i simulering for ungdomsytelsen

### DIFF
--- a/packages/prosess-avregning/i18n/nb_NO.json
+++ b/packages/prosess-avregning/i18n/nb_NO.json
@@ -89,6 +89,7 @@
   "Avregning.FRISINN.nyttBeløp": "FRISINN nytt beløp",
   "Avregning.FRISINN.tidligereUtbetalt": "FRISINN tidligere utbetalt",
   "Avregning.FRISINN.differanse": "FRISINN nærstående avvik",
+  "Avregning.UNG.nyttBeløp": "Ungdomsprogramytelse nytt beløp",
 
   "Avregning.HjelpetekstPleiepenger": "Her skal du oppgi hvorfor brukeren ikke skulle fått utbetalt ytelsen i perioden(e). Du må også oppgi hvordan feilutbetalingen ble oppdaget, hvem som oppdaget den og når den ble oppdaget eller meldt til NAV. Eksempel på tekst: «Vi mottok melding fra deg [dato]om at du hadde jobbet heltid. Du kan ikke jobbe og motta pleiepenger samtidig. Da vi mottok meldingen fra deg, var det allerede utbetalt pleiepenger for perioden du har jobbet.",
   "Avregning.ApenTilbakekrevingsbehandling": "Det foreligger en åpen tilbakekrevingsbehandling, endringer i vedtaket vil automatisk oppdatere eksisterende feilutbetalte perioder og beløp.",

--- a/packages/prosess-avregning/src/components/AvregningPanel.jsx
+++ b/packages/prosess-avregning/src/components/AvregningPanel.jsx
@@ -26,6 +26,7 @@ import avregningSimuleringResultatPropType from '../propTypes/avregningSimulerin
 import AvregningSummary from './AvregningSummary';
 import AvregningTable from './AvregningTable';
 
+import { ung_kodeverk_behandling_FagsakYtelseType } from '@navikt/ung-sak-typescript-client';
 import styles from './avregningPanel.module.css';
 
 // TODO Denne komponenten må refaktorerast! Er frykteleg stor
@@ -119,10 +120,12 @@ export class AvregningPanelImpl extends Component {
       harVurderFeilutbetalingAP,
       harSjekkHøyEtterbetalingAP,
       behandling,
+      fagsak,
       ...formProps
     } = this.props;
     const simuleringResultatOption = getSimuleringResult(simuleringResultat, feilutbetaling);
-
+    const fagsakSakstype = typeof fagsak?.sakstype === 'string' ? fagsak?.sakstype : fagsak?.sakstype?.kode;
+    const isUngFagsak = fagsakSakstype === ung_kodeverk_behandling_FagsakYtelseType.UNGDOMSYTELSE;
     return (
       <>
         <VStack gap="space-32">
@@ -143,6 +146,7 @@ export class AvregningPanelImpl extends Component {
                 etterbetaling={simuleringResultatOption.sumEtterbetaling}
                 inntrekk={simuleringResultatOption.sumInntrekk}
                 ingenPerioderMedAvvik={simuleringResultatOption.ingenPerioderMedAvvik}
+                isUngFagsak={isUngFagsak}
               />
 
               <AvregningTable
@@ -150,6 +154,7 @@ export class AvregningPanelImpl extends Component {
                 toggleDetails={this.toggleDetails}
                 simuleringResultat={simuleringResultatOption}
                 ingenPerioderMedAvvik={simuleringResultatOption.ingenPerioderMedAvvik}
+                isUngFagsak={isUngFagsak}
               />
               {hasOpenTilbakekrevingsbehandling && (
                 <Label size="small" as="p">

--- a/packages/prosess-avregning/src/components/AvregningSummary.jsx
+++ b/packages/prosess-avregning/src/components/AvregningSummary.jsx
@@ -13,7 +13,15 @@ import styles from './avregningSummary.module.css';
  *
  * Presentationskomponent
  */
-const AvregningSummary = ({ fom, tom, feilutbetaling, etterbetaling, inntrekk = null, ingenPerioderMedAvvik }) => (
+const AvregningSummary = ({
+  fom,
+  tom,
+  feilutbetaling,
+  etterbetaling,
+  inntrekk = null,
+  ingenPerioderMedAvvik,
+  isUngFagsak,
+}) => (
   <>
     <BodyShort size="small" className={styles.summaryTitle}>
       <FormattedMessage id="Avregning.bruker" />
@@ -52,7 +60,7 @@ const AvregningSummary = ({ fom, tom, feilutbetaling, etterbetaling, inntrekk = 
               <BodyShort size="small" className={feilutbetaling ? styles.redNumber : styles.positivNumber}>
                 {formatCurrencyNoKr(feilutbetaling)}
               </BodyShort>
-              {inntrekk !== null && (
+              {inntrekk !== null && !isUngFagsak && (
                 <BodyShort size="small">
                   <FormattedMessage id="Avregning.inntrekk" />:
                   <span className={inntrekk ? styles.lastNumberRed : styles.lastNumberPositiv}>

--- a/packages/prosess-avregning/src/components/AvregningSummary.spec.tsx
+++ b/packages/prosess-avregning/src/components/AvregningSummary.spec.tsx
@@ -1,7 +1,6 @@
 import { renderWithIntl } from '@fpsak-frontend/utils-test/test-utils';
 import { screen } from '@testing-library/react';
 
-import React from 'react';
 import messages from '../../i18n/nb_NO.json';
 import AvregningSummary from './AvregningSummary';
 
@@ -12,6 +11,7 @@ describe('<AvregningSummary>', () => {
     feilutbetaling: 15000,
     etterbetaling: 0,
     inntrekk: 20000,
+    isUngFagsak: false,
   };
 
   it('skal vise AvregningSummary', () => {

--- a/packages/prosess-avregning/src/components/AvregningTable.spec.tsx
+++ b/packages/prosess-avregning/src/components/AvregningTable.spec.tsx
@@ -1,6 +1,5 @@
 import { renderWithIntl } from '@fpsak-frontend/utils-test/test-utils';
 import { screen } from '@testing-library/react';
-import React from 'react';
 import messages from '../../i18n/nb_NO.json';
 import AvregningTable from './AvregningTable';
 
@@ -46,6 +45,7 @@ const mockProps = {
   showDetails: [],
   simuleringResultat,
   ingenPerioderMedAvvik: false,
+  isUngFagsak: false,
 };
 
 describe('<AvregningTable>', () => {

--- a/packages/prosess-avregning/src/components/AvregningTable.tsx
+++ b/packages/prosess-avregning/src/components/AvregningTable.tsx
@@ -149,6 +149,7 @@ interface AvregningTableProps {
     perioderPerMottaker: SimuleringMottaker[];
   };
   ingenPerioderMedAvvik: boolean;
+  isUngFagsak: boolean;
 }
 
 const AvregningTable = ({
@@ -156,6 +157,7 @@ const AvregningTable = ({
   toggleDetails,
   showDetails,
   ingenPerioderMedAvvik,
+  isUngFagsak,
 }: AvregningTableProps) => (
   <>
     {simuleringResultat.perioderPerMottaker.map((mottaker, mottakerIndex) => {
@@ -219,17 +221,28 @@ const AvregningTable = ({
                     ingenPerioderMedAvvik,
                     mottaker.resultatPerFagområde,
                     mottaker.resultatOgMotregningRader,
-                  ).map((resultat, resultatIndex) => {
-                    const boldText = resultat.feltnavn !== avregningCodes.INNTREKKNESTEMÅNED;
-                    return (
-                      <Table.Row key={`rowIndex${resultatIndex + 1}`} className={styles.rowBorderSolid}>
-                        <Table.DataCell className={boldText ? 'font-bold' : ''} textSize="small">
-                          <FormattedMessage id={`Avregning.${resultat.feltnavn}`} />
-                        </Table.DataCell>
-                        {createColumns(resultat.resultaterPerMåned, rangeOfMonths, nesteMåned, boldText)}
-                      </Table.Row>
-                    );
-                  }),
+                  )
+                    .filter(resultat => {
+                      if (
+                        isUngFagsak &&
+                        (resultat.feltnavn === avregningCodes.INNTREKKNESTEMÅNED ||
+                          resultat.feltnavn === avregningCodes.INNTREKK)
+                      ) {
+                        return false;
+                      }
+                      return true;
+                    })
+                    .map((resultat, resultatIndex) => {
+                      const boldText = resultat.feltnavn !== avregningCodes.INNTREKKNESTEMÅNED;
+                      return (
+                        <Table.Row key={`rowIndex${resultatIndex + 1}`} className={styles.rowBorderSolid}>
+                          <Table.DataCell className={boldText ? 'font-bold' : ''} textSize="small">
+                            <FormattedMessage id={`Avregning.${resultat.feltnavn}`} />
+                          </Table.DataCell>
+                          {createColumns(resultat.resultaterPerMåned, rangeOfMonths, nesteMåned, boldText)}
+                        </Table.Row>
+                      );
+                    }),
                 )}
             </Table.Body>
           </Table>


### PR DESCRIPTION
### **Behov / Bakgrunn**
[TSFF-1815](https://jira.adeo.no/browse/TSFF-1815)
Skal ikke vise inntrekk for Ung da det ikke benyttes.

### **Løsning**
Sjekk på fagsaktype og viser innhold deretter.

### **Andre endringer**


### **Skjermbilder** (hvis relevant)
