### PR TITLE
fix - legger tilbake uuid som param for oppretting av ny behandling.

### DIFF
--- a/packages/v2/gui/src/sak/meny/ny-behandling/MenyNyBehandlingIndex.tsx
+++ b/packages/v2/gui/src/sak/meny/ny-behandling/MenyNyBehandlingIndex.tsx
@@ -32,8 +32,12 @@ interface OwnProps {
   };
   uuidForSistLukkede?: string;
   erTilbakekrevingAktivert: boolean;
-  sjekkOmTilbakekrevingKanOpprettes: (params: { saksnummer: string; ytelsesbehandlingUuid: string }) => void;
-  sjekkOmTilbakekrevingRevurderingKanOpprettes: (params: { behandlingUuid: string }) => void;
+  sjekkOmTilbakekrevingKanOpprettes: (params: {
+    saksnummer: string;
+    ytelsesbehandlingUuid: string;
+    uuid: string;
+  }) => void;
+  sjekkOmTilbakekrevingRevurderingKanOpprettes: (params: { behandlingUuid: string; uuid: string }) => void;
   lukkModal: () => void;
   aktorId?: string;
   gjeldendeVedtakBehandlendeEnhetId?: string;

--- a/packages/v2/gui/src/sak/meny/ny-behandling/components/NyBehandlingModal.tsx
+++ b/packages/v2/gui/src/sak/meny/ny-behandling/components/NyBehandlingModal.tsx
@@ -57,8 +57,12 @@ interface NyBehandlingModalProps {
   behandlingUuid?: string;
   uuidForSistLukkede?: string;
   erTilbakekrevingAktivert: boolean;
-  sjekkOmTilbakekrevingKanOpprettes: (params: { saksnummer: string; ytelsesbehandlingUuid: string }) => void;
-  sjekkOmTilbakekrevingRevurderingKanOpprettes: (params: { behandlingUuid: string }) => void;
+  sjekkOmTilbakekrevingKanOpprettes: (params: {
+    saksnummer: string;
+    ytelsesbehandlingUuid: string;
+    uuid: string;
+  }) => void;
+  sjekkOmTilbakekrevingRevurderingKanOpprettes: (params: { behandlingUuid: string; uuid: string }) => void;
   aktorId?: string;
   gjeldendeVedtakBehandlendeEnhetId?: string;
   sisteDagISøknadsperiode?: Date | null;
@@ -93,10 +97,14 @@ export const NyBehandlingModal = ({
   useEffect(() => {
     if (erTilbakekrevingAktivert) {
       if (uuidForSistLukkede !== undefined) {
-        sjekkOmTilbakekrevingKanOpprettes({ saksnummer, ytelsesbehandlingUuid: uuidForSistLukkede });
+        sjekkOmTilbakekrevingKanOpprettes({
+          saksnummer,
+          ytelsesbehandlingUuid: uuidForSistLukkede,
+          uuid: uuidForSistLukkede,
+        });
       }
       if (erTilbakekreving(behandlingType) && behandlingUuid) {
-        sjekkOmTilbakekrevingRevurderingKanOpprettes({ behandlingUuid });
+        sjekkOmTilbakekrevingRevurderingKanOpprettes({ behandlingUuid, uuid: behandlingUuid });
       }
     }
   }, [


### PR DESCRIPTION
### **Behov / Bakgrunn**
uuid ble feilaktig fjernet da ung-sak ikke bruker denne parameteren

### **Løsning**
legger tilbake uuid som param for oppretting av ny behandling.

### **Andre endringer**


### **Skjermbilder** (hvis relevant)
