### PR TITLE
TSFF-2112: Legg til støtte for å fortsette uten endring i beredskap og nattevåk

### DIFF
--- a/packages/fakta-etablert-tilsyn/src/ui/components/beredskap/beredskapsperiodeoversikt-messages/BeredskapsperiodeoversiktMessages.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/beredskap/beredskapsperiodeoversikt-messages/BeredskapsperiodeoversiktMessages.tsx
@@ -1,12 +1,20 @@
-import { Alert, Box } from '@navikt/ds-react';
+import { Alert, Box, Button } from '@navikt/ds-react';
 import BeredskapType from '../../../../types/BeredskapType';
 import { getStringMedPerioder } from '../../../../util/periodUtils';
+import React from 'react';
+import ContainerContext from '../../../context/ContainerContext';
 
 interface BeredskapsperiodeoversiktMessagesProps {
   beredskapData: BeredskapType;
+  fortsettUtenEndring: () => void;
 }
 
-const BeredskapsperiodeoversiktMessages = ({ beredskapData }: BeredskapsperiodeoversiktMessagesProps) => {
+const BeredskapsperiodeoversiktMessages = ({
+  beredskapData,
+  fortsettUtenEndring,
+}: BeredskapsperiodeoversiktMessagesProps) => {
+  const { readOnly, harAksjonspunktForBeredskap } = React.useContext(ContainerContext);
+
   if (!beredskapData.harPerioder()) {
     return <p>Søker har ikke oppgitt at det er behov for beredskap.</p>;
   }
@@ -16,6 +24,24 @@ const BeredskapsperiodeoversiktMessages = ({ beredskapData }: Beredskapsperiodeo
       <Box.New marginBlock="0 6">
         <Alert size="small" variant="warning">
           {`Vurder behov for beredskap i ${getStringMedPerioder(perioderTilVurdering)}.`}
+        </Alert>
+      </Box.New>
+    );
+  } else if (!readOnly && harAksjonspunktForBeredskap) {
+    return (
+      <Box.New marginBlock="0 6">
+        <Alert size="small" data-testid="nattevåk-ferdig" variant="info">
+          <div style={{ display: 'flex' }}>
+            <>Behov for beredskap er ferdig vurdert og du kan gå videre i vurderingen.</>
+            <Button
+              style={{ marginLeft: '2rem' }}
+              onClick={fortsettUtenEndring}
+              size="small"
+              id="gåVidereFraNattevåkKnapp"
+            >
+              Fortsett
+            </Button>
+          </div>
         </Alert>
       </Box.New>
     );

--- a/packages/fakta-etablert-tilsyn/src/ui/components/beredskap/beredskapsperioderoversikt/Beredskapsperiodeoversikt.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/beredskap/beredskapsperioderoversikt/Beredskapsperiodeoversikt.tsx
@@ -7,6 +7,7 @@ import Vurderingsperiode from '../../../../types/Vurderingsperiode';
 import Periodenavigasjon from '../../periodenavigasjon/Periodenavigasjon';
 import BeredskapsperiodeoversiktController from '../beredskapsperiodeoversikt-controller/BeredskapsperiodeoversiktController';
 import BeredskapsperiodeoversiktMessages from '../beredskapsperiodeoversikt-messages/BeredskapsperiodeoversiktMessages';
+import ContainerContext from '../../../context/ContainerContext';
 
 interface BeredskapsperiodeoversiktProps {
   beredskapData: BeredskapType;
@@ -16,6 +17,7 @@ const Beredskapsperiodeoversikt = ({ beredskapData }: BeredskapsperiodeoversiktP
   const [valgtPeriode, setValgtPeriode] = React.useState<Vurderingsperiode>(null);
   const [editMode, setEditMode] = React.useState(false);
   const { beskrivelser } = beredskapData;
+  const { lagreBeredskapvurdering } = React.useContext(ContainerContext);
 
   const perioderTilVurdering = beredskapData.finnPerioderTilVurdering();
   const vurderteBeredskapsperioder = beredskapData.finnVurdertePerioder();
@@ -33,7 +35,10 @@ const Beredskapsperiodeoversikt = ({ beredskapData }: BeredskapsperiodeoversiktP
 
   return (
     <>
-      <BeredskapsperiodeoversiktMessages beredskapData={beredskapData} />
+      <BeredskapsperiodeoversiktMessages
+        beredskapData={beredskapData}
+        fortsettUtenEndring={() => lagreBeredskapvurdering(beredskapData.vurderinger)}
+      />
       <NavigationWithDetailView
         navigationSection={() => (
           <Periodenavigasjon

--- a/packages/fakta-etablert-tilsyn/src/ui/components/nattevåk/nattevåksperiodeoversikt-messages/NattevåksperiodeoversiktMessages.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/nattevåk/nattevåksperiodeoversikt-messages/NattevåksperiodeoversiktMessages.tsx
@@ -1,12 +1,20 @@
-import { Alert, Box } from '@navikt/ds-react';
+import { Alert, Box, Button } from '@navikt/ds-react';
 import NattevåkType from '../../../../types/NattevåkType';
 import { getStringMedPerioder } from '../../../../util/periodUtils';
+import React from 'react';
+import ContainerContext from '../../../context/ContainerContext';
 
 interface NattevåksperiodeoversiktMessagesProps {
   nattevåkData: NattevåkType;
+  fortsettUtenEndring: () => void;
 }
 
-const NattevåksperiodeoversiktMessages = ({ nattevåkData }: NattevåksperiodeoversiktMessagesProps) => {
+const NattevåksperiodeoversiktMessages = ({
+  nattevåkData,
+  fortsettUtenEndring,
+}: NattevåksperiodeoversiktMessagesProps) => {
+  const { readOnly, harAksjonspunktForNattevåk } = React.useContext(ContainerContext);
+
   if (!nattevåkData.harPerioder()) {
     return <p>Søker har ikke oppgitt at det er behov for nattevåk.</p>;
   }
@@ -16,6 +24,24 @@ const NattevåksperiodeoversiktMessages = ({ nattevåkData }: Nattevåksperiodeo
       <Box.New marginBlock="0 6">
         <Alert size="small" variant="warning">
           {`Vurder behov for nattevåk i ${getStringMedPerioder(perioderTilVurdering)}.`}
+        </Alert>
+      </Box.New>
+    );
+  } else if (!readOnly && harAksjonspunktForNattevåk) {
+    return (
+      <Box.New marginBlock="0 6">
+        <Alert size="small" data-testid="nattevåk-ferdig" variant="info">
+          <div style={{ display: 'flex' }}>
+            <>Behov for nattevåk er ferdig vurdert og du kan gå videre i vurderingen.</>
+            <Button
+              style={{ marginLeft: '2rem' }}
+              onClick={fortsettUtenEndring}
+              size="small"
+              id="gåVidereFraNattevåkKnapp"
+            >
+              Fortsett
+            </Button>
+          </div>
         </Alert>
       </Box.New>
     );

--- a/packages/fakta-etablert-tilsyn/src/ui/components/nattevåk/nattevåksperiodeoversikt/Nattevåksperiodeoversikt.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/nattevåk/nattevåksperiodeoversikt/Nattevåksperiodeoversikt.tsx
@@ -6,6 +6,7 @@ import Vurderingsperiode from '../../../../types/Vurderingsperiode';
 import Periodenavigasjon from '../../periodenavigasjon/Periodenavigasjon';
 import NattevåksperiodeoversiktController from '../nattevåksperiodeoversikt-controller/NattevåksperiodeoversiktController';
 import NattevåksperiodeoversiktMessages from '../nattevåksperiodeoversikt-messages/NattevåksperiodeoversiktMessages';
+import ContainerContext from '../../../context/ContainerContext';
 
 interface NattevåksperiodeoversiktProps {
   nattevåkData: NattevåkType;
@@ -15,6 +16,7 @@ const Nattevåksperiodeoversikt = ({ nattevåkData }: NattevåksperiodeoversiktP
   const [valgtPeriode, setValgtPeriode] = React.useState<Vurderingsperiode>(null);
   const [editMode, setEditMode] = React.useState(false);
   const { beskrivelser } = nattevåkData;
+  const { lagreNattevåkvurdering } = React.useContext(ContainerContext);
 
   const perioderTilVurdering = nattevåkData.finnPerioderTilVurdering();
   const vurderteNattevåksperioder = nattevåkData.finnVurdertePerioder();
@@ -32,7 +34,10 @@ const Nattevåksperiodeoversikt = ({ nattevåkData }: NattevåksperiodeoversiktP
 
   return (
     <>
-      <NattevåksperiodeoversiktMessages nattevåkData={nattevåkData} />
+      <NattevåksperiodeoversiktMessages
+        nattevåkData={nattevåkData}
+        fortsettUtenEndring={() => lagreNattevåkvurdering(nattevåkData.vurderinger)}
+      />
       <NavigationWithDetailView
         navigationSection={() => (
           <Periodenavigasjon


### PR DESCRIPTION
### **Behov / Bakgrunn**

I en revurdering har vi har per nå mulighet til å klikke fortsett uten endringer, mens i beredskap og nattevåk må man inn i en periode og klikke "lagre" for å få forbi steget

### **Løsning**

Legg til støtte for å bare fortsette med samme resultat som før, dersom alle perioder allerede er vurdert