### PR TITLE
Justeringer i uttak

### DIFF
--- a/packages/v2/gui/src/prosess/uttak/uttak-detaljer/GraderingMotInntektDetaljer.tsx
+++ b/packages/v2/gui/src/prosess/uttak/uttak-detaljer/GraderingMotInntektDetaljer.tsx
@@ -32,30 +32,33 @@ const GraderingMotInntektDetaljer: FC<ownProps> = ({ alleArbeidsforhold, inntekt
   return (
     <VStack className={`${styles.uttakDetaljerDetailItem} mt-2`}>
       <UttakDetaljerEkspanderbar title={`Beregningsgrunnlag: ${beregningsgrunnlag}`}>
-        {inntektsforhold.map(inntForhold => {
-          const { arbeidsgiverIdentifikator } = inntForhold;
-          const arbeidsforholdData = arbeidsgiverIdentifikator
-            ? alleArbeidsforhold?.[arbeidsgiverIdentifikator]
-            : undefined;
-          return (
-            <Box.New
-              key={`${arbeidsgiverIdentifikator}_avkorting_inntekt_grunnlag`}
-              className={styles.uttakDetaljerBeregningFirma}
-            >
-              <BodyShort size="small" weight="semibold" className="leading-6">
-                {inntForhold.type !== InntektsforholdDtoType.FRILANSER
-                  ? `${arbeidsforholdData?.navn || 'Mangler navn'} (${arbeidsforholdData?.identifikator || arbeidsgiverIdentifikator})`
-                  : 'Frilanser'}{' '}
-                {inntForhold.erNytt && (
-                  <Tag size="small" variant="info">
-                    Ny
-                  </Tag>
-                )}
-              </BodyShort>
-              <BodyShort size="small">Inntekt: {formatNOK(inntForhold.bruttoInntekt)}</BodyShort>
-            </Box.New>
-          );
-        })}
+        {inntektsforhold
+          // Ikke vise tilkommende inntekstforhold i beregningsgrunnlag
+          .filter(inntForhold => !inntForhold.erNytt)
+          .map(inntForhold => {
+            const { arbeidsgiverIdentifikator } = inntForhold;
+            const arbeidsforholdData = arbeidsgiverIdentifikator
+              ? alleArbeidsforhold?.[arbeidsgiverIdentifikator]
+              : undefined;
+            return (
+              <Box.New
+                key={`${arbeidsgiverIdentifikator}_avkorting_inntekt_grunnlag`}
+                className={styles.uttakDetaljerBeregningFirma}
+              >
+                <BodyShort size="small" weight="semibold" className="leading-6">
+                  {inntForhold.type !== InntektsforholdDtoType.FRILANSER
+                    ? `${arbeidsforholdData?.navn || 'Mangler navn'} (${arbeidsforholdData?.identifikator || arbeidsgiverIdentifikator})`
+                    : 'Frilanser'}{' '}
+                  {inntForhold.erNytt && (
+                    <Tag size="small" variant="info">
+                      Ny
+                    </Tag>
+                  )}
+                </BodyShort>
+                <BodyShort size="small">Inntekt: {formatNOK(inntForhold.bruttoInntekt)}</BodyShort>
+              </Box.New>
+            );
+          })}
       </UttakDetaljerEkspanderbar>
       <UttakDetaljerEkspanderbar title={`Utbetalt lønn: ${løpendeInntekt}`}>
         {inntektsforhold.map(inntForhold => {

--- a/packages/v2/gui/src/prosess/uttak/uttak-detaljer/GraderingMotInntektDetaljer.tsx
+++ b/packages/v2/gui/src/prosess/uttak/uttak-detaljer/GraderingMotInntektDetaljer.tsx
@@ -43,8 +43,9 @@ const GraderingMotInntektDetaljer: FC<ownProps> = ({ alleArbeidsforhold, inntekt
               className={styles.uttakDetaljerBeregningFirma}
             >
               <BodyShort size="small" weight="semibold" className="leading-6">
-                {arbeidsforholdData?.navn || 'Mangler navn'} (
-                {arbeidsforholdData?.identifikator || arbeidsgiverIdentifikator}){' '}
+                {inntForhold.type !== InntektsforholdDtoType.FRILANSER
+                  ? `${arbeidsforholdData?.navn || 'Mangler navn'} (${arbeidsforholdData?.identifikator || arbeidsgiverIdentifikator})`
+                  : 'Frilanser'}{' '}
                 {inntForhold.erNytt && (
                   <Tag size="small" variant="info">
                     Ny


### PR DESCRIPTION
### **Behov / Bakgrunn**
Tilkommen inntekt er ikke med i beregningsgrunnlaget, men det kan virke forvirrende at den blir listet opp under beregningsgrunnlag ved gradering mot inntekt. 

### **Løsning**
Skjuler tilkommen inntekt fra oppsummeringen under beregningsgrunnlag

### **Skjermbilder** (hvis relevant)
Før:
<img width="416" height="340" alt="Skjermbilde 2025-09-02 kl  15 11 44" src="https://github.com/user-attachments/assets/34441011-cdd8-4a9a-97d9-74fbc04b4843" />

Etter:
<img width="416" height="286" alt="Skjermbilde 2025-09-02 kl  15 09 35" src="https://github.com/user-attachments/assets/72ee8c3b-5f13-429d-8df8-df8f2f63657f" />
