### PR TITLE
TSFF-2066 - venter til behandlingrettigheter er hentet før tabs vises

### DIFF
--- a/packages/ung/sak-app/behandlingsupport/BehandlingSupportIndex.spec.tsx
+++ b/packages/ung/sak-app/behandlingsupport/BehandlingSupportIndex.spec.tsx
@@ -58,6 +58,17 @@ describe('<BehandlingSupportIndex>', () => {
           behandlingId={1}
           behandlingVersjon={2}
           navAnsatt={navAnsatt}
+          behandlingRettigheter={{
+            behandlingKanBytteEnhet: false,
+            behandlingKanHenlegges: false,
+            behandlingKanGjenopptas: false,
+            behandlingKanOpnesForEndringer: false,
+            behandlingKanSettesPaVent: false,
+            behandlingKanSendeMelding: false,
+            behandlingFraBeslutter: false,
+            behandlingTilGodkjenning: false,
+            vergeBehandlingsmeny: VergeBehandlingmenyValg.SKJUL,
+          }}
         />
       </MemoryRouter>,
     );

--- a/packages/ung/sak-app/behandlingsupport/BehandlingSupportIndex.tsx
+++ b/packages/ung/sak-app/behandlingsupport/BehandlingSupportIndex.tsx
@@ -2,6 +2,7 @@ import { kjønn } from '@k9-sak-web/backend/k9sak/kodeverk/Kjønn.js';
 import { FormidlingClientContext } from '@k9-sak-web/gui/app/FormidlingClientContext.js';
 import MeldingerBackendClient from '@k9-sak-web/gui/sak/meldinger/MeldingerBackendClient.js';
 import NotatBackendClient from '@k9-sak-web/gui/sak/notat/NotatBackendClient.js';
+import { LoadingPanel } from '@k9-sak-web/gui/shared/loading-panel/LoadingPanel.js';
 import { erTilbakekreving } from '@k9-sak-web/gui/utils/behandlingUtils.js';
 import BehandlingRettigheter from '@k9-sak-web/sak-app/src/behandling/behandlingRettigheterTsType';
 import {
@@ -237,6 +238,10 @@ const BehandlingSupportIndex = ({
     valgtSupportPanel
       ? !valgbareSupportPaneler.includes(valgtSupportPanel) && valgtSupportPanel !== SupportTabs.MELDINGER
       : false;
+
+  if (!behandlingRettigheter) {
+    return <LoadingPanel />;
+  }
 
   return (
     <Tabs defaultValue={aktivtSupportPanel} className={styles.tablistWrapper}>


### PR DESCRIPTION
### **Behov / Bakgrunn**
https://jira.adeo.no/browse/TSFF-2066
Beslutter havner ikke i beslutterpanelet automatisk.

### **Løsning**
Venter til rettigheter er hentet før hjelpepaneler vises. Fører til riktig navigasjon.

### **Andre endringer**


### **Skjermbilder** (hvis relevant)
