### PR TITLE
TSFF-1828: Vise inntektsgradering i opplæringspenger

### DIFF
--- a/packages/behandling-opplaeringspenger/src/BehandlingOpplaeringspengerIndex.tsx
+++ b/packages/behandling-opplaeringspenger/src/BehandlingOpplaeringspengerIndex.tsx
@@ -35,6 +35,7 @@ const opplaeringspengerData = [
   { key: OpplaeringspengerBehandlingApiKeys.SIMULERING_RESULTAT },
   { key: OpplaeringspengerBehandlingApiKeys.UTTAK },
   { key: OpplaeringspengerBehandlingApiKeys.OVERLAPPENDE_YTELSER },
+  { key: OpplaeringspengerBehandlingApiKeys.INNTEKTSGRADERING },
 ];
 
 interface OwnProps {

--- a/packages/behandling-opplaeringspenger/src/components/Uttak.tsx
+++ b/packages/behandling-opplaeringspenger/src/components/Uttak.tsx
@@ -1,7 +1,7 @@
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import aksjonspunktStatus from '@fpsak-frontend/kodeverk/src/aksjonspunktStatus';
 import { fagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
-import { Uttak } from '@k9-sak-web/prosess-uttak';
+import { Inntektsgradering, Uttak } from '@k9-sak-web/prosess-uttak';
 import { Aksjonspunkt, AlleKodeverk, ArbeidsgiverOpplysningerPerId, Behandling } from '@k9-sak-web/types';
 import { VStack } from '@navikt/ds-react';
 import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
@@ -10,6 +10,7 @@ import VurderOverlappendeSakIndex from '@k9-sak-web/gui/prosess/uttak/vurder-ove
 interface UttakProps {
   behandling: Pick<Behandling, 'versjon' | 'uuid' | 'status'>;
   uttaksperioder: any;
+  inntektsgraderinger?: Inntektsgradering[];
   perioderTilVurdering?: string[];
   utsattePerioder: string[];
   arbeidsgiverOpplysningerPerId: ArbeidsgiverOpplysningerPerId;
@@ -23,6 +24,7 @@ interface UttakProps {
 export default ({
   behandling,
   uttaksperioder,
+  inntektsgraderinger,
   utsattePerioder,
   perioderTilVurdering = [],
   arbeidsgiverOpplysningerPerId,
@@ -87,6 +89,7 @@ export default ({
       containerData={{
         behandling,
         uttaksperioder,
+        inntektsgraderinger,
         utsattePerioder,
         aktivBehandlingUuid: behandling.uuid,
         perioderTilVurdering,

--- a/packages/behandling-opplaeringspenger/src/data/opplaeringspengerBehandlingApi.ts
+++ b/packages/behandling-opplaeringspenger/src/data/opplaeringspengerBehandlingApi.ts
@@ -59,6 +59,7 @@ export enum OpplaeringspengerBehandlingApiKeys {
   GJENNOMGÅTT_OPPLÆRING = 'GJENNOMGÅTT_OPPLÆRING',
   NØDVENDIG_OPPLÆRING = 'NØDVENDIG_OPPLÆRING',
   REISETID = 'REISETID',
+  INNTEKTSGRADERING = 'INNTEKTSGRADERING',
 }
 
 const endpoints = new RestApiConfigBuilder()
@@ -110,6 +111,7 @@ const endpoints = new RestApiConfigBuilder()
   .withRel('gjennomgått-opplæring', OpplaeringspengerBehandlingApiKeys.GJENNOMGÅTT_OPPLÆRING)
   .withRel('nødvendig-opplæring', OpplaeringspengerBehandlingApiKeys.NØDVENDIG_OPPLÆRING)
   .withRel('reisetid', OpplaeringspengerBehandlingApiKeys.REISETID)
+  .withRel('pleiepenger-inntektsgradering', OpplaeringspengerBehandlingApiKeys.INNTEKTSGRADERING)
 
   // operasjoner
   .withRel('dokumentdata-lagre', OpplaeringspengerBehandlingApiKeys.DOKUMENTDATA_LAGRE)

--- a/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/UttakProsessStegPanelDef.tsx
+++ b/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/UttakProsessStegPanelDef.tsx
@@ -9,6 +9,7 @@ class PanelDef extends ProsessStegPanelDef {
   getKomponent = ({
     behandling,
     uttaksperioder,
+    inntektsgraderinger,
     utsattePerioder,
     arbeidsgiverOpplysningerPerId,
     aksjonspunkter,
@@ -20,6 +21,7 @@ class PanelDef extends ProsessStegPanelDef {
     <Uttak
       behandling={behandling}
       uttaksperioder={uttaksperioder}
+      inntektsgraderinger={inntektsgraderinger}
       utsattePerioder={utsattePerioder}
       arbeidsgiverOpplysningerPerId={arbeidsgiverOpplysningerPerId}
       aksjonspunkter={aksjonspunkter}
@@ -59,8 +61,9 @@ class PanelDef extends ProsessStegPanelDef {
 
   getEndepunkter = () => [OpplaeringspengerBehandlingApiKeys.ARBEIDSFORHOLD];
 
-  getData = ({ uttak, arbeidsgiverOpplysningerPerId, alleKodeverk }) => ({
+  getData = ({ uttak, arbeidsgiverOpplysningerPerId, alleKodeverk, inntektsgradering }) => ({
     uttaksperioder: uttak?.uttaksplan != null ? uttak?.uttaksplan?.perioder : uttak?.simulertUttaksplan?.perioder,
+    inntektsgraderinger: inntektsgradering?.perioder,
     utsattePerioder: uttak?.utsattePerioder,
     virkningsdatoUttakNyeRegler: uttak?.virkningsdatoUttakNyeRegler,
     arbeidsgiverOpplysningerPerId,


### PR DESCRIPTION
helst unngå datehenting med HATEOAS-oppsettet, må finne alternativ løsning senere.
pleiepenger-inntektsgradering er riktig rel