### PR TITLE
Bytte datepicker til select i midlertidig alene

### DIFF
--- a/loosely-type-checked-files.json
+++ b/loosely-type-checked-files.json
@@ -265,7 +265,6 @@
   "packages/prosess-omsorgsdager/src/ui/components/tester/__tests__/kronisk-syk.spec.tsx",
   "packages/prosess-omsorgsdager/src/ui/components/tester/__tests__/vilkar-midlertidig-alene.spec.tsx",
   "packages/prosess-omsorgsdager/src/ui/components/vilkar-kronisk-sykt-barn/VilkarKroniskSyktBarn.tsx",
-  "packages/prosess-omsorgsdager/src/ui/components/vilkar-midlertidig-alene/VilkarMidlertidigAlene.tsx",
   "packages/prosess-omsorgsdager/src/util/dateUtils.ts",
   "packages/prosess-tilbakekreving/src/components/TilbakekrevingForm.spec.tsx",
   "packages/prosess-tilbakekreving/src/components/TilbakekrevingForm.tsx",

--- a/packages/prosess-omsorgsdager/src/util/dateUtils.ts
+++ b/packages/prosess-omsorgsdager/src/util/dateUtils.ts
@@ -69,25 +69,3 @@ export function isValidDate(date: any) {
 export function isValidPeriod({ fom, tom }: Period) {
   return isValidDate(fom) && isValidDate(tom);
 }
-
-export function hanteringAvDatoForDatoVelger(soknadsdato) {
-  const antallÅrFramITid = 10;
-  const maxDato = new Date(soknadsdato);
-  maxDato.setFullYear(maxDato.getFullYear() + antallÅrFramITid);
-
-  const startDato = new Date(maxDato.getFullYear() - antallÅrFramITid, 12, 1);
-  const invalidDateRanges = [];
-
-  for (let i = 0; i < antallÅrFramITid; i += 1) {
-    invalidDateRanges.push({
-      from: `${(startDato.getFullYear() + i).toString()}-01-01`,
-      to: `${(startDato.getFullYear() + i).toString()}-12-30`,
-    });
-  }
-
-  return {
-    invalidDateRanges,
-    minDate: startDato.toISOString().substring(0, 10),
-    maxDate: maxDato.toISOString().substring(0, 10),
-  };
-}

--- a/packages/prosess-omsorgsdager/src/util/stringUtils.ts
+++ b/packages/prosess-omsorgsdager/src/util/stringUtils.ts
@@ -22,12 +22,26 @@ export const formatereDato = (dato: string): string => dato.replaceAll('-', '.')
 
 export const formatereDatoTilLesemodus = (dato: string): string => dayjs(dato).format('DD.MM.YYYY');
 
-export const utledTilgjengeligeÅr = (fraDato: string): TilgjengeligÅrOption[] => {
+/**
+ * Utleder tilgjengelige år basert på fraDato og eventuelle relative år
+ * @param {number} fraDato: Datoen som angir startpunktet for tilgjengelige år.
+ * @param {number | undefined} relativtFraÅr: Antall år før fraDato som skal inkluderes (valgfritt).
+ * @param {number | undefined} relativtTilÅr: Antall år etter fraDato som skal inkluderes (valgfritt).
+ * @returns En liste av objekter med tilgjengelige år.
+ */
+export const utledTilgjengeligeÅr = (
+  fraDato: string,
+  relativtFraÅr?: number | undefined,
+  relativtTilÅr: number | undefined = 19,
+): TilgjengeligÅrOption[] => {
   const nåværendeÅr = dayjs().year();
   const årFraDato = dayjs(fraDato).year();
-  const tidligsteMuligeÅr = årFraDato > nåværendeÅr ? årFraDato : nåværendeÅr - 1;
+  let tidligsteMuligeÅr = årFraDato > nåværendeÅr ? årFraDato : nåværendeÅr - 1;
+  if (relativtFraÅr !== undefined) {
+    tidligsteMuligeÅr = årFraDato - relativtFraÅr;
+  }
   const år: TilgjengeligÅrOption[] = [{ value: '0', title: 'Dato for opphør', disabled: true }];
-  for (let i = tidligsteMuligeÅr; i <= dayjs().year() + 19; i += 1) {
+  for (let i = tidligsteMuligeÅr; i <= dayjs().year() + relativtTilÅr; i += 1) {
     år.push({ value: i.toString(), title: `31.12.${i.toString()}`, disabled: false });
   }
   return år;

--- a/packages/prosess-omsorgsdager/src/util/validationReactHookFormUtils.ts
+++ b/packages/prosess-omsorgsdager/src/util/validationReactHookFormUtils.ts
@@ -1,4 +1,10 @@
 import { tekstTilBoolean } from './stringUtils';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import timezone from 'dayjs/plugin/timezone';
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
 
 export function valideringsFunksjoner(getValues, prop: string) {
   const erDatoFyltUt = dato => {
@@ -6,9 +12,13 @@ export function valideringsFunksjoner(getValues, prop: string) {
     return dato.toLowerCase() !== 'dd.mm.åååå' && dato !== '';
   };
 
-  const erDatoSisteDagenIÅret = dato => {
-    if (!tekstTilBoolean(getValues()[prop])) return true;
-    return dato.substr(5, 5) === '12-31';
+  /**
+   * @param datoSting DD.MM.YYYY
+   * @returns boolean
+   */
+  const erDatoSisteDagenIÅret = (datoSting: string) => {
+    const dato = dayjs.tz(datoSting, 'DD.MM.YYYY', 'Europe/Oslo');
+    return dato.isSame(dato.endOf('year'), 'day');
   };
 
   const erDatoGyldig = dato => {


### PR DESCRIPTION
### **Behov / Bakgrunn**
Når sb skal innvilge midlertidig alene settes det alltid til ut året. Nå som de har begynt å innvilge for 2026 må de trykke 12 ganger i kalenderen for å kunne velge 31.12.2026. De skal aldri velge noe annet en 31.12.xx, alle andre datoer er deaktivert. 

### **Løsning**
Bruker samme løsning som tidligere er lagt til for alene om omsorgen (tilbakekreving) og bytter ut datepicker med select/dropdown for et år bakover og 5 år fremover i tid. 

### **Andre endringer**
Fikset noen mindre ts warnings

### **Skjermbilder** (hvis relevant)
Før
<img width="300"  alt="Skjermbilde 2025-08-28 kl  12 42 41" src="https://github.com/user-attachments/assets/1616cad6-29bb-46f8-abd3-e0ffe15871cb" />

Etter:
<img width="300" alt="Skjermbilde 2025-08-28 kl  12 43 03" src="https://github.com/user-attachments/assets/bf47ec5b-0ce1-49e2-a93a-af3ded5bfe8b" />
<img width="300" alt="Skjermbilde 2025-08-28 kl  12 43 09" src="https://github.com/user-attachments/assets/16394fda-9cc7-475e-a411-458406b6e91a" />
