### PR TITLE
Lager egen tag for visning av fremhevet data

### DIFF
--- a/packages/v2/gui/src/prosess/uttak/uttak-detaljer/FremhevingTag.tsx
+++ b/packages/v2/gui/src/prosess/uttak/uttak-detaljer/FremhevingTag.tsx
@@ -1,0 +1,22 @@
+import { CheckmarkIcon } from '@navikt/aksel-icons';
+import { Box, HStack } from '@navikt/ds-react';
+import styles from './fremhevingTag.module.css';
+
+interface FremhevingTag {
+  text: string;
+}
+
+export const FremhevingTag = ({ text }: FremhevingTag) => (
+  <Box.New
+    paddingBlock="space-2"
+    paddingInline="space-4 space-8"
+    width="fit-content"
+    borderRadius="4"
+    className={styles.fremhevingTag}
+  >
+    <HStack gap="space-2">
+      <CheckmarkIcon />
+      {text}
+    </HStack>
+  </Box.New>
+);

--- a/packages/v2/gui/src/prosess/uttak/uttak-detaljer/UttakDetaljer.tsx
+++ b/packages/v2/gui/src/prosess/uttak/uttak-detaljer/UttakDetaljer.tsx
@@ -9,7 +9,7 @@ import {
 import { fagsakYtelsesType, type FagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
 import { useKodeverkContext } from '@k9-sak-web/gui/kodeverk/index.js';
 import { KodeverkType, type KodeverkNavnFraKodeType } from '@k9-sak-web/lib/kodeverk/types.js';
-import { BriefcaseClockIcon, CheckmarkIcon, HandHeartIcon, SackKronerIcon } from '@navikt/aksel-icons';
+import { BriefcaseClockIcon, HandHeartIcon, SackKronerIcon } from '@navikt/aksel-icons';
 import { Alert, Box, Heading, HelpText, HGrid, HStack, Tag } from '@navikt/ds-react';
 import { type JSX } from 'react';
 import {
@@ -17,6 +17,7 @@ import {
   IkkeOppfylteÅrsakerMedTekst,
 } from '../constants/UttaksperiodeInfoÅrsakerTekst';
 import type { UttaksperiodeMedInntektsgradering } from '../types/UttaksperiodeMedInntektsgradering';
+import { FremhevingTag } from './FremhevingTag';
 import GraderingMotArbeidstidDetaljer from './GraderingMotArbeidstidDetaljer';
 import GraderingMotInntektDetaljer from './GraderingMotInntektDetaljer';
 import GraderingMotTilsynDetaljer from './GraderingMotTilsynDetaljer';
@@ -152,10 +153,7 @@ const UttakDetaljer = ({ uttak, arbeidsforhold, manueltOverstyrt, ytelsetype }: 
           >
             {shouldHighlightTilsyn && (
               <Box.New className={styles.uttakDetaljerTag}>
-                <Tag size="medium" variant="alt3-moderate">
-                  <CheckmarkIcon />
-                  Gir lavest {graderingBenevnelse(ytelsetype)}
-                </Tag>
+                <FremhevingTag text={`Gir lavest ${graderingBenevnelse(ytelsetype)}`} />
               </Box.New>
             )}
             <HStack>
@@ -177,10 +175,7 @@ const UttakDetaljer = ({ uttak, arbeidsforhold, manueltOverstyrt, ytelsetype }: 
         >
           {shouldHighlightArbeidstid && (
             <Box.New className={styles.uttakDetaljerTag}>
-              <Tag size="medium" variant="alt3-moderate">
-                <CheckmarkIcon />
-                Gir lavest {graderingBenevnelse(ytelsetype)}
-              </Tag>
+              <FremhevingTag text={`Gir lavest ${graderingBenevnelse(ytelsetype)}`} />
             </Box.New>
           )}
           <HStack>
@@ -201,10 +196,7 @@ const UttakDetaljer = ({ uttak, arbeidsforhold, manueltOverstyrt, ytelsetype }: 
           >
             {shouldHighlightInntekt && (
               <Box.New className={styles.uttakDetaljerTag}>
-                <Tag size="medium" variant="alt3-moderate">
-                  <CheckmarkIcon />
-                  Gir lavest {graderingBenevnelse(ytelsetype)}
-                </Tag>
+                <FremhevingTag text={`Gir lavest ${graderingBenevnelse(ytelsetype)}`} />
               </Box.New>
             )}
             <HStack>

--- a/packages/v2/gui/src/prosess/uttak/uttak-detaljer/fremhevingTag.module.css
+++ b/packages/v2/gui/src/prosess/uttak/uttak-detaljer/fremhevingTag.module.css
@@ -1,0 +1,3 @@
+.fremhevingTag {
+  background-color: var(--ax-border-brand-blue-subtle);
+}

--- a/packages/v2/gui/src/prosess/uttak/uttak-detaljer/fremhevingTag.module.d.css.ts
+++ b/packages/v2/gui/src/prosess/uttak/uttak-detaljer/fremhevingTag.module.d.css.ts
@@ -1,0 +1,5 @@
+declare const styles: {
+  readonly "fremhevingTag": string;
+};
+export = styles;
+


### PR DESCRIPTION
### **Behov / Bakgrunn**
Aksels tag kan ikke vises slik vi ønsker etter overgang til darkside.

### **Løsning**
Lager egen tag for vår visning.

### **Andre endringer**


### **Skjermbilder** (hvis relevant)
<img width="449" height="311" alt="Skjermbilde 2025-09-09 kl  10 25 47" src="https://github.com/user-attachments/assets/edceaa6e-1a20-44cf-8d38-b730a2b64ede" />
