### PR TITLE
FAGSYSTEM-421232: Nytt skjæringstidspunkt skal markeres med skravert linje i uttak

### DIFF
--- a/packages/v2/backend/src/k9sak/kontrakt/Periode.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/Periode.ts
@@ -1,0 +1,3 @@
+import type { k9_sak_typer_Periode } from '@k9-sak-web/backend/k9sak/generated/types.js';
+
+export type Periode = k9_sak_typer_Periode;

--- a/packages/v2/backend/src/k9sak/kontrakt/Uttaksplan.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/Uttaksplan.ts
@@ -1,0 +1,3 @@
+import type { pleiepengerbarn_uttak_kontrakter_Uttaksplan } from '@k9-sak-web/backend/k9sak/generated/types.js';
+
+export type Uttaksplan = pleiepengerbarn_uttak_kontrakter_Uttaksplan;

--- a/packages/v2/gui/src/prosess/uttak/Uttak.stories.tsx
+++ b/packages/v2/gui/src/prosess/uttak/Uttak.stories.tsx
@@ -378,7 +378,7 @@ export const UttakLesemodus: Story = {
 /**
  * UttakMedOpphold
  *
- * et opphold mellom uke 10 og uke 11 (mandag 09.03 er en ukedag i gapet).
+ * Et opphold mellom uke 10 og uke 11 (mandag 09.03 er en ukedag i gapet).
  */
 export const UttakMedOpphold: Story = {
   decorators: [withFakeUttakBackend()],

--- a/packages/v2/gui/src/prosess/uttak/Uttak.stories.tsx
+++ b/packages/v2/gui/src/prosess/uttak/Uttak.stories.tsx
@@ -2,6 +2,7 @@ import { BehandlingProvider } from '@k9-sak-web/gui/context/BehandlingContext.js
 import { withFakeUttakBackend } from '@k9-sak-web/gui/storybook/decorators/withFakeUttakBackend.js';
 import {
   arbeidsgivereWithTilkommet,
+  Endringsstatus,
   inntektsgraderingFlereArbeidsgivere,
   lagAvsluttetBehandling,
   lagIkkeOppfyltPeriode,
@@ -371,5 +372,89 @@ export const UttakLesemodus: Story = {
         canvas.getByRole('row', { name: '1 - 3 01.01.2024 - 15.01.2024 100% Søker 100 % Ny denne behandlingen' }),
       );
     });
+  },
+};
+
+/**
+ * UttakMedOpphold
+ *
+ * et opphold mellom uke 10 og uke 11 (mandag 09.03 er en ukedag i gapet).
+ */
+export const UttakMedOpphold: Story = {
+  decorators: [withFakeUttakBackend()],
+  args: {
+    behandling: lagUtredBehandling(),
+    uttak: lagUttak([
+      lagIkkeOppfyltPeriode('2026-02-24/2026-02-24', [Årsak.FOR_LAV_TAPT_ARBEIDSTID], {
+        uttaksgrad: 0,
+        endringsstatus: Endringsstatus.ENDRET,
+        utbetalingsgrader: [
+          {
+            arbeidsforhold: { type: 'ARBEIDSTAKER', organisasjonsnummer: '123456789' },
+            normalArbeidstid: 'PT7H30M',
+            faktiskArbeidstid: 'PT7H30M',
+            utbetalingsgrad: 0,
+            tilkommet: false,
+          },
+        ],
+      }),
+      lagOppfyltPeriode('2026-02-25/2026-02-25', {
+        uttaksgrad: 27,
+        søkersTapteArbeidstid: 27,
+        årsaker: [Årsak.AVKORTET_MOT_INNTEKT],
+        endringsstatus: Endringsstatus.ENDRET,
+        utbetalingsgrader: [
+          {
+            arbeidsforhold: { type: 'ARBEIDSTAKER', organisasjonsnummer: '123456789' },
+            normalArbeidstid: 'PT7H30M',
+            faktiskArbeidstid: 'PT5H28M',
+            utbetalingsgrad: 27,
+            tilkommet: false,
+          },
+        ],
+      }),
+      lagOppfyltPeriode('2026-02-26/2026-02-27', {
+        uttaksgrad: 20,
+        søkersTapteArbeidstid: 20,
+        årsaker: [Årsak.AVKORTET_MOT_INNTEKT],
+        endringsstatus: Endringsstatus.UENDRET,
+        utbetalingsgrader: [
+          {
+            arbeidsforhold: { type: 'ARBEIDSTAKER', organisasjonsnummer: '123456789' },
+            normalArbeidstid: 'PT7H30M',
+            faktiskArbeidstid: 'PT6H',
+            utbetalingsgrad: 20,
+            tilkommet: false,
+          },
+        ],
+      }),
+      lagOppfyltPeriode('2026-03-02/2026-03-06', {
+        uttaksgrad: 20,
+        søkersTapteArbeidstid: 20,
+        årsaker: [Årsak.AVKORTET_MOT_INNTEKT],
+        endringsstatus: Endringsstatus.NY,
+        utbetalingsgrader: [
+          {
+            arbeidsforhold: { type: 'ARBEIDSTAKER', organisasjonsnummer: '123456789' },
+            normalArbeidstid: 'PT7H30M',
+            faktiskArbeidstid: 'PT6H',
+            utbetalingsgrad: 20,
+            tilkommet: false,
+          },
+        ],
+      }),
+      // Gap mellom 06.03 og 10.03: 07.03 lørdag, 08.03 søndag, 09.03 mandag (ukedag) → opphold
+      lagOppfyltPeriode('2026-03-10/2026-03-10', {
+        uttaksgrad: 100,
+        søkersTapteArbeidstid: 100,
+        årsaker: [Årsak.FULL_DEKNING],
+        endringsstatus: Endringsstatus.NY,
+      }),
+    ]),
+    erOverstyrer: false,
+    aksjonspunkter: [],
+    hentBehandling: fn(),
+    relevanteAksjonspunkter: relevanteAksjonspunkterAlle,
+    readOnly: true,
   },
 };

--- a/packages/v2/gui/src/prosess/uttak/utils/uttaksperioder.test.ts
+++ b/packages/v2/gui/src/prosess/uttak/utils/uttaksperioder.test.ts
@@ -62,6 +62,26 @@ describe('lagUttaksperiodeliste', () => {
     await expect(earlier?.harOppholdTilNestePeriode).toBe(false);
   });
 
+  it('setter ikke opphold når perioder skilles kun av helg (fredag til mandag)', async () => {
+    const perioder = {
+      [key('2024-01-01', '2024-01-05')]: {}, // mandag–fredag
+      [key('2024-01-08', '2024-01-12')]: {}, // neste mandag–fredag
+    } as any;
+    const liste = lagUttaksperiodeliste(perioder);
+    const earlier = liste.find(p => p.periode.fom === '2024-01-01');
+    await expect(earlier?.harOppholdTilNestePeriode).toBe(false);
+  });
+
+  it('markerer opphold når det er minst én ukedag i gapet', async () => {
+    const perioder = {
+      [key('2024-01-01', '2024-01-04')]: {}, // mandag–torsdag
+      [key('2024-01-08', '2024-01-12')]: {}, // neste mandag
+    } as any;
+    const liste = lagUttaksperiodeliste(perioder);
+    const earlier = liste.find(p => p.periode.fom === '2024-01-01');
+    await expect(earlier?.harOppholdTilNestePeriode).toBe(true);
+  });
+
   it('ignorerer ugyldig nøkkel-format', async () => {
     const perioder = {
       ugyldigNøkkel: { some: 'x' },

--- a/packages/v2/gui/src/prosess/uttak/utils/uttaksperioder.ts
+++ b/packages/v2/gui/src/prosess/uttak/utils/uttaksperioder.ts
@@ -1,21 +1,21 @@
 import { initializeDate } from '@k9-sak-web/lib/dateUtils/initializeDate.js';
 import { YYYYMMDD_DATE_FORMAT } from '@k9-sak-web/lib/dateUtils/formats.js';
 import { sortPeriodsByNewest, sortPeriodsChronological } from './periodUtils';
-import type {
-  k9_sak_typer_Periode as Periode,
-  pleiepengerbarn_uttak_kontrakter_Uttaksplan as Uttaksplan,
-} from '@k9-sak-web/backend/k9sak/generated/types.js';
+import type { Periode } from '@k9-sak-web/backend/k9sak/kontrakt/Periode.js';
+import type { Uttaksplan } from '@k9-sak-web/backend/k9sak/kontrakt/Uttaksplan.js';
 import type { UttaksperiodeBeriket } from '../types/UttaksperiodeBeriket';
+import type { Dayjs } from 'dayjs';
 
-const sjekkOmPerioderErKantIKant = (periode: Periode, nestePeriode: Periode) => {
-  const sisteUkeIFørstePeriode = initializeDate(periode.tom).week();
-  const førsteUkeINestePeriode = initializeDate(nestePeriode.fom).week();
-  return (
-    sisteUkeIFørstePeriode === førsteUkeINestePeriode ||
-    førsteUkeINestePeriode === sisteUkeIFørstePeriode + 1 ||
-    (sisteUkeIFørstePeriode >= 52 && førsteUkeINestePeriode === 1)
-  );
+const oppholdHarUkedager = (tom: Dayjs, fom: Dayjs) => {
+  for (let dag = tom.add(1, 'day'); dag.isBefore(fom); dag = dag.add(1, 'day')) {
+    // hvis dag er en ukedag (mandag-fredag), returner true
+    if ([1, 2, 3, 4, 5].includes(dag.day())) return true;
+  }
+  return false;
 };
+
+const sjekkOmPerioderErKantIKant = (periode: Periode, nestePeriode: Periode) =>
+  !oppholdHarUkedager(initializeDate(periode.tom), initializeDate(nestePeriode.fom));
 
 const lagUttaksperiodeliste = (uttaksperioder: Uttaksplan['perioder']): UttaksperiodeBeriket[] => {
   const perioder = Object.keys(uttaksperioder ?? {})


### PR DESCRIPTION
### **Behov / Bakgrunn**
Vi ønsker å markere opphold i ytelsen og nytt skjæringspunkt med skravert linje. Eksisterende implementasjon vil kun vise skravert linje med opphold på minst 1 uke mellom to perioder
