### PR TITLE
FAGSYSTEM-396943 - Retter props for overstyringspanel

### DIFF
--- a/packages/behandling-felles/src/util/prosessSteg/ProsessStegOverstyringPanelDef.tsx
+++ b/packages/behandling-felles/src/util/prosessSteg/ProsessStegOverstyringPanelDef.tsx
@@ -2,6 +2,7 @@ import { ReactNode } from 'react';
 
 import kodeverkTyper from '@fpsak-frontend/kodeverk/src/kodeverkTyper';
 import { VilkarresultatMedOverstyringProsessIndex as VilkarresultatMedOverstyringProsessIndexV2 } from '@k9-sak-web/gui/prosess/vilkar-overstyring/VilkarresultatMedOverstyringProsessIndex.js';
+import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 import { ProsessStegPanelDef } from './ProsessStegDef';
 
 const harVilkarresultatMedOverstyring = (aksjonspunkterForSteg, aksjonspunktDefKoderForSteg) => {
@@ -33,7 +34,11 @@ class ProsessStegOverstyringPanelDef extends ProsessStegPanelDef {
   getOverstyrVisningAvKomponent = ({ vilkarForSteg, aksjonspunkterForSteg, aksjonspunktDefKoderForSteg }): boolean =>
     vilkarForSteg.length > 0 && harVilkarresultatMedOverstyring(aksjonspunkterForSteg, aksjonspunktDefKoderForSteg);
 
-  getKomponent = (props): ReactNode => <VilkarresultatMedOverstyringProsessIndexV2 {...props} />;
+  getKomponent = (props): ReactNode => {
+    const deepCopyProps = JSON.parse(JSON.stringify(props));
+    konverterKodeverkTilKode(deepCopyProps, false);
+    return <VilkarresultatMedOverstyringProsessIndexV2 {...props} {...deepCopyProps} />;
+  };
 
   getData = ({
     vilkarForSteg,

--- a/packages/behandling-omsorgspenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/AlderPanelDef.tsx
+++ b/packages/behandling-omsorgspenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/AlderPanelDef.tsx
@@ -1,6 +1,5 @@
 import vilkarType from '@fpsak-frontend/kodeverk/src/vilkarType';
 import { ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 
 class AlderPanelDef extends ProsessStegPanelDef {
   overstyringDef = new ProsessStegOverstyringPanelDef(this);
@@ -9,11 +8,7 @@ class AlderPanelDef extends ProsessStegPanelDef {
 
   getTekstKode = () => 'Alder';
 
-  getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
-  };
+  getKomponent = props => this.overstyringDef.getKomponent(props);
 
   getAksjonspunktKoder = () => [];
 

--- a/packages/behandling-omsorgspenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/MedlemskapPanelDef.tsx
+++ b/packages/behandling-omsorgspenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/MedlemskapPanelDef.tsx
@@ -2,7 +2,6 @@ import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import vilkarType from '@fpsak-frontend/kodeverk/src/vilkarType';
 import { ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
 
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 import { OmsorgspengerBehandlingApiKeys } from '../../../data/omsorgspengerBehandlingApi';
 
 class MedlemskapPanelDef extends ProsessStegPanelDef {
@@ -12,11 +11,7 @@ class MedlemskapPanelDef extends ProsessStegPanelDef {
 
   getTekstKode = () => 'Medlemskap';
 
-  getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
-  };
+  getKomponent = props => this.overstyringDef.getKomponent(props);
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.OVERSTYR_MEDLEMSKAPSVILKAR];
 

--- a/packages/behandling-omsorgspenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/OmsorgenForPanelDef.tsx
+++ b/packages/behandling-omsorgspenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/OmsorgenForPanelDef.tsx
@@ -2,7 +2,6 @@
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import vilkarType from '@fpsak-frontend/kodeverk/src/vilkarType';
 import { ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 
 class OmsorgenForPanelDef extends ProsessStegPanelDef {
   overstyringDef = new ProsessStegOverstyringPanelDef(this);
@@ -12,9 +11,7 @@ class OmsorgenForPanelDef extends ProsessStegPanelDef {
   getTekstKode = () => 'Omsorg';
 
   getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps, lovReferanse: '§ 9-5' });
+    return this.overstyringDef.getKomponent({ ...props, lovReferanse: '§ 9-5' });
   };
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.OVERSTYR_OMSORGEN_FOR];

--- a/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/FortsattMedlemskapProsessStegPanelDef.tsx
+++ b/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/FortsattMedlemskapProsessStegPanelDef.tsx
@@ -1,16 +1,11 @@
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import { ProsessStegDef, ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
 import { prosessStegCodes } from '@k9-sak-web/konstanter';
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 
 class PanelDef extends ProsessStegPanelDef {
   overstyringDef = new ProsessStegOverstyringPanelDef(this);
 
-  getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
-  };
+  getKomponent = props => this.overstyringDef.getKomponent(props);
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.OVERSTYR_LØPENDE_MEDLEMSKAPSVILKAR];
 

--- a/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarFortsPaneler/MedlemskapPanelDef.tsx
+++ b/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarFortsPaneler/MedlemskapPanelDef.tsx
@@ -2,7 +2,6 @@ import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import vilkarType from '@fpsak-frontend/kodeverk/src/vilkarType';
 import { ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
 
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 import { OpplaeringspengerBehandlingApiKeys } from '../../../data/opplaeringspengerBehandlingApi';
 
 class MedlemskapPanelDef extends ProsessStegPanelDef {
@@ -12,11 +11,7 @@ class MedlemskapPanelDef extends ProsessStegPanelDef {
 
   getTekstKode = () => 'Medlemskap';
 
-  getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
-  };
+  getKomponent = props => this.overstyringDef.getKomponent(props);
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.OVERSTYR_MEDLEMSKAPSVILKAR];
 

--- a/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/AlderPanelDef.tsx
+++ b/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/AlderPanelDef.tsx
@@ -1,6 +1,5 @@
 import vilkarType from '@fpsak-frontend/kodeverk/src/vilkarType';
 import { ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 class AlderPanelDef extends ProsessStegPanelDef {
   overstyringDef = new ProsessStegOverstyringPanelDef(this);
 
@@ -8,11 +7,7 @@ class AlderPanelDef extends ProsessStegPanelDef {
 
   getTekstKode = () => 'Alder';
 
-  getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
-  };
+  getKomponent = props => this.overstyringDef.getKomponent(props);
 
   getAksjonspunktKoder = () => [];
 

--- a/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/OmsorgenForPanelDef.tsx
+++ b/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/OmsorgenForPanelDef.tsx
@@ -2,7 +2,6 @@
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import vilkarType from '@fpsak-frontend/kodeverk/src/vilkarType';
 import { ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 class OmsorgenForPanelDef extends ProsessStegPanelDef {
   overstyringDef = new ProsessStegOverstyringPanelDef(this);
 
@@ -10,12 +9,7 @@ class OmsorgenForPanelDef extends ProsessStegPanelDef {
 
   getTekstKode = () => 'Omsorg';
 
-  getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
-  };
-
+  getKomponent = props => this.overstyringDef.getKomponent(props);
   getAksjonspunktKoder = () => [aksjonspunktCodes.OVERSTYR_OMSORGEN_FOR];
 
   getVilkarKoder = () => [vilkarType.OMSORGENFORVILKARET];

--- a/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/opplaeringPaneler/InstitusjonPanelDef.tsx
+++ b/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/opplaeringPaneler/InstitusjonPanelDef.tsx
@@ -1,7 +1,6 @@
 import { aksjonspunktCodes } from '@k9-sak-web/backend/k9sak/kodeverk/AksjonspunktCodes.js';
 import { vilkarType } from '@k9-sak-web/backend/k9sak/kodeverk/behandling/VilkårType.js';
 import { ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 
 class InstitusjonPanelDef extends ProsessStegPanelDef {
   overstyringDef = new ProsessStegOverstyringPanelDef(this);
@@ -11,9 +10,7 @@ class InstitusjonPanelDef extends ProsessStegPanelDef {
   getTekstKode = () => 'Institusjon';
 
   getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps, skjulOverstyring: true });
+    return this.overstyringDef.getKomponent({ ...props, skjulOverstyring: true });
   };
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.VURDER_INSTITUSJON];

--- a/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/opplaeringPaneler/LangvarigSykdomPanelDef.tsx
+++ b/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/opplaeringPaneler/LangvarigSykdomPanelDef.tsx
@@ -1,7 +1,6 @@
 import { aksjonspunktCodes } from '@k9-sak-web/backend/k9sak/kodeverk/AksjonspunktCodes.js';
 import { vilkarType } from '@k9-sak-web/backend/k9sak/kodeverk/behandling/VilkårType.js';
 import { ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 
 class LangvarigSykdomPanelDef extends ProsessStegPanelDef {
   overstyringDef = new ProsessStegOverstyringPanelDef(this);
@@ -11,9 +10,7 @@ class LangvarigSykdomPanelDef extends ProsessStegPanelDef {
   getTekstKode = () => 'Langvarig sykdom';
 
   getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps, skjulOverstyring: true });
+    return this.overstyringDef.getKomponent({ ...props, skjulOverstyring: true });
   };
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.VURDER_LANGVARIG_SYK];

--- a/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/opplaeringPaneler/NødvendigOpplæringPanelDef.tsx
+++ b/packages/behandling-opplaeringspenger/src/panelDefinisjoner/prosessStegPaneler/opplaeringPaneler/NødvendigOpplæringPanelDef.tsx
@@ -1,7 +1,6 @@
 import { aksjonspunktCodes } from '@k9-sak-web/backend/k9sak/kodeverk/AksjonspunktCodes.js';
 import { vilkarType } from '@k9-sak-web/backend/k9sak/kodeverk/behandling/VilkårType.js';
 import { ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 
 class NødvendigOpplæringPanelDef extends ProsessStegPanelDef {
   overstyringDef = new ProsessStegOverstyringPanelDef(this);
@@ -11,9 +10,7 @@ class NødvendigOpplæringPanelDef extends ProsessStegPanelDef {
   getTekstKode = () => 'Opplæring og reisetid';
 
   getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps, skjulOverstyring: true });
+    return this.overstyringDef.getKomponent({ ...props, skjulOverstyring: true });
   };
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.VURDER_OPPLÆRING, aksjonspunktCodes.VURDER_REISETID];

--- a/packages/behandling-pleiepenger-sluttfase/src/panelDefinisjoner/prosessStegPaneler/FortsattMedlemskapProsessStegPanelDef.tsx
+++ b/packages/behandling-pleiepenger-sluttfase/src/panelDefinisjoner/prosessStegPaneler/FortsattMedlemskapProsessStegPanelDef.tsx
@@ -1,16 +1,11 @@
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import { ProsessStegDef, ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
 import { prosessStegCodes } from '@k9-sak-web/konstanter';
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 
 class PanelDef extends ProsessStegPanelDef {
   overstyringDef = new ProsessStegOverstyringPanelDef(this);
 
-  getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
-  };
+  getKomponent = props => this.overstyringDef.getKomponent(props);
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.OVERSTYR_LØPENDE_MEDLEMSKAPSVILKAR];
 

--- a/packages/behandling-pleiepenger-sluttfase/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarFortsPaneler/MedlemskapPanelDef.tsx
+++ b/packages/behandling-pleiepenger-sluttfase/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarFortsPaneler/MedlemskapPanelDef.tsx
@@ -2,7 +2,6 @@ import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import vilkarType from '@fpsak-frontend/kodeverk/src/vilkarType';
 import { ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
 
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 import { PleiepengerSluttfaseBehandlingApiKeys } from '../../../data/pleiepengerSluttfaseBehandlingApi';
 
 class MedlemskapPanelDef extends ProsessStegPanelDef {
@@ -12,11 +11,7 @@ class MedlemskapPanelDef extends ProsessStegPanelDef {
 
   getTekstKode = () => 'Medlemskap';
 
-  getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
-  };
+  getKomponent = props => this.overstyringDef.getKomponent(props);
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.OVERSTYR_MEDLEMSKAPSVILKAR];
 

--- a/packages/behandling-pleiepenger-sluttfase/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/AlderPanelDef.tsx
+++ b/packages/behandling-pleiepenger-sluttfase/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/AlderPanelDef.tsx
@@ -1,6 +1,5 @@
 import vilkarType from '@fpsak-frontend/kodeverk/src/vilkarType';
 import { ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 
 class AlderPanelDef extends ProsessStegPanelDef {
   overstyringDef = new ProsessStegOverstyringPanelDef(this);
@@ -9,11 +8,7 @@ class AlderPanelDef extends ProsessStegPanelDef {
 
   getTekstKode = () => 'Alder';
 
-  getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
-  };
+  getKomponent = props => this.overstyringDef.getKomponent(props);
 
   getAksjonspunktKoder = () => [];
 

--- a/packages/behandling-pleiepenger/src/panelDefinisjoner/prosessStegPaneler/FortsattMedlemskapProsessStegPanelDef.tsx
+++ b/packages/behandling-pleiepenger/src/panelDefinisjoner/prosessStegPaneler/FortsattMedlemskapProsessStegPanelDef.tsx
@@ -1,16 +1,11 @@
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import { ProsessStegDef, ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
 import { prosessStegCodes } from '@k9-sak-web/konstanter';
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 
 class PanelDef extends ProsessStegPanelDef {
   overstyringDef = new ProsessStegOverstyringPanelDef(this);
 
-  getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
-  };
+  getKomponent = props => this.overstyringDef.getKomponent(props);
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.OVERSTYR_LØPENDE_MEDLEMSKAPSVILKAR];
 

--- a/packages/behandling-pleiepenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarFortsPaneler/MedlemskapPanelDef.tsx
+++ b/packages/behandling-pleiepenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarFortsPaneler/MedlemskapPanelDef.tsx
@@ -2,7 +2,6 @@ import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import vilkarType from '@fpsak-frontend/kodeverk/src/vilkarType';
 import { ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
 
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 import { PleiepengerBehandlingApiKeys } from '../../../data/pleiepengerBehandlingApi';
 
 class MedlemskapPanelDef extends ProsessStegPanelDef {
@@ -12,11 +11,7 @@ class MedlemskapPanelDef extends ProsessStegPanelDef {
 
   getTekstKode = () => 'Medlemskap';
 
-  getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
-  };
+  getKomponent = props => this.overstyringDef.getKomponent(props);
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.OVERSTYR_MEDLEMSKAPSVILKAR];
 

--- a/packages/behandling-pleiepenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/AlderPanelDef.tsx
+++ b/packages/behandling-pleiepenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/AlderPanelDef.tsx
@@ -1,6 +1,5 @@
 import vilkarType from '@fpsak-frontend/kodeverk/src/vilkarType';
 import { ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 
 class AlderPanelDef extends ProsessStegPanelDef {
   overstyringDef = new ProsessStegOverstyringPanelDef(this);
@@ -9,11 +8,7 @@ class AlderPanelDef extends ProsessStegPanelDef {
 
   getTekstKode = () => 'Alder';
 
-  getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
-  };
+  getKomponent = props => this.overstyringDef.getKomponent(props);
 
   getAksjonspunktKoder = () => [];
 

--- a/packages/behandling-pleiepenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/OmsorgenForPanelDef.tsx
+++ b/packages/behandling-pleiepenger/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/OmsorgenForPanelDef.tsx
@@ -2,7 +2,6 @@
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import vilkarType from '@fpsak-frontend/kodeverk/src/vilkarType';
 import { ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 
 class OmsorgenForPanelDef extends ProsessStegPanelDef {
   overstyringDef = new ProsessStegOverstyringPanelDef(this);
@@ -11,11 +10,7 @@ class OmsorgenForPanelDef extends ProsessStegPanelDef {
 
   getTekstKode = () => 'Omsorg';
 
-  getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
-  };
+  getKomponent = props => this.overstyringDef.getKomponent(props);
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.OVERSTYR_OMSORGEN_FOR];
 

--- a/packages/behandling-ungdomsytelse/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/AlderPanelDef.tsx
+++ b/packages/behandling-ungdomsytelse/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/AlderPanelDef.tsx
@@ -1,6 +1,5 @@
 import { ung_kodeverk_vilkår_VilkårType as VilkårType } from '@k9-sak-web/backend/ungsak/generated/types.js';
 import { ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 
 class AlderPanelDef extends ProsessStegPanelDef {
   overstyringDef = new ProsessStegOverstyringPanelDef(this);
@@ -9,11 +8,7 @@ class AlderPanelDef extends ProsessStegPanelDef {
 
   getTekstKode = () => 'Alder';
 
-  getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
-  };
+  getKomponent = props => this.overstyringDef.getKomponent(props);
 
   getAksjonspunktKoder = () => [];
 

--- a/packages/behandling-ungdomsytelse/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/UngdomsprogramPanelDef.tsx
+++ b/packages/behandling-ungdomsytelse/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/UngdomsprogramPanelDef.tsx
@@ -1,6 +1,5 @@
 import { ung_kodeverk_vilkår_VilkårType as VilkårType } from '@k9-sak-web/backend/ungsak/generated/types.js';
 import { ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 
 class UngdomsprogramPanelDef extends ProsessStegPanelDef {
   overstyringDef = new ProsessStegOverstyringPanelDef(this);
@@ -9,11 +8,7 @@ class UngdomsprogramPanelDef extends ProsessStegPanelDef {
 
   getTekstKode = () => 'Ungdomsprogram';
 
-  getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
-  };
+  getKomponent = props => this.overstyringDef.getKomponent(props);
 
   getAksjonspunktKoder = () => [];
 

--- a/packages/behandling-unntak/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/MedlemskapPanelDef.tsx
+++ b/packages/behandling-unntak/src/panelDefinisjoner/prosessStegPaneler/inngangsvilkarPaneler/MedlemskapPanelDef.tsx
@@ -2,7 +2,6 @@ import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import vilkarType from '@fpsak-frontend/kodeverk/src/vilkarType';
 import { ProsessStegOverstyringPanelDef, ProsessStegPanelDef } from '@k9-sak-web/behandling-felles';
 
-import { konverterKodeverkTilKode } from '@k9-sak-web/lib/kodeverk/konverterKodeverkTilKode.js';
 import { UnntakBehandlingApiKeys } from '../../../data/unntakBehandlingApi';
 
 class MedlemskapPanelDef extends ProsessStegPanelDef {
@@ -12,11 +11,7 @@ class MedlemskapPanelDef extends ProsessStegPanelDef {
 
   getTekstKode = () => 'Medlemskap';
 
-  getKomponent = props => {
-    const deepCopyProps = JSON.parse(JSON.stringify(props));
-    konverterKodeverkTilKode(deepCopyProps, false);
-    return this.overstyringDef.getKomponent({ ...props, ...deepCopyProps });
-  };
+  getKomponent = props => this.overstyringDef.getKomponent(props);
 
   getAksjonspunktKoder = () => [aksjonspunktCodes.OVERSTYR_MEDLEMSKAPSVILKAR];
 


### PR DESCRIPTION
### **Behov / Bakgrunn**
https://jira.adeo.no/browse/FAGSYSTEM-396943
I noen tilfeller fikk ikke overstyringspanelet props som er konvertert med kodeverkendringer

### **Løsning**
Fikser det ett sted for alle.

### **Andre endringer**


### **Skjermbilder** (hvis relevant)
