### PR TITLE
Demo av meir spesifikk feilhandtering ved useMutation.

### DIFF
--- a/packages/v2/gui/src/fakta/inntektsmelding/api/inntektsmeldingQueries.ts
+++ b/packages/v2/gui/src/fakta/inntektsmelding/api/inntektsmeldingQueries.ts
@@ -22,7 +22,7 @@ export const useEtterspørInntektsmelding = () => {
 
   return useMutation<void, Error, EtterspørInntektsmeldingRequest>({
     mutationFn: requestBody => api.etterspørInntektsmelding(requestBody),
-    throwOnError: true,
+    throwOnError: false,
   });
 };
 

--- a/packages/v2/gui/src/fakta/inntektsmelding/ui/components/NyInntektsmeldingDialog/SendForespørsel.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/ui/components/NyInntektsmeldingDialog/SendForespørsel.tsx
@@ -1,5 +1,5 @@
 import type { ArbeidsgiverArbeidsforholdId } from '@k9-sak-web/backend/k9sak/kontrakt/kompletthet/ArbeidsgiverArbeidsforholdId.js';
-import { BodyShort, Button, Dialog, HStack, Label, VStack } from '@navikt/ds-react';
+import { BodyShort, Button, Dialog, HStack, Label, LocalAlert, VStack } from '@navikt/ds-react';
 import { RhfForm, RhfTextarea } from '@navikt/ft-form-hooks';
 import { minLength, required } from '@navikt/ft-form-validators';
 import { useForm } from 'react-hook-form';
@@ -48,6 +48,17 @@ export const SendForespørselContent = ({ førsteFraværsdag, arbeidsgiver }: Se
     <RhfForm formMethods={formMethods} onSubmit={handleSubmit}>
       <Dialog.Body>
         <VStack gap="space-24">
+          {etterspørInntektsmeldingMutation.isError ? (
+            <LocalAlert status="error">
+              <LocalAlert.Header>
+                <LocalAlert.Title>Feil ved sending av forespørsel</LocalAlert.Title>
+              </LocalAlert.Header>
+              <LocalAlert.Content>
+                <p>{etterspørInntektsmeldingMutation.error?.message}</p>
+                <p>Du kan forsøke på nytt. Hvis feil vedvarer forsøk å laste siden på nytt og prøv igjen.</p>
+              </LocalAlert.Content>
+            </LocalAlert>
+          ) : null}
           <div>
             <Label size="small" as="div" className="mb-1">
               For første fraværsdag


### PR DESCRIPTION
### **Behov / Bakgrunn**

Meir brukervennlig feilhandtering når mutation request feiler. (Istadenfor at feil propagerer til ErrorBoundary og bruker mister input state)

### **Løsning**

Setter throwOnError false i useMutation, sjekker error state i komponent, og viser feilmelding integrert i input skjema når forespørsel feiler.

Dette er eit initielt eksempel. Så kan vi etterkvart lage meir gjenbrukbar hjelpekomponenter/funksjonalitet for å kunne bruke denne strategien fleire stader i koden. 

Med denne løysing kan for eksempel feilmelding vidareutviklast til å gje brukar mulighet til å utføre relasting av data (tanstack invalidatequery, etc) for å fikse problem uten full relasting av sida, viss vi trur det kan hjelpe på aktuell feil. 

### **Skjermbilder** (hvis relevant)
<img width="703" height="553" alt="Skjermbilde 2026-02-27 kl  12 12 35" src="https://github.com/user-attachments/assets/8481fb24-3300-4999-9c44-d1d6be731bf7" />
<img width="694" height="738" alt="Skjermbilde 2026-02-27 kl  12 12 44" src="https://github.com/user-attachments/assets/179b830b-167e-40bf-8d8a-357fce470137" />
