### PR TITLE
FAGSYSTEM-396649 - kodeverk er ikke string men objekt

### DIFF
--- a/packages/v2/gui/src/prosess/vilkar-overstyring/components-periodisert/VilkarResultPickerPeriodisertRHF.tsx
+++ b/packages/v2/gui/src/prosess/vilkar-overstyring/components-periodisert/VilkarResultPickerPeriodisertRHF.tsx
@@ -157,10 +157,10 @@ const VilkarResultPickerPeriodisertRHF: FunctionComponent<OwnProps> & StaticFunc
               name={`${fieldNamePrefix ? `${fieldNamePrefix}.` : ''}avslagCode`}
               label="Avslagsårsak"
               selectValues={avslagsårsakerForVilkar
-                .filter((avslagsårsak): avslagsårsak is string => typeof avslagsårsak === 'string')
+                .filter(avslagsårsak => typeof avslagsårsak === 'object' && 'kode' in avslagsårsak)
                 .map(avslagsårsak => (
-                  <option key={avslagsårsak} value={avslagsårsak}>
-                    {avslagsårsak}
+                  <option key={avslagsårsak.kode} value={avslagsårsak.kode}>
+                    {avslagsårsak.navn}
                   </option>
                 ))}
               readOnly={readOnly}
@@ -215,10 +215,10 @@ const VilkarResultPickerPeriodisertRHF: FunctionComponent<OwnProps> & StaticFunc
                 name={`${fieldNamePrefix ? `${fieldNamePrefix}.` : ''}avslagCode`}
                 label="Avslagsårsak"
                 selectValues={avslagsårsakerForVilkar
-                  .filter((avslagsårsak): avslagsårsak is string => typeof avslagsårsak === 'string')
+                  .filter(avslagsårsak => typeof avslagsårsak === 'object' && 'kode' in avslagsårsak)
                   .map(avslagsårsak => (
-                    <option key={avslagsårsak} value={avslagsårsak}>
-                      {avslagsårsak}
+                    <option key={avslagsårsak.kode} value={avslagsårsak.kode}>
+                      {avslagsårsak.navn}
                     </option>
                   ))}
                 readOnly={readOnly}


### PR DESCRIPTION
### **Behov / Bakgrunn**
FAGSYSTEM-396649
Kodeverk er ikke string men objekt.

### **Løsning**
Bruker avslagsårsak som objekt.

### **Andre endringer**


### **Skjermbilder** (hvis relevant)
