### PR TITLE
TSFF-1975: viser innvilget resultat i vedtak i revurderinger

### DIFF
--- a/packages/prosess-vedtak/src/components/revurdering/VedtakInnvilgetRevurderingPanel.tsx
+++ b/packages/prosess-vedtak/src/components/revurdering/VedtakInnvilgetRevurderingPanel.tsx
@@ -68,39 +68,33 @@ interface VedtakInnvilgetRevurderingPanelProps {
 
 export const VedtakInnvilgetRevurderingPanelImpl = ({
   intl,
-  ytelseTypeKode,
   konsekvenserForYtelsen,
   tilbakekrevingText,
   bgPeriodeMedAvslagsårsak,
 }: VedtakInnvilgetRevurderingPanelProps & WrappedComponentProps) => {
   const { kodeverkNavnFraKode } = useKodeverkContext();
-
   return (
     // eslint-disable-next-line react/jsx-no-useless-fragment
     <>
-      {(ytelseTypeKode === fagsakYtelsesType.OMSORGSPENGER ||
-        ytelseTypeKode === fagsakYtelsesType.FRISINN ||
-        ytelseTypeKode === fagsakYtelsesType.PLEIEPENGER_SYKT_BARN) && (
-        <div data-testid="innvilgetRevurdering">
-          <Label size="small" as="p">
-            {intl.formatMessage({ id: 'VedtakForm.Resultat' })}
-          </Label>
-          <BodyShort size="small">
-            {lagKonsekvensForYtelsenTekst(konsekvenserForYtelsen, kodeverkNavnFraKode)}
-            {lagKonsekvensForYtelsenTekst(konsekvenserForYtelsen, kodeverkNavnFraKode) !== '' &&
-              tilbakekrevingText &&
-              '. '}
-            {tilbakekrevingText &&
-              intl.formatMessage({
-                id: tilbakekrevingText,
-              })}
-            {bgPeriodeMedAvslagsårsak && (
-              <BodyShort size="small">{lagPeriodevisning(bgPeriodeMedAvslagsårsak)}</BodyShort>
-            )}
-          </BodyShort>
-          <VerticalSpacer sixteenPx />
-        </div>
-      )}
+      <div data-testid="innvilgetRevurdering">
+        <Label size="small" as="p">
+          {intl.formatMessage({ id: 'VedtakForm.Resultat' })}
+        </Label>
+        <BodyShort size="small">
+          {lagKonsekvensForYtelsenTekst(konsekvenserForYtelsen, kodeverkNavnFraKode)}
+          {lagKonsekvensForYtelsenTekst(konsekvenserForYtelsen, kodeverkNavnFraKode) !== '' &&
+            tilbakekrevingText &&
+            '. '}
+          {tilbakekrevingText &&
+            intl.formatMessage({
+              id: tilbakekrevingText,
+            })}
+          {bgPeriodeMedAvslagsårsak && (
+            <BodyShort size="small">{lagPeriodevisning(bgPeriodeMedAvslagsårsak)}</BodyShort>
+          )}
+        </BodyShort>
+        <VerticalSpacer sixteenPx />
+      </div>
     </>
   );
 };

--- a/packages/prosess-vedtak/src/components/revurdering/VedtakInnvilgetRevurderingPanel.tsx
+++ b/packages/prosess-vedtak/src/components/revurdering/VedtakInnvilgetRevurderingPanel.tsx
@@ -1,6 +1,5 @@
 import avslagsarsakCodes from '@fpsak-frontend/kodeverk/src/avslagsarsakCodes';
 import { VerticalSpacer } from '@fpsak-frontend/shared-components';
-import { fagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
 import { useKodeverkContext } from '@k9-sak-web/gui/kodeverk/index.js';
 import { DDMMYYYY_DATE_FORMAT } from '@k9-sak-web/lib/dateUtils/formats.js';
 import { KodeverkNavnFraKodeType } from '@k9-sak-web/lib/kodeverk/types.js';


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi må vise at opplæringspenger er innvilget i revurdering

### **Løsning**
Vi viser at opplæringspenger er innvilget i revurdering

### **Andre endringer**
Fjerner sjekk på ytelse. Dette vil vi vel alltid vise?
<img width="329" height="126" alt="image" src="https://github.com/user-attachments/assets/eab49cc4-d53c-4a1b-b6f8-c1e0701b8415" />
