### PR TITLE
Fix: Setter bare delvis vurdert dersom steget er success

### DIFF
--- a/packages/behandling-aktivitetspenger/src/components/Prossesmotor.ts
+++ b/packages/behandling-aktivitetspenger/src/components/Prossesmotor.ts
@@ -106,7 +106,7 @@ const byggVilkårPanel = (
     type,
     label: panelKonfig.label,
     id: panelKonfig.id,
-    usePartialStatus: sjekkDelvisVilkårStatus(relevanteVilkår),
+    usePartialStatus: type === ProcessMenuStepType.success ? sjekkDelvisVilkårStatus(relevanteVilkår) : false,
     erVurdert: erPanelVurdert(type),
     urlKode: panelKonfig.id,
   };

--- a/packages/behandling-pleiepenger/src/prosess/api/Prosessmotor.spec.tsx
+++ b/packages/behandling-pleiepenger/src/prosess/api/Prosessmotor.spec.tsx
@@ -190,6 +190,47 @@ describe('Prosessmotor', () => {
         expect(inngangsvilkårPanel.type).toBe(ProcessMenuStepType.warning);
       });
     });
+
+    test('setter aldri usePartialStatus=true når panel er warning, selv med delvis oppfylt vilkår', async () => {
+      const api = new FakeK9SakProsessApi({
+        vilkår: [
+          {
+            vilkarType: k9_kodeverk_vilkår_VilkårType.SØKNADSFRIST,
+            perioder: [
+              {
+                vilkarStatus: k9_kodeverk_vilkår_Utfall.OPPFYLT,
+                periode: { fom: '', tom: '' },
+                vurderesIBehandlingen: true,
+              },
+              {
+                vilkarStatus: k9_kodeverk_vilkår_Utfall.IKKE_OPPFYLT,
+                periode: { fom: '', tom: '' },
+                vurderesIBehandlingen: true,
+              },
+            ],
+            relevanteInnvilgetMerknader: [],
+          },
+        ],
+        aksjonspunkter: [
+          {
+            definisjon:
+              k9_kodeverk_behandling_aksjonspunkt_AksjonspunktDefinisjon.KONTROLLER_OPPLYSNINGER_OM_SØKNADSFRIST,
+            status: k9_kodeverk_behandling_aksjonspunkt_AksjonspunktStatus.OPPRETTET,
+          },
+        ],
+      });
+      const behandling = createMockBehandling();
+
+      const { result } = renderHook(() => useProsessmotor({ api, behandling }), {
+        wrapper: createWrapper(queryClient),
+      });
+
+      await waitFor(() => {
+        const inngangsvilkårPanel = result.current[0];
+        expect(inngangsvilkårPanel.type).toBe(ProcessMenuStepType.warning);
+        expect(inngangsvilkårPanel.usePartialStatus).toBe(false);
+      });
+    });
   });
 
   describe('beregnUttakType', () => {

--- a/packages/behandling-pleiepenger/src/prosess/api/Prosessmotor.ts
+++ b/packages/behandling-pleiepenger/src/prosess/api/Prosessmotor.ts
@@ -152,7 +152,7 @@ const byggVilkårPanel = (
     type,
     label: panelKonfig.label,
     id: panelKonfig.id,
-    usePartialStatus: sjekkDelvisVilkårStatus(relevanteVilkår),
+    usePartialStatus: type === ProcessMenuStepType.success ? sjekkDelvisVilkårStatus(relevanteVilkår) : false,
     erVurdert: erPanelVurdert(type),
   };
 };


### PR DESCRIPTION
### **Behov / Bakgrunn**
Steg blir satt til delvis for andre situasjoner enn at steget er succcess.

### **Løsning**
Trenger bare delvismarkering dersom steget er godkjent.

### **Andre endringer**


### **Skjermbilder** (hvis relevant)
