### PR TITLE
Starter ikke på grunn av forskjellige react-versjoner

### DIFF
--- a/ung.vite.config.js
+++ b/ung.vite.config.js
@@ -76,6 +76,9 @@ export default ({ mode }) => {
     },
     base: '/ung/web',
     publicDir: './public',
+    resolve: {
+      dedupe: ['react', 'react-dom'],
+    },
     plugins: [
       tailwindcss(),
       createHtmlPlugin({

--- a/vite.config.js
+++ b/vite.config.js
@@ -85,6 +85,9 @@ export default ({ mode }) => {
     },
     base: '/k9/web',
     publicDir: './public',
+    resolve: {
+      dedupe: ['react', 'react-dom'],
+    },
     plugins: [
       tailwindcss(),
       react({


### PR DESCRIPTION
### **Behov / Bakgrunn**
Får ikke startet k9-sak-web lokalt (på windows)

### **Løsning**
This adds resolve.dedupe for react and react-dom, which forces Vite to resolve both to a single instance even when packages like @navikt/ds-react try to bundle their own copies.
