### PR TITLE
Retter lenke i header for ung

### DIFF
--- a/packages/v2/gui/src/sak/dekoratør/HeaderWithErrorPanel.tsx
+++ b/packages/v2/gui/src/sak/dekoratør/HeaderWithErrorPanel.tsx
@@ -4,6 +4,7 @@ import { Dropdown, InternalHeader, Spacer } from '@navikt/ds-react';
 import Endringslogg from '@navikt/familie-endringslogg';
 import { useEffect, useRef } from 'react';
 import { useLocation } from 'react-router';
+import { isUngWeb } from '../../utils/urlUtils';
 import ErrorMessagePanel from './ErrorMessagePanel';
 import type { Feilmelding } from './feilmeldingTsType';
 import styles from './headerWithErrorPanel.module.css';
@@ -66,13 +67,13 @@ const HeaderWithErrorPanel = ({
   }, [errorMessages.length]);
 
   const skalViseEndringslogg = !location.pathname.includes('/close') && !!navBrukernavn && showEndringslogg;
-
+  const skalBrukeLos = !isUngWeb();
   return (
     <div>
       <InternalHeader className={isInDevelopmentModeOrTestEnvironment() ? styles.containerDev : ''}>
         <InternalHeader.Title
           className={isInDevelopmentModeOrTestEnvironment() ? styles.containerDev : ''}
-          href={getHeaderTitleHref(getPathToLos, headerTitleHref)}
+          href={skalBrukeLos ? getHeaderTitleHref(getPathToLos, headerTitleHref) : headerTitleHref}
         >
           {ytelse}
         </InternalHeader.Title>


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi lenker til LOS for Ung men Ung skal ikke brukes LOS.

### **Løsning**
Lenker ikke til LOS dersom man er i Ung

### **Andre endringer**


### **Skjermbilder** (hvis relevant)
