### PR TITLE
Fix: Viser ikke tilkjent ytelse dersom uttak er avslått

### DIFF
--- a/packages/behandling-pleiepenger/src/prosess/api/Prosessmotor.spec.tsx
+++ b/packages/behandling-pleiepenger/src/prosess/api/Prosessmotor.spec.tsx
@@ -109,6 +109,59 @@ describe('Prosessmotor', () => {
       });
     });
 
+    test('tilkjentYtelse og simulering er default når uttakPanel er danger (alle perioder avslått)', async () => {
+      const api = new FakeK9SakProsessApi({
+        uttak: {
+          uttaksplan: {
+            perioder: {
+              '2024-01-01/2024-01-31': { utfall: k9_kodeverk_vilkår_Utfall.IKKE_OPPFYLT },
+              '2024-02-01/2024-02-28': { utfall: k9_kodeverk_vilkår_Utfall.IKKE_OPPFYLT },
+            },
+          },
+          simulertUttaksplan: {},
+        },
+        beregningsresultatUtbetaling: {
+          perioder: [
+            {
+              andeler: [
+                {
+                  uttak: [
+                    { utfall: 'INNVILGET', periode: { fom: '2024-01-01', tom: '2024-01-31' }, utbetalingsgrad: 100 },
+                  ],
+                  inntektskategori: '-',
+                },
+              ],
+              dagsats: 500,
+              fom: '2024-01-01',
+              tom: '2024-01-31',
+            },
+          ],
+        },
+      });
+      const behandling = createMockBehandling();
+
+      const { result } = renderHook(() => useProsessmotor({ api, behandling }), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await waitFor(() => {
+        const uttakPanel = result.current[4];
+        const tilkjentYtelsePanel = result.current[5];
+        const simuleringPanel = result.current[6];
+
+        expect(uttakPanel.id).toBe('uttak');
+        expect(uttakPanel.type).toBe(ProcessMenuStepType.danger);
+
+        expect(tilkjentYtelsePanel.id).toBe('tilkjent_ytelse');
+        expect(tilkjentYtelsePanel.type).toBe(ProcessMenuStepType.default);
+        expect(tilkjentYtelsePanel).toHaveProperty('erVurdert', false);
+
+        expect(simuleringPanel.id).toBe('simulering');
+        expect(simuleringPanel.type).toBe(ProcessMenuStepType.default);
+        expect(simuleringPanel).toHaveProperty('erVurdert', false);
+      });
+    });
+
     test('setter panel til warning når det finnes åpent aksjonspunkt', async () => {
       const api = new FakeK9SakProsessApi({
         vilkår: [

--- a/packages/behandling-pleiepenger/src/prosess/api/Prosessmotor.ts
+++ b/packages/behandling-pleiepenger/src/prosess/api/Prosessmotor.ts
@@ -332,7 +332,7 @@ export const useProsessmotor = ({ api, behandling }: ProsessmotorProps) => {
     );
 
     const tilkjentYtelsePanel = byggPanelUtenVilkår(
-      uttakPanel.erVurdert,
+      uttakPanel.erVurdert && uttakPanel.type !== ProcessMenuStepType.danger,
       beregnTilkjentYtelseType(beregningsresultatUtbetaling, PANEL_KONFIG.tilkjentYtelse, aksjonspunkter),
       PANEL_KONFIG.tilkjentYtelse.label,
       PANEL_KONFIG.tilkjentYtelse.id,


### PR DESCRIPTION
### **Behov / Bakgrunn**
Viser tilkjent ytelse selv uttak har avslag.

### **Løsning**
Viser ikke tilkjent ytelse dersom uttak er avslått.
Gjelder Prosessmenyv2

### **Andre endringer**


### **Skjermbilder** (hvis relevant)
