### PR TITLE
Bugfix: redigering i sykdom med utført aksjonspunkt fører til 409 i k9-sak og 500 mot formidling

### DIFF
--- a/packages/behandling-pleiepenger-sluttfase/src/components/MedisinskVilkår.tsx
+++ b/packages/behandling-pleiepenger-sluttfase/src/components/MedisinskVilkår.tsx
@@ -48,6 +48,7 @@ export default ({
         onFinished: løsAksjonspunkt,
         readOnly: readOnly || !harAksjonspunkt,
         visFortsettknapp,
+        medisinskVilkårAksjonspunkt,
         fagsakYtelseType,
         behandlingType,
       }}

--- a/packages/behandling-pleiepenger/src/components/MedisinskVilkår.tsx
+++ b/packages/behandling-pleiepenger/src/components/MedisinskVilkår.tsx
@@ -1,6 +1,6 @@
 import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
-import aksjonspunktStatus from '@fpsak-frontend/kodeverk/src/aksjonspunktStatus';
 import { findAksjonspunkt, findEndpointsFromRels, httpErrorHandler } from '@fpsak-frontend/utils';
+import { isAksjonspunktOpen } from '@k9-sak-web/gui/utils/aksjonspunktUtils.js';
 import { MedisinskVilkår } from '@k9-sak-web/fakta-medisinsk-vilkar';
 import { useRestApiErrorDispatcher } from '@k9-sak-web/rest-api-hooks';
 
@@ -20,8 +20,7 @@ export default ({
 
   const medisinskVilkårAksjonspunkt = findAksjonspunkt(aksjonspunkter, aksjonspunktCodes.MEDISINSK_VILKAAR);
   const medisinskVilkårAksjonspunktkode = medisinskVilkårAksjonspunkt?.definisjon.kode;
-  const medisinskVilkårAksjonspunktstatus = medisinskVilkårAksjonspunkt?.status.kode;
-  const visFortsettknapp = medisinskVilkårAksjonspunktstatus === aksjonspunktStatus.OPPRETTET;
+  const visFortsettknapp = isAksjonspunktOpen(medisinskVilkårAksjonspunkt?.status.kode);
 
   const løsAksjonspunkt = aksjonspunktArgs =>
     submitCallback([
@@ -49,6 +48,7 @@ export default ({
         onFinished: løsAksjonspunkt,
         readOnly: readOnly || !harAksjonspunkt,
         visFortsettknapp,
+        medisinskVilkårAksjonspunkt,
         fagsakYtelseType,
         behandlingType,
         pleietrengendePart,

--- a/packages/fakta-medisinsk-vilkår/src/types/ContainerContract.ts
+++ b/packages/fakta-medisinsk-vilkår/src/types/ContainerContract.ts
@@ -1,5 +1,6 @@
 import { FagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
 import { Personopplysninger } from '@k9-sak-web/types';
+import Aksjonspunkt from '@k9-sak-web/types/src/aksjonspunktTsType';
 import BehandlingType from '../constants/BehandlingType';
 import { FeatureToggles } from '@k9-sak-web/gui/featuretoggles/FeatureToggles.js';
 
@@ -21,6 +22,7 @@ interface ContainerContract {
   onFinished: (...args: unknown[]) => void;
   httpErrorHandler: (statusCode: number, locationHeader?: string) => void;
   visFortsettknapp: boolean;
+  medisinskVilkårAksjonspunkt?: Aksjonspunkt;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   fagsakYtelseType?: FagsakYtelsesType;
   behandlingType?: BehandlingType;

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/diagnosekodeoversikt/Diagnosekodeoversikt.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/diagnosekodeoversikt/Diagnosekodeoversikt.tsx
@@ -1,4 +1,5 @@
 import { httpUtils } from '@fpsak-frontend/utils';
+import useRefetchBehandlingVedSykdomsendring from '../../hooks/useRefetchBehandlingVedSykdomsendring';
 
 import { initDiagnosekodeSearcher } from '@k9-sak-web/gui/shared/diagnosekodeVelger/diagnosekodeSearcher.js';
 import WriteAccessBoundContent from '@k9-sak-web/gui/shared/write-access-bound-content/WriteAccessBoundContent.js';
@@ -34,6 +35,7 @@ interface DiagnosekodeoversiktProps {
 
 const Diagnosekodeoversikt = ({ onDiagnosekoderUpdated }: DiagnosekodeoversiktProps): JSX.Element => {
   const { endpoints, httpErrorHandler, readOnly } = React.useContext(ContainerContext);
+  const refetchBehandlingVedSykdomsendring = useRefetchBehandlingVedSykdomsendring();
   const [modalIsOpen, setModalIsOpen] = React.useState(false);
   const addButtonRef = React.useRef<HTMLButtonElement>(undefined);
 
@@ -96,9 +98,9 @@ const Diagnosekodeoversikt = ({ onDiagnosekoderUpdated }: DiagnosekodeoversiktPr
 
   const slettDiagnosekodeMutation = useMutation({
     mutationFn: (diagnosekode: string) => slettDiagnosekode(diagnosekode),
-
     onSuccess: async () => {
       await refetch().finally(() => {
+        refetchBehandlingVedSykdomsendring();
         onDiagnosekoderUpdated();
         focusAddButton();
       });
@@ -106,9 +108,9 @@ const Diagnosekodeoversikt = ({ onDiagnosekoderUpdated }: DiagnosekodeoversiktPr
   });
   const lagreDiagnosekodeMutation = useMutation({
     mutationFn: (nyeDiagnosekoder: string[]) => lagreDiagnosekode(nyeDiagnosekoder),
-
     onSuccess: async () => {
       await refetch().finally(() => {
+        refetchBehandlingVedSykdomsendring();
         onDiagnosekoderUpdated();
         setModalIsOpen(false);
         focusAddButton();

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/innleggelsesperiodeoversikt/Innleggelsesperiodeoversikt.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/innleggelsesperiodeoversikt/Innleggelsesperiodeoversikt.tsx
@@ -1,4 +1,5 @@
 import { httpUtils, Period } from '@fpsak-frontend/utils';
+import useRefetchBehandlingVedSykdomsendring from '../../hooks/useRefetchBehandlingVedSykdomsendring';
 import WriteAccessBoundContent from '@k9-sak-web/gui/shared/write-access-bound-content/WriteAccessBoundContent.js';
 import { Alert, Box, Button, Heading, HStack, Loader } from '@navikt/ds-react';
 import React, { useEffect, useMemo, type JSX } from 'react';
@@ -20,6 +21,7 @@ const Innleggelsesperiodeoversikt = ({
   onInnleggelsesperioderUpdated,
 }: InnleggelsesperiodeoversiktProps): JSX.Element => {
   const { endpoints, httpErrorHandler, pleietrengendePart, readOnly } = React.useContext(ContainerContext);
+  const refetchBehandlingVedSykdomsendring = useRefetchBehandlingVedSykdomsendring();
 
   const [modalIsOpen, setModalIsOpen] = React.useState(false);
   const [innleggelsesperioderResponse, setInnleggelsesperioderResponse] = React.useState<InnleggelsesperiodeResponse>({
@@ -76,6 +78,7 @@ const Innleggelsesperiodeoversikt = ({
       controller.signal,
     )
       .then(() => {
+        refetchBehandlingVedSykdomsendring();
         onInnleggelsesperioderUpdated();
         updateInnlegelsesperioder();
       })

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/medisinsk-vilkår/tests/MedisinskVilkår.spec.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/medisinsk-vilkår/tests/MedisinskVilkår.spec.tsx
@@ -3,6 +3,7 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { render, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { afterEach, beforeEach, describe, it, vi } from 'vitest';
+import { BehandlingProvider } from '@k9-sak-web/gui/context/BehandlingContext.js';
 import ContainerContract from '../../../../types/ContainerContract';
 import ContainerContext from '../../../context/ContainerContext';
 import queryClient from '../../../context/queryClient';
@@ -22,19 +23,21 @@ const vurderingsoversiktMock = {
 const httpErrorHandlerMock = () => null;
 const contextWrapper = (ui, contextValues?: Partial<ContainerContract>) =>
   render(
-    <QueryClientProvider client={queryClient}>
-      <ContainerContext.Provider
-        value={
-          {
-            httpErrorHandler: httpErrorHandlerMock,
-            endpoints: { status: statusEndpointMock },
-            ...contextValues,
-          } as any
-        }
-      >
-        {ui}
-      </ContainerContext.Provider>
-    </QueryClientProvider>,
+    <BehandlingProvider refetchBehandling={vi.fn()}>
+      <QueryClientProvider client={queryClient}>
+        <ContainerContext.Provider
+          value={
+            {
+              httpErrorHandler: httpErrorHandlerMock,
+              endpoints: { status: statusEndpointMock },
+              ...contextValues,
+            } as any
+          }
+        >
+          {ui}
+        </ContainerContext.Provider>
+      </QueryClientProvider>
+    </BehandlingProvider>,
   );
 
 const renderMedisinskVilkår = (contextValues?: Partial<ContainerContract>) =>

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/nye-dokumenter-som-kan-påvirke-eksisterende-vurderinger/NyeDokumenterSomKanPåvirkeEksisterendeVurderingerController.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/nye-dokumenter-som-kan-påvirke-eksisterende-vurderinger/NyeDokumenterSomKanPåvirkeEksisterendeVurderingerController.tsx
@@ -1,4 +1,5 @@
 import { httpUtils } from '@fpsak-frontend/utils';
+import useRefetchBehandlingVedSykdomsendring from '../../hooks/useRefetchBehandlingVedSykdomsendring';
 import { PageContainer } from '@k9-sak-web/gui/shared/pageContainer/PageContainer.js';
 import { Box } from '@navikt/ds-react';
 import React, { useMemo, type JSX } from 'react';
@@ -16,6 +17,7 @@ const NyeDokumenterSomKanPåvirkeEksisterendeVurderingerController = ({
   afterEndringerRegistrert,
 }: NyeDokumenterSomKanPåvirkeEksisterendeVurderingerControllerProps): JSX.Element => {
   const { endpoints, httpErrorHandler, behandlingUuid } = React.useContext(ContainerContext);
+  const refetchBehandlingVedSykdomsendring = useRefetchBehandlingVedSykdomsendring();
   const controller = useMemo(() => new AbortController(), []);
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const [httpErrorHasOccured, setHttpErrorHasOccured] = React.useState(false);
@@ -36,6 +38,7 @@ const NyeDokumenterSomKanPåvirkeEksisterendeVurderingerController = ({
     try {
       await bekreftAtEndringerErRegistrert();
       afterEndringerRegistrert();
+      refetchBehandlingVedSykdomsendring();
       setIsSubmitting(false);
     } catch {
       setHttpErrorHasOccured(true);

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/vilkarsvurdering-av-livets-sluttfase/VilkarsvurderingAvLivetsSluttfase.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/vilkarsvurdering-av-livets-sluttfase/VilkarsvurderingAvLivetsSluttfase.tsx
@@ -1,6 +1,5 @@
 import { get, Period } from '@fpsak-frontend/utils';
-import { useRefetchBehandling } from '@k9-sak-web/gui/context/BehandlingContext.js';
-import { isAksjonspunktOpen } from '@k9-sak-web/gui/utils/aksjonspunktUtils.js';
+import useRefetchBehandlingVedSykdomsendring from '../../hooks/useRefetchBehandlingVedSykdomsendring';
 import React, { useMemo, type JSX } from 'react';
 import Step, { livetsSluttfaseSteg, StepId } from '../../../types/Step';
 import SykdomsstegStatusResponse from '../../../types/SykdomsstegStatusResponse';
@@ -31,9 +30,8 @@ const VilkårsvurderingAvLivetsSluttfase = ({
   hentSykdomsstegStatus,
   sykdomsstegStatus,
 }: VilkårsvurderingAvLivetsSluttfaseProps): JSX.Element => {
-  const { endpoints, httpErrorHandler, fagsakYtelseType, behandlingType, medisinskVilkårAksjonspunkt } =
-    React.useContext(ContainerContext);
-  const refetchBehandling = useRefetchBehandling();
+  const { endpoints, httpErrorHandler, fagsakYtelseType, behandlingType } = React.useContext(ContainerContext);
+  const refetchBehandlingVedSykdomsendring = useRefetchBehandlingVedSykdomsendring();
   const controller = useMemo(() => new AbortController(), []);
 
   const [state, dispatch] = React.useReducer(vilkårsvurderingReducer, {
@@ -124,7 +122,7 @@ const VilkårsvurderingAvLivetsSluttfase = ({
     dispatch({ type: ActionType.PENDING });
     try {
       const status = await hentSykdomsstegStatus();
-      if (!isAksjonspunktOpen(medisinskVilkårAksjonspunkt?.status.kode)) void refetchBehandling();
+      refetchBehandlingVedSykdomsendring();
       const nesteSteg = finnNesteStegForLivetsSluttfase(status);
       if (nesteSteg === livetsSluttfaseSteg || nesteSteg === null) {
         await oppdaterVurderingsoversikt();

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/vilkarsvurdering-av-livets-sluttfase/VilkarsvurderingAvLivetsSluttfase.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/vilkarsvurdering-av-livets-sluttfase/VilkarsvurderingAvLivetsSluttfase.tsx
@@ -1,4 +1,6 @@
 import { get, Period } from '@fpsak-frontend/utils';
+import { useRefetchBehandling } from '@k9-sak-web/gui/context/BehandlingContext.js';
+import { isAksjonspunktOpen } from '@k9-sak-web/gui/utils/aksjonspunktUtils.js';
 import React, { useMemo, type JSX } from 'react';
 import Step, { livetsSluttfaseSteg, StepId } from '../../../types/Step';
 import SykdomsstegStatusResponse from '../../../types/SykdomsstegStatusResponse';
@@ -29,7 +31,9 @@ const VilkårsvurderingAvLivetsSluttfase = ({
   hentSykdomsstegStatus,
   sykdomsstegStatus,
 }: VilkårsvurderingAvLivetsSluttfaseProps): JSX.Element => {
-  const { endpoints, httpErrorHandler, fagsakYtelseType, behandlingType } = React.useContext(ContainerContext);
+  const { endpoints, httpErrorHandler, fagsakYtelseType, behandlingType, medisinskVilkårAksjonspunkt } =
+    React.useContext(ContainerContext);
+  const refetchBehandling = useRefetchBehandling();
   const controller = useMemo(() => new AbortController(), []);
 
   const [state, dispatch] = React.useReducer(vilkårsvurderingReducer, {
@@ -120,6 +124,7 @@ const VilkårsvurderingAvLivetsSluttfase = ({
     dispatch({ type: ActionType.PENDING });
     try {
       const status = await hentSykdomsstegStatus();
+      if (!isAksjonspunktOpen(medisinskVilkårAksjonspunkt?.status.kode)) void refetchBehandling();
       const nesteSteg = finnNesteStegForLivetsSluttfase(status);
       if (nesteSteg === livetsSluttfaseSteg || nesteSteg === null) {
         await oppdaterVurderingsoversikt();

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/vilkårsvurdering-av-tilsyn-og-pleie/VilkårsvurderingAvTilsynOgPleie.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/vilkårsvurdering-av-tilsyn-og-pleie/VilkårsvurderingAvTilsynOgPleie.tsx
@@ -1,6 +1,5 @@
 import { get, Period } from '@fpsak-frontend/utils';
-import { useRefetchBehandling } from '@k9-sak-web/gui/context/BehandlingContext.js';
-import { isAksjonspunktOpen } from '@k9-sak-web/gui/utils/aksjonspunktUtils.js';
+import useRefetchBehandlingVedSykdomsendring from '../../hooks/useRefetchBehandlingVedSykdomsendring';
 import { NavigationWithDetailView } from '@k9-sak-web/gui/shared/navigation-with-detail-view/NavigationWithDetailView.js';
 import { PageContainer } from '@k9-sak-web/gui/shared/pageContainer/PageContainer.js';
 import { Box } from '@navikt/ds-react';
@@ -28,8 +27,8 @@ const VilkårsvurderingAvTilsynOgPleie = ({
   hentSykdomsstegStatus,
   sykdomsstegStatus,
 }: VilkårsvurderingAvTilsynOgPleieProps): JSX.Element => {
-  const { endpoints, httpErrorHandler, medisinskVilkårAksjonspunkt } = React.useContext(ContainerContext);
-  const refetchBehandling = useRefetchBehandling();
+  const { endpoints, httpErrorHandler } = React.useContext(ContainerContext);
+  const refetchBehandlingVedSykdomsendring = useRefetchBehandlingVedSykdomsendring();
   const controller = useMemo(() => new AbortController(), []);
 
   const [state, dispatch] = React.useReducer(vilkårsvurderingReducer, {
@@ -118,9 +117,7 @@ const VilkårsvurderingAvTilsynOgPleie = ({
     dispatch({ type: ActionType.PENDING });
     try {
       const status = await hentSykdomsstegStatus();
-      if (!isAksjonspunktOpen(medisinskVilkårAksjonspunkt?.status.kode)) {
-        void refetchBehandling();
-      }
+      refetchBehandlingVedSykdomsendring();
       if (status.kanLøseAksjonspunkt) {
         navigerTilNesteSteg(toOmsorgspersonerSteg, true);
         return;

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/vilkårsvurdering-av-tilsyn-og-pleie/VilkårsvurderingAvTilsynOgPleie.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/vilkårsvurdering-av-tilsyn-og-pleie/VilkårsvurderingAvTilsynOgPleie.tsx
@@ -1,4 +1,6 @@
 import { get, Period } from '@fpsak-frontend/utils';
+import { useRefetchBehandling } from '@k9-sak-web/gui/context/BehandlingContext.js';
+import { isAksjonspunktOpen } from '@k9-sak-web/gui/utils/aksjonspunktUtils.js';
 import { NavigationWithDetailView } from '@k9-sak-web/gui/shared/navigation-with-detail-view/NavigationWithDetailView.js';
 import { PageContainer } from '@k9-sak-web/gui/shared/pageContainer/PageContainer.js';
 import { Box } from '@navikt/ds-react';
@@ -26,7 +28,8 @@ const VilkårsvurderingAvTilsynOgPleie = ({
   hentSykdomsstegStatus,
   sykdomsstegStatus,
 }: VilkårsvurderingAvTilsynOgPleieProps): JSX.Element => {
-  const { endpoints, httpErrorHandler } = React.useContext(ContainerContext);
+  const { endpoints, httpErrorHandler, medisinskVilkårAksjonspunkt } = React.useContext(ContainerContext);
+  const refetchBehandling = useRefetchBehandling();
   const controller = useMemo(() => new AbortController(), []);
 
   const [state, dispatch] = React.useReducer(vilkårsvurderingReducer, {
@@ -115,6 +118,9 @@ const VilkårsvurderingAvTilsynOgPleie = ({
     dispatch({ type: ActionType.PENDING });
     try {
       const status = await hentSykdomsstegStatus();
+      if (!isAksjonspunktOpen(medisinskVilkårAksjonspunkt?.status.kode)) {
+        void refetchBehandling();
+      }
       if (status.kanLøseAksjonspunkt) {
         navigerTilNesteSteg(toOmsorgspersonerSteg, true);
         return;

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/vilkårsvurdering-av-tilsyn-og-pleie/__tests__/VilkårsvurderingAvTilsynOgPleie.spec.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/vilkårsvurdering-av-tilsyn-og-pleie/__tests__/VilkårsvurderingAvTilsynOgPleie.spec.tsx
@@ -1,6 +1,8 @@
 /* eslint-disable max-len */
 import { httpUtils } from '@fpsak-frontend/utils';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { vi } from 'vitest';
+import { BehandlingProvider } from '@k9-sak-web/gui/context/BehandlingContext.js';
 import { dokumentSteg, toOmsorgspersonerSteg } from '../../../../types/Step';
 import Vurderingstype from '../../../../types/Vurderingstype';
 import ContainerContext from '../../../context/ContainerContext';
@@ -31,19 +33,21 @@ const vurderingsoversiktMock = {
 
 const contextWrapper = ui =>
   render(
-    <ContainerContext.Provider
-      value={
-        {
-          endpoints: { vurderingsoversiktKontinuerligTilsynOgPleie: vurderingsoversiktEndpoint },
-          httpErrorHandler: httpErrorHandlerMock,
-          readOnly: false,
-        } as any
-      }
-    >
-      <VurderingContext.Provider value={{ vurderingstype: Vurderingstype.KONTINUERLIG_TILSYN_OG_PLEIE }}>
-        {ui}
-      </VurderingContext.Provider>
-    </ContainerContext.Provider>,
+    <BehandlingProvider refetchBehandling={vi.fn()}>
+      <ContainerContext.Provider
+        value={
+          {
+            endpoints: { vurderingsoversiktKontinuerligTilsynOgPleie: vurderingsoversiktEndpoint },
+            httpErrorHandler: httpErrorHandlerMock,
+            readOnly: false,
+          } as any
+        }
+      >
+        <VurderingContext.Provider value={{ vurderingstype: Vurderingstype.KONTINUERLIG_TILSYN_OG_PLEIE }}>
+          {ui}
+        </VurderingContext.Provider>
+      </ContainerContext.Provider>
+    </BehandlingProvider>,
   );
 
 const navigerTilNesteStegMock = {

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/vilkårsvurdering-av-to-omsorgspersoner/VilkårsvurderingAvToOmsorgspersoner.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/vilkårsvurdering-av-to-omsorgspersoner/VilkårsvurderingAvToOmsorgspersoner.tsx
@@ -1,6 +1,5 @@
 import { httpUtils, Period } from '@fpsak-frontend/utils';
-import { useRefetchBehandling } from '@k9-sak-web/gui/context/BehandlingContext.js';
-import { isAksjonspunktOpen } from '@k9-sak-web/gui/utils/aksjonspunktUtils.js';
+import useRefetchBehandlingVedSykdomsendring from '../../hooks/useRefetchBehandlingVedSykdomsendring';
 import { NavigationWithDetailView } from '@k9-sak-web/gui/shared/navigation-with-detail-view/NavigationWithDetailView.js';
 import { PageContainer } from '@k9-sak-web/gui/shared/pageContainer/PageContainer.js';
 import { Box } from '@navikt/ds-react';
@@ -28,9 +27,8 @@ const VilkårsvurderingAvToOmsorgspersoner = ({
   hentSykdomsstegStatus,
   sykdomsstegStatus,
 }: VilkårsvurderingAvToOmsorgspersonerProps): JSX.Element => {
-  const { endpoints, onFinished, httpErrorHandler, readOnly, medisinskVilkårAksjonspunkt } =
-    React.useContext(ContainerContext);
-  const refetchBehandling = useRefetchBehandling();
+  const { endpoints, onFinished, httpErrorHandler, readOnly } = React.useContext(ContainerContext);
+  const refetchBehandlingVedSykdomsendring = useRefetchBehandlingVedSykdomsendring();
   const controller = useMemo(() => new AbortController(), []);
 
   const [state, dispatch] = React.useReducer(vilkårsvurderingReducer, {
@@ -115,7 +113,7 @@ const VilkårsvurderingAvToOmsorgspersoner = ({
   const onVurderingLagret = async () => {
     dispatch({ type: ActionType.PENDING });
     const status = await hentSykdomsstegStatus();
-    if (!isAksjonspunktOpen(medisinskVilkårAksjonspunkt?.status.kode)) void refetchBehandling();
+    refetchBehandlingVedSykdomsendring();
     if (status.kanLøseAksjonspunkt) {
       onFinished();
       return;

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/vilkårsvurdering-av-to-omsorgspersoner/VilkårsvurderingAvToOmsorgspersoner.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/vilkårsvurdering-av-to-omsorgspersoner/VilkårsvurderingAvToOmsorgspersoner.tsx
@@ -1,4 +1,6 @@
 import { httpUtils, Period } from '@fpsak-frontend/utils';
+import { useRefetchBehandling } from '@k9-sak-web/gui/context/BehandlingContext.js';
+import { isAksjonspunktOpen } from '@k9-sak-web/gui/utils/aksjonspunktUtils.js';
 import { NavigationWithDetailView } from '@k9-sak-web/gui/shared/navigation-with-detail-view/NavigationWithDetailView.js';
 import { PageContainer } from '@k9-sak-web/gui/shared/pageContainer/PageContainer.js';
 import { Box } from '@navikt/ds-react';
@@ -26,7 +28,9 @@ const VilkårsvurderingAvToOmsorgspersoner = ({
   hentSykdomsstegStatus,
   sykdomsstegStatus,
 }: VilkårsvurderingAvToOmsorgspersonerProps): JSX.Element => {
-  const { endpoints, onFinished, httpErrorHandler, readOnly } = React.useContext(ContainerContext);
+  const { endpoints, onFinished, httpErrorHandler, readOnly, medisinskVilkårAksjonspunkt } =
+    React.useContext(ContainerContext);
+  const refetchBehandling = useRefetchBehandling();
   const controller = useMemo(() => new AbortController(), []);
 
   const [state, dispatch] = React.useReducer(vilkårsvurderingReducer, {
@@ -111,6 +115,7 @@ const VilkårsvurderingAvToOmsorgspersoner = ({
   const onVurderingLagret = async () => {
     dispatch({ type: ActionType.PENDING });
     const status = await hentSykdomsstegStatus();
+    if (!isAksjonspunktOpen(medisinskVilkårAksjonspunkt?.status.kode)) void refetchBehandling();
     if (status.kanLøseAksjonspunkt) {
       onFinished();
       return;

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/vilkårsvurdering-av-to-omsorgspersoner/__tests__/VilkårsvurderingAvToOmsorgspersoner.spec.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/vilkårsvurdering-av-to-omsorgspersoner/__tests__/VilkårsvurderingAvToOmsorgspersoner.spec.tsx
@@ -1,6 +1,7 @@
 import { httpUtils } from '@fpsak-frontend/utils';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeAll, beforeEach, describe, it, vi } from 'vitest';
+import { BehandlingProvider } from '@k9-sak-web/gui/context/BehandlingContext.js';
 import { dokumentSteg } from '../../../../types/Step';
 import Vurderingstype from '../../../../types/Vurderingstype';
 import ContainerContext from '../../../context/ContainerContext';
@@ -35,20 +36,22 @@ const onFinishedMock = {
 
 const contextWrapper = ui =>
   render(
-    <ContainerContext.Provider
-      value={
-        {
-          endpoints: { vurderingsoversiktBehovForToOmsorgspersoner: vurderingsoversiktEndpoint },
-          httpErrorHandler: httpErrorHandlerMock,
-          readOnly: false,
-          onFinished: onFinishedMock.fn,
-        } as any
-      }
-    >
-      <VurderingContext.Provider value={{ vurderingstype: Vurderingstype.TO_OMSORGSPERSONER }}>
-        {ui}
-      </VurderingContext.Provider>
-    </ContainerContext.Provider>,
+    <BehandlingProvider refetchBehandling={vi.fn()}>
+      <ContainerContext.Provider
+        value={
+          {
+            endpoints: { vurderingsoversiktBehovForToOmsorgspersoner: vurderingsoversiktEndpoint },
+            httpErrorHandler: httpErrorHandlerMock,
+            readOnly: false,
+            onFinished: onFinishedMock.fn,
+          } as any
+        }
+      >
+        <VurderingContext.Provider value={{ vurderingstype: Vurderingstype.TO_OMSORGSPERSONER }}>
+          {ui}
+        </VurderingContext.Provider>
+      </ContainerContext.Provider>
+    </BehandlingProvider>,
   );
 
 const navigerTilNesteStegMock = {

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/vilkårsvurdering-langvarig-sykdom/VilkarsvurderingLangvarigSykdom.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/vilkårsvurdering-langvarig-sykdom/VilkarsvurderingLangvarigSykdom.tsx
@@ -1,4 +1,6 @@
 import { get, Period } from '@fpsak-frontend/utils';
+import { useRefetchBehandling } from '@k9-sak-web/gui/context/BehandlingContext.js';
+import { isAksjonspunktOpen } from '@k9-sak-web/gui/utils/aksjonspunktUtils.js';
 import React, { useMemo, type JSX } from 'react';
 import Step, { langvarigSykdomSteg, StepId } from '../../../types/Step';
 import SykdomsstegStatusResponse from '../../../types/SykdomsstegStatusResponse';
@@ -29,7 +31,9 @@ const VilkårsvurderingLangvarigSykdom = ({
   hentSykdomsstegStatus,
   sykdomsstegStatus,
 }: VilkårsvurderingLangvarigSykdomProps): JSX.Element => {
-  const { endpoints, httpErrorHandler, fagsakYtelseType, behandlingType } = React.useContext(ContainerContext);
+  const { endpoints, httpErrorHandler, fagsakYtelseType, behandlingType, medisinskVilkårAksjonspunkt } =
+    React.useContext(ContainerContext);
+  const refetchBehandling = useRefetchBehandling();
   const controller = useMemo(() => new AbortController(), []);
 
   const [state, dispatch] = React.useReducer(vilkårsvurderingReducer, {
@@ -120,6 +124,7 @@ const VilkårsvurderingLangvarigSykdom = ({
     dispatch({ type: ActionType.PENDING });
     try {
       const status = await hentSykdomsstegStatus();
+      if (!isAksjonspunktOpen(medisinskVilkårAksjonspunkt?.status.kode)) void refetchBehandling();
       const nesteSteg = finnNesteStegForOpplæringspenger(status);
       if (nesteSteg === langvarigSykdomSteg || nesteSteg === null) {
         await oppdaterVurderingsoversikt();

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/vilkårsvurdering-langvarig-sykdom/VilkarsvurderingLangvarigSykdom.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/vilkårsvurdering-langvarig-sykdom/VilkarsvurderingLangvarigSykdom.tsx
@@ -1,6 +1,5 @@
 import { get, Period } from '@fpsak-frontend/utils';
-import { useRefetchBehandling } from '@k9-sak-web/gui/context/BehandlingContext.js';
-import { isAksjonspunktOpen } from '@k9-sak-web/gui/utils/aksjonspunktUtils.js';
+import useRefetchBehandlingVedSykdomsendring from '../../hooks/useRefetchBehandlingVedSykdomsendring';
 import React, { useMemo, type JSX } from 'react';
 import Step, { langvarigSykdomSteg, StepId } from '../../../types/Step';
 import SykdomsstegStatusResponse from '../../../types/SykdomsstegStatusResponse';
@@ -31,9 +30,8 @@ const VilkårsvurderingLangvarigSykdom = ({
   hentSykdomsstegStatus,
   sykdomsstegStatus,
 }: VilkårsvurderingLangvarigSykdomProps): JSX.Element => {
-  const { endpoints, httpErrorHandler, fagsakYtelseType, behandlingType, medisinskVilkårAksjonspunkt } =
-    React.useContext(ContainerContext);
-  const refetchBehandling = useRefetchBehandling();
+  const { endpoints, httpErrorHandler, fagsakYtelseType, behandlingType } = React.useContext(ContainerContext);
+  const refetchBehandlingVedSykdomsendring = useRefetchBehandlingVedSykdomsendring();
   const controller = useMemo(() => new AbortController(), []);
 
   const [state, dispatch] = React.useReducer(vilkårsvurderingReducer, {
@@ -124,7 +122,7 @@ const VilkårsvurderingLangvarigSykdom = ({
     dispatch({ type: ActionType.PENDING });
     try {
       const status = await hentSykdomsstegStatus();
-      if (!isAksjonspunktOpen(medisinskVilkårAksjonspunkt?.status.kode)) void refetchBehandling();
+      refetchBehandlingVedSykdomsendring();
       const nesteSteg = finnNesteStegForOpplæringspenger(status);
       if (nesteSteg === langvarigSykdomSteg || nesteSteg === null) {
         await oppdaterVurderingsoversikt();

--- a/packages/fakta-medisinsk-vilkår/src/ui/hooks/useRefetchBehandlingVedSykdomsendring.ts
+++ b/packages/fakta-medisinsk-vilkår/src/ui/hooks/useRefetchBehandlingVedSykdomsendring.ts
@@ -1,0 +1,22 @@
+import { useRefetchBehandling } from '@k9-sak-web/gui/context/BehandlingContext.js';
+import { isAksjonspunktOpen } from '@k9-sak-web/gui/utils/aksjonspunktUtils.js';
+import React from 'react';
+import ContainerContext from '../context/ContainerContext';
+
+/**
+ * Når sykdomsdata endres mens aksjonspunkt 9001 allerede er utført (UTFO), vil
+ * backend rulle tilbake behandlingen og inkrementere versjonsnummeret. Vi må
+ * derfor refetche behandlingen slik at frontend er i sync med ny versjon.
+ */
+const useRefetchBehandlingVedSykdomsendring = (): (() => void) => {
+  const { medisinskVilkårAksjonspunkt } = React.useContext(ContainerContext);
+  const refetchBehandling = useRefetchBehandling();
+
+  return () => {
+    if (!isAksjonspunktOpen(medisinskVilkårAksjonspunkt?.status.kode)) {
+      void refetchBehandling();
+    }
+  };
+};
+
+export default useRefetchBehandlingVedSykdomsendring;

--- a/packages/v2/gui/src/context/BehandlingContext.tsx
+++ b/packages/v2/gui/src/context/BehandlingContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, type ReactNode } from 'react';
+import { useContext, createContext, type ReactNode } from 'react';
 
 export interface BehandlingContextType {
   refetchBehandling: () => Promise<any>;
@@ -17,7 +17,7 @@ export const BehandlingProvider = ({
 };
 
 export const useRefetchBehandling = (): BehandlingContextType['refetchBehandling'] => {
-  const context = React.useContext(BehandlingContext);
+  const context = useContext(BehandlingContext);
   if (!context) {
     throw new Error('useRefetchBehandling must be used within a BehandlingProvider');
   }

--- a/packages/v2/gui/src/context/BehandlingContext.tsx
+++ b/packages/v2/gui/src/context/BehandlingContext.tsx
@@ -1,5 +1,4 @@
-import type { ReactNode } from 'react';
-import { createContext } from 'react';
+import React, { createContext, type ReactNode } from 'react';
 
 export interface BehandlingContextType {
   refetchBehandling: () => Promise<any>;
@@ -15,4 +14,12 @@ export const BehandlingProvider = ({
   refetchBehandling: BehandlingContextType['refetchBehandling'];
 }) => {
   return <BehandlingContext.Provider value={{ refetchBehandling }}>{children}</BehandlingContext.Provider>;
+};
+
+export const useRefetchBehandling = (): BehandlingContextType['refetchBehandling'] => {
+  const context = React.useContext(BehandlingContext);
+  if (!context) {
+    throw new Error('useRefetchBehandling must be used within a BehandlingProvider');
+  }
+  return context.refetchBehandling;
 };

--- a/packages/v2/gui/src/storybook/decorators/withStoryReload.tsx
+++ b/packages/v2/gui/src/storybook/decorators/withStoryReload.tsx
@@ -1,5 +1,6 @@
 import type { Decorator } from '@storybook/react';
 import { useEffect } from 'react';
+import { BehandlingProvider } from '../../context/BehandlingContext';
 
 /**
  *
@@ -10,7 +11,11 @@ import { useEffect } from 'react';
 
 const withStoryReload = (): Decorator => Story => {
   useEffect(() => () => window.location.reload(), []);
-  return <Story />;
+  return (
+    <BehandlingProvider refetchBehandling={() => Promise.resolve()}>
+      <Story />
+    </BehandlingProvider>
+  );
 };
 
 export default withStoryReload;


### PR DESCRIPTION
### **Behov / Bakgrunn**
Redigeringer i sykdom når aksjonspunktet er utført vil **alltid** føre til feil etterpå. Det rulles tilbake selv om det eneste man har gjort er å legge til en bokstav i begrunnelse på en av periodene uten å endre utfallet. Man kommer seg ikke ut av det uten manuell refresh.

### **Løsning**
En hotfix som sjekker om aksjonspunktet har status UTFO når man gjør post-kall i sykdom. Dersom det er tilfellet må man kjøre en refresh onSuccess. Da havner man tilbake i sykdom med 9001 (sykdom) i OPPR, og da fungerer ting fint

### **Skjermbilder** (hvis relevant)
filmer av problem og løsning her
https://nav-it.slack.com/archives/C0B2B3H2PLH/p1778074453027249