### PR TITLE
Fjern nøkkkel for overstyring i prosess sykdom og opplæring

### DIFF
--- a/packages/behandling-omsorgspenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/OpptjeningPanelDef.tsx
+++ b/packages/behandling-omsorgspenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/OpptjeningPanelDef.tsx
@@ -10,7 +10,7 @@ import { OmsorgspengerBehandlingApiKeys } from '../../../data/omsorgspengerBehan
 class OpptjeningPanelDef extends ProsessStegPanelDef {
   getId = () => 'OPPTJENING';
 
-  getTekstKode = () => 'Behandlingspunkt.Opptjening';
+  getTekstKode = () => 'Opptjening';
 
   getKomponent = props => {
     if (props.featureToggles.BRUK_V2_VILKAR_OPPTJENING) {

--- a/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarFortsPaneler/OpptjeningPanelDef.tsx
+++ b/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarFortsPaneler/OpptjeningPanelDef.tsx
@@ -18,7 +18,7 @@ class OpptjeningPanelDef extends ProsessStegPanelDef {
     return <OpptjeningVilkarProsessIndex {...props} />;
   };
 
-  getTekstKode = () => 'Behandlingspunkt.Opptjening';
+  getTekstKode = () => 'Opptjening';
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.VURDER_OPPTJENINGSVILKARET];
 

--- a/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/opplaeringPaneler/InstitusjonPanelDef.tsx
+++ b/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/opplaeringPaneler/InstitusjonPanelDef.tsx
@@ -13,7 +13,7 @@ class InstitusjonPanelDef extends ProsessStegPanelDef {
   getKomponent = props => {
     const deepCopyProps = JSON.parse(JSON.stringify(props));
     konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
+    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps, visOverstyring: false });
   };
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.VURDER_INSTITUSJON];

--- a/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/opplaeringPaneler/InstitusjonPanelDef.tsx
+++ b/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/opplaeringPaneler/InstitusjonPanelDef.tsx
@@ -13,7 +13,7 @@ class InstitusjonPanelDef extends ProsessStegPanelDef {
   getKomponent = props => {
     const deepCopyProps = JSON.parse(JSON.stringify(props));
     konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps, visOverstyring: false });
+    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps, skjulOverstyring: true });
   };
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.VURDER_INSTITUSJON];

--- a/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/opplaeringPaneler/LangvarigSykdomPanelDef.tsx
+++ b/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/opplaeringPaneler/LangvarigSykdomPanelDef.tsx
@@ -13,7 +13,7 @@ class LangvarigSykdomPanelDef extends ProsessStegPanelDef {
   getKomponent = props => {
     const deepCopyProps = JSON.parse(JSON.stringify(props));
     konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps, visOverstyring: false });
+    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps, skjulOverstyring: true });
   };
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.VURDER_LANGVARIG_SYK];

--- a/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/opplaeringPaneler/LangvarigSykdomPanelDef.tsx
+++ b/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/opplaeringPaneler/LangvarigSykdomPanelDef.tsx
@@ -13,7 +13,7 @@ class LangvarigSykdomPanelDef extends ProsessStegPanelDef {
   getKomponent = props => {
     const deepCopyProps = JSON.parse(JSON.stringify(props));
     konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
+    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps, visOverstyring: false });
   };
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.VURDER_LANGVARIG_SYK];

--- a/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/opplaeringPaneler/NødvendigOpplæringPanelDef.tsx
+++ b/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/opplaeringPaneler/NødvendigOpplæringPanelDef.tsx
@@ -13,7 +13,7 @@ class NødvendigOpplæringPanelDef extends ProsessStegPanelDef {
   getKomponent = props => {
     const deepCopyProps = JSON.parse(JSON.stringify(props));
     konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
+    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps, visOverstyring: false });
   };
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.VURDER_OPPLÆRING, aksjonspunktCodes.VURDER_REISETID];

--- a/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/opplaeringPaneler/NødvendigOpplæringPanelDef.tsx
+++ b/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/opplaeringPaneler/NødvendigOpplæringPanelDef.tsx
@@ -13,7 +13,7 @@ class NødvendigOpplæringPanelDef extends ProsessStegPanelDef {
   getKomponent = props => {
     const deepCopyProps = JSON.parse(JSON.stringify(props));
     konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps, visOverstyring: false });
+    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps, skjulOverstyring: true });
   };
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.VURDER_OPPLÆRING, aksjonspunktCodes.VURDER_REISETID];

--- a/packages/behandling-pleiepenger-sluttfase/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarFortsPaneler/OpptjeningPanelDef.tsx
+++ b/packages/behandling-pleiepenger-sluttfase/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarFortsPaneler/OpptjeningPanelDef.tsx
@@ -10,7 +10,7 @@ import { PleiepengerSluttfaseBehandlingApiKeys } from '../../../data/pleiepenger
 class OpptjeningPanelDef extends ProsessStegPanelDef {
   getId = () => 'OPPTJENING';
 
-  getTekstKode = () => 'Behandlingspunkt.Opptjening';
+  getTekstKode = () => 'Opptjening';
 
   getKomponent = props => {
     if (props.featureToggles.BRUK_V2_VILKAR_OPPTJENING) {

--- a/packages/behandling-pleiepenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarFortsPaneler/OpptjeningPanelDef.tsx
+++ b/packages/behandling-pleiepenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarFortsPaneler/OpptjeningPanelDef.tsx
@@ -18,7 +18,7 @@ class OpptjeningPanelDef extends ProsessStegPanelDef {
     return <OpptjeningVilkarProsessIndex {...props} />;
   };
 
-  getTekstKode = () => 'Behandlingspunkt.Opptjening';
+  getTekstKode = () => 'Opptjening';
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.VURDER_OPPTJENINGSVILKARET];
 

--- a/packages/v2/gui/src/prosess/vilkar-overstyring/VilkarresultatMedOverstyringProsessIndex.tsx
+++ b/packages/v2/gui/src/prosess/vilkar-overstyring/VilkarresultatMedOverstyringProsessIndex.tsx
@@ -65,7 +65,7 @@ export interface VilkarresultatMedOverstyringProsessIndexProps {
   visPeriodisering: boolean;
   vilkar: VilkårMedPerioderDto[];
   visAllePerioder: boolean;
-  visOverstyring: boolean;
+  skjulOverstyring: boolean;
 }
 
 export const VilkarresultatMedOverstyringProsessIndex = ({
@@ -84,7 +84,7 @@ export const VilkarresultatMedOverstyringProsessIndex = ({
   visPeriodisering,
   vilkar,
   visAllePerioder,
-  visOverstyring = true,
+  skjulOverstyring = false,
 }: VilkarresultatMedOverstyringProsessIndexProps) => {
   const [activeTab, setActiveTab] = useState(0);
 
@@ -141,7 +141,7 @@ export const VilkarresultatMedOverstyringProsessIndex = ({
           panelTittelKode={panelTittelKode}
           periode={activePeriode}
           toggleOverstyring={toggleOverstyring}
-          visOverstyring={visOverstyring}
+          skjulOverstyring={skjulOverstyring}
         />
         <VilkarresultatMedOverstyringFormPeriodisert
           key={`${activePeriode?.periode?.fom}-${activePeriode?.periode?.tom}`}

--- a/packages/v2/gui/src/prosess/vilkar-overstyring/VilkarresultatMedOverstyringProsessIndex.tsx
+++ b/packages/v2/gui/src/prosess/vilkar-overstyring/VilkarresultatMedOverstyringProsessIndex.tsx
@@ -65,6 +65,7 @@ export interface VilkarresultatMedOverstyringProsessIndexProps {
   visPeriodisering: boolean;
   vilkar: VilkårMedPerioderDto[];
   visAllePerioder: boolean;
+  visOverstyring: boolean;
 }
 
 export const VilkarresultatMedOverstyringProsessIndex = ({
@@ -83,6 +84,7 @@ export const VilkarresultatMedOverstyringProsessIndex = ({
   visPeriodisering,
   vilkar,
   visAllePerioder,
+  visOverstyring = true,
 }: VilkarresultatMedOverstyringProsessIndexProps) => {
   const [activeTab, setActiveTab] = useState(0);
 
@@ -139,6 +141,7 @@ export const VilkarresultatMedOverstyringProsessIndex = ({
           panelTittelKode={panelTittelKode}
           periode={activePeriode}
           toggleOverstyring={toggleOverstyring}
+          visOverstyring={visOverstyring}
         />
         <VilkarresultatMedOverstyringFormPeriodisert
           key={`${activePeriode?.periode?.fom}-${activePeriode?.periode?.tom}`}

--- a/packages/v2/gui/src/prosess/vilkar-overstyring/VilkarresultatMedOverstyringProsessIndex.tsx
+++ b/packages/v2/gui/src/prosess/vilkar-overstyring/VilkarresultatMedOverstyringProsessIndex.tsx
@@ -65,7 +65,7 @@ export interface VilkarresultatMedOverstyringProsessIndexProps {
   visPeriodisering: boolean;
   vilkar: VilkårMedPerioderDto[];
   visAllePerioder: boolean;
-  skjulOverstyring: boolean;
+  skjulOverstyring?: boolean;
 }
 
 export const VilkarresultatMedOverstyringProsessIndex = ({

--- a/packages/v2/gui/src/prosess/vilkar-overstyring/components-periodisert/VilkarresultatMedOverstyringHeader.tsx
+++ b/packages/v2/gui/src/prosess/vilkar-overstyring/components-periodisert/VilkarresultatMedOverstyringHeader.tsx
@@ -35,7 +35,8 @@ const isHidden = (
   aksjonspunktCodes: AksjonspunktCodes[],
   aksjonspunktCode: string,
   vurderesIBehandlingen: boolean,
-) => (!isOverridden(aksjonspunktCodes, aksjonspunktCode) && !kanOverstyre) || !vurderesIBehandlingen;
+  visOverstyring: boolean,
+) => (!isOverridden(aksjonspunktCodes, aksjonspunktCode) && !kanOverstyre) || !vurderesIBehandlingen || !visOverstyring;
 
 const vilkårResultatText = (originalErVilkarOk?: boolean, periode?: VilkårPeriodeDto) => {
   let text = 'Ikke behandlet';
@@ -67,6 +68,7 @@ interface VilkarresultatMedOverstyringHeaderProps {
   panelTittelKode: string;
   toggleOverstyring: (overstyrtPanel: SetStateAction<string[]>) => void;
   periode?: VilkårPeriodeDto;
+  visOverstyring: boolean;
 }
 
 const VilkarresultatMedOverstyringHeader = ({
@@ -79,6 +81,7 @@ const VilkarresultatMedOverstyringHeader = ({
   toggleOverstyring,
   aksjonspunkter,
   periode,
+  visOverstyring = true,
 }: VilkarresultatMedOverstyringHeaderProps) => {
   const aksjonspunktCodes = aksjonspunkter
     .filter((a): a is { definisjon: AksjonspunktCodes } => a.definisjon !== undefined)
@@ -119,6 +122,7 @@ const VilkarresultatMedOverstyringHeader = ({
               aksjonspunktCodes,
               overstyringApKode,
               !!periode?.vurderesIBehandlingen,
+              visOverstyring,
             ) && (
               <Box.New marginBlock={'1 0'}>
                 <Button

--- a/packages/v2/gui/src/prosess/vilkar-overstyring/components-periodisert/VilkarresultatMedOverstyringHeader.tsx
+++ b/packages/v2/gui/src/prosess/vilkar-overstyring/components-periodisert/VilkarresultatMedOverstyringHeader.tsx
@@ -35,8 +35,9 @@ const isHidden = (
   aksjonspunktCodes: AksjonspunktCodes[],
   aksjonspunktCode: string,
   vurderesIBehandlingen: boolean,
-  visOverstyring: boolean,
-) => (!isOverridden(aksjonspunktCodes, aksjonspunktCode) && !kanOverstyre) || !vurderesIBehandlingen || !visOverstyring;
+  skjulOverstyring: boolean,
+) =>
+  (!isOverridden(aksjonspunktCodes, aksjonspunktCode) && !kanOverstyre) || !vurderesIBehandlingen || skjulOverstyring;
 
 const vilkårResultatText = (originalErVilkarOk?: boolean, periode?: VilkårPeriodeDto) => {
   let text = 'Ikke behandlet';
@@ -68,7 +69,7 @@ interface VilkarresultatMedOverstyringHeaderProps {
   panelTittelKode: string;
   toggleOverstyring: (overstyrtPanel: SetStateAction<string[]>) => void;
   periode?: VilkårPeriodeDto;
-  visOverstyring: boolean;
+  skjulOverstyring: boolean;
 }
 
 const VilkarresultatMedOverstyringHeader = ({
@@ -81,7 +82,7 @@ const VilkarresultatMedOverstyringHeader = ({
   toggleOverstyring,
   aksjonspunkter,
   periode,
-  visOverstyring = true,
+  skjulOverstyring = false,
 }: VilkarresultatMedOverstyringHeaderProps) => {
   const aksjonspunktCodes = aksjonspunkter
     .filter((a): a is { definisjon: AksjonspunktCodes } => a.definisjon !== undefined)
@@ -122,7 +123,7 @@ const VilkarresultatMedOverstyringHeader = ({
               aksjonspunktCodes,
               overstyringApKode,
               !!periode?.vurderesIBehandlingen,
-              visOverstyring,
+              skjulOverstyring,
             ) && (
               <Box.New marginBlock={'1 0'}>
                 <Button

--- a/packages/v2/gui/src/prosess/vilkar-overstyring/components-periodisert/VilkarresultatMedOverstyringHeader.tsx
+++ b/packages/v2/gui/src/prosess/vilkar-overstyring/components-periodisert/VilkarresultatMedOverstyringHeader.tsx
@@ -69,7 +69,7 @@ interface VilkarresultatMedOverstyringHeaderProps {
   panelTittelKode: string;
   toggleOverstyring: (overstyrtPanel: SetStateAction<string[]>) => void;
   periode?: VilkårPeriodeDto;
-  skjulOverstyring: boolean;
+  skjulOverstyring?: boolean;
 }
 
 const VilkarresultatMedOverstyringHeader = ({

--- a/packages/v2/gui/src/prosess/vilkar-overstyring/components-periodisert/VilkarresultatMedOverstyringHeader.tsx
+++ b/packages/v2/gui/src/prosess/vilkar-overstyring/components-periodisert/VilkarresultatMedOverstyringHeader.tsx
@@ -82,7 +82,7 @@ const VilkarresultatMedOverstyringHeader = ({
   toggleOverstyring,
   aksjonspunkter,
   periode,
-  skjulOverstyring = false,
+  skjulOverstyring,
 }: VilkarresultatMedOverstyringHeaderProps) => {
   const aksjonspunktCodes = aksjonspunkter
     .filter((a): a is { definisjon: AksjonspunktCodes } => a.definisjon !== undefined)

--- a/packages/v2/gui/src/prosess/vilkar-overstyring/components-periodisert/VilkarresultatMedOverstyringHeader.tsx
+++ b/packages/v2/gui/src/prosess/vilkar-overstyring/components-periodisert/VilkarresultatMedOverstyringHeader.tsx
@@ -35,7 +35,7 @@ const isHidden = (
   aksjonspunktCodes: AksjonspunktCodes[],
   aksjonspunktCode: string,
   vurderesIBehandlingen: boolean,
-  skjulOverstyring: boolean,
+  skjulOverstyring?: boolean,
 ) =>
   (!isOverridden(aksjonspunktCodes, aksjonspunktCode) && !kanOverstyre) || !vurderesIBehandlingen || skjulOverstyring;
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
Bare institusjon som kan gå automatisk, og den kan redigeres i faktapanelet. Vi har ikke behov for å vise overstyringsknapp

### **Løsning**
vi skjuler overstyring

### **Annet**
Fikser visning av tekst for opptjening. Dukker opp som "Behandlingspunkt.Opptjening" nå

