### PR TITLE
chore: bump axios version to 1.15.2 across all packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@navikt/ft-utils": "5.0.0",
     "@popperjs/core": "2.11.8",
     "@sentry/browser": "10.49.0",
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "date-fns": "4.1.0",
     "dayjs": "1.11.20",
     "history": "5.3.0",

--- a/packages/fakta-medisinsk-vilkår/package.json
+++ b/packages/fakta-medisinsk-vilkår/package.json
@@ -17,7 +17,7 @@
     "@navikt/ft-utils": "5.0.0",
     "@popperjs/core": "2.11.8",
     "@tanstack/react-query": "5.99.0",
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "classnames": "2.5.1",
     "dayjs": "1.11.20",
     "react": "19.2.5",

--- a/packages/rest-api/package.json
+++ b/packages/rest-api/package.json
@@ -6,6 +6,6 @@
   "private": true,
   "dependencies": {
     "@k9-sak-web/backend": "workspace:^",
-    "axios": "1.15.0"
+    "axios": "1.15.2"
   }
 }

--- a/packages/sak-app/package.json
+++ b/packages/sak-app/package.json
@@ -37,7 +37,7 @@
     "@sentry/browser": "10.49.0",
     "@sentry/react": "10.49.0",
     "@tanstack/react-query": "5.99.0",
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "classnames": "2.5.1",
     "dayjs": "1.11.20",
     "history": "5.3.0",

--- a/packages/ung/sak-app/package.json
+++ b/packages/ung/sak-app/package.json
@@ -24,7 +24,7 @@
     "@sentry/react": "10.49.0",
     "@tanstack/react-query": "5.99.0",
     "@types/react": "19.2.14",
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "classnames": "2.5.1",
     "dayjs": "1.11.20",
     "history": "5.3.0",

--- a/packages/v2/gui/package.json
+++ b/packages/v2/gui/package.json
@@ -40,7 +40,7 @@
     "@tanstack/react-query": "5.99.0",
     "@types/css-tree": "2.3.11",
     "@types/object-hash": "3.0.6",
-    "axios": "1.15.0",
+    "axios": "1.15.2",
     "css-tree": "3.2.1",
     "dayjs": "1.11.20",
     "editorjs-html": "3.4.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2659,7 +2659,7 @@ __metadata:
     "@popperjs/core": "npm:2.11.8"
     "@tanstack/react-query": "npm:5.99.0"
     "@types/react": "npm:19.2.14"
-    axios: "npm:1.15.0"
+    axios: "npm:1.15.2"
     classnames: "npm:2.5.1"
     dayjs: "npm:1.11.20"
     react: "npm:19.2.5"
@@ -2754,7 +2754,7 @@ __metadata:
     "@types/object-hash": "npm:3.0.6"
     "@types/react": "npm:19.2.14"
     "@types/react-dom": "npm:19.2.3"
-    axios: "npm:1.15.0"
+    axios: "npm:1.15.2"
     css-tree: "npm:3.2.1"
     dayjs: "npm:1.11.20"
     editorjs-html: "npm:3.4.3"
@@ -2954,7 +2954,7 @@ __metadata:
   resolution: "@k9-sak-web/rest-api@workspace:packages/rest-api"
   dependencies:
     "@k9-sak-web/backend": "workspace:^"
-    axios: "npm:1.15.0"
+    axios: "npm:1.15.2"
   languageName: unknown
   linkType: soft
 
@@ -2996,7 +2996,7 @@ __metadata:
     "@sentry/react": "npm:10.49.0"
     "@tanstack/react-query": "npm:5.99.0"
     "@types/react": "npm:19.2.14"
-    axios: "npm:1.15.0"
+    axios: "npm:1.15.2"
     classnames: "npm:2.5.1"
     dayjs: "npm:1.11.20"
     history: "npm:5.3.0"
@@ -3044,7 +3044,7 @@ __metadata:
     "@sentry/react": "npm:10.49.0"
     "@tanstack/react-query": "npm:5.99.0"
     "@types/react": "npm:19.2.14"
-    axios: "npm:1.15.0"
+    axios: "npm:1.15.2"
     classnames: "npm:2.5.1"
     dayjs: "npm:1.11.20"
     history: "npm:5.3.0"
@@ -6190,7 +6190,18 @@ __metadata:
   languageName: node
   linkType: hard
 
-"axios@npm:1.15.0, axios@npm:^1.6.1":
+"axios@npm:1.15.2":
+  version: 1.15.2
+  resolution: "axios@npm:1.15.2"
+  dependencies:
+    follow-redirects: "npm:^1.15.11"
+    form-data: "npm:^4.0.5"
+    proxy-from-env: "npm:^2.1.0"
+  checksum: 10/eebbd8cb777316d4252cd994a06ec9fb956ef519214a62dab6c5443ae8b753b5116e9a770502316789e6cdef1101e6aae53b6936d6a3791b2d66d75f4d7d2462
+  languageName: node
+  linkType: hard
+
+"axios@npm:^1.6.1":
   version: 1.15.0
   resolution: "axios@npm:1.15.0"
   dependencies:
@@ -10352,7 +10363,7 @@ __metadata:
     "@types/redux-form": "npm:8.3.11"
     "@vitejs/plugin-react": "npm:6.0.1"
     "@vitest/eslint-plugin": "npm:1.6.16"
-    axios: "npm:1.15.0"
+    axios: "npm:1.15.2"
     axios-mock-adapter: "npm:2.1.0"
     cross-env: "npm:10.1.0"
     date-fns: "npm:4.1.0"


### PR DESCRIPTION
This pull request updates the `axios` dependency from version 1.15.0 to 1.15.2 across multiple packages in the repository. This change ensures all packages are using the latest patch version of `axios`, which may include important bug fixes and security updates.

Dependency updates:

* Updated `axios` from version 1.15.0 to 1.15.2 in the root `package.json` and the following package files to ensure consistency and benefit from the latest fixes: `packages/fakta-medisinsk-vilkår/package.json`, `packages/rest-api/package.json`, `packages/sak-app/package.json`, `packages/ung/sak-app/package.json`, and `packages/v2/gui/package.json`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L63-R63) [[2]](diffhunk://#diff-cf9b8889c1aef093f039e519f2ccede71d9f574e09520025bf0a739c64ba6a59L20-R20) [[3]](diffhunk://#diff-dec1bd55a1f78ea3e7f21f4d132a000075fe26254a9ffba80f397645a31909f2L9-R9) [[4]](diffhunk://#diff-fc70d794123a964993beeabab7d53ea68cc3eba97f001b8566f2a4bf55432fcfL40-R40) [[5]](diffhunk://#diff-08c33f18311b6062dffdf3cea39b215d8ee6e79f29ebf4b6cb5f11361b48d358L27-R27) [[6]](diffhunk://#diff-f6c4ca7fec05d8e9b7b4d471e30947fce0e2e4e2517d019530e7f76951bb7896L43-R43)
