### PR TITLE
Retter feil i prosessmeny v2

### DIFF
--- a/packages/behandling-pleiepenger/src/prosess/inngangsvilkårPaneler/InngangsvilkarProsessStegInitPanel.tsx
+++ b/packages/behandling-pleiepenger/src/prosess/inngangsvilkårPaneler/InngangsvilkarProsessStegInitPanel.tsx
@@ -92,7 +92,7 @@ export const InngangsvilkarProsessStegInitPanel = ({
           </Tabs.List>
         </Tabs>
       )}
-      <HGrid columns={2} marginBlock={tabs.length > 1 ? 'space-32' : 'space-16'}>
+      <HGrid columns={2} marginBlock={tabs.length > 1 ? 'space-32' : 'space-16'} gap="space-16">
         <VStack gap="space-48">
           <SøknadsfristProsessStegInitPanel
             behandling={behandling}

--- a/packages/v2/gui/src/behandling/prosess/ProsessMeny.tsx
+++ b/packages/v2/gui/src/behandling/prosess/ProsessMeny.tsx
@@ -74,17 +74,6 @@ export const ProsessMeny = ({ children, steg: prosessmotorSteg }: ProsessMenyPro
     const gyldigePanelIds = prosessmotorSteg.map(s => s.id);
     const panelMedAksjonspunkt = prosessmotorSteg.find(steg => steg.type === ProcessMenuStepType.warning);
 
-    // Automatisk naviger til panel med aksjonspunkt hvis bruker ikke har valgt noe
-    if (panelMedAksjonspunkt && !sisteAktivtValgtePanelId) {
-      setValgtPanelId(panelMedAksjonspunkt.id);
-      setSearchParams(forrige => {
-        const neste = new URLSearchParams(forrige);
-        neste.set('punkt', panelMedAksjonspunkt.id);
-        return neste;
-      });
-      return;
-    }
-
     // Velg default panel når ingen er valgt
     if (urlPanelId === 'default') {
       setSisteAktivtValgtePanelId(null);
@@ -102,6 +91,8 @@ export const ProsessMeny = ({ children, steg: prosessmotorSteg }: ProsessMenyPro
           return neste;
         });
       }
+
+      return;
     }
 
     // Respekter siste aktive valg
@@ -113,6 +104,16 @@ export const ProsessMeny = ({ children, steg: prosessmotorSteg }: ProsessMenyPro
     if (urlPanelId && gyldigePanelIds.includes(urlPanelId)) {
       setValgtPanelId(urlPanelId);
       return;
+    }
+
+    // Automatisk naviger til panel med aksjonspunkt hvis bruker ikke har valgt noe
+    if (panelMedAksjonspunkt && !sisteAktivtValgtePanelId) {
+      setValgtPanelId(panelMedAksjonspunkt.id);
+      setSearchParams(forrige => {
+        const neste = new URLSearchParams(forrige);
+        neste.set('punkt', panelMedAksjonspunkt.id);
+        return neste;
+      });
     }
   }, [urlPanelId, prosessmotorSteg, setSearchParams, sisteAktivtValgtePanelId]);
 


### PR DESCRIPTION
### **Behov / Bakgrunn**


### **Løsning**

- Legger gap mellom kolonner i inngangsvilkår
- Endrer i logikk for prosessmeny slik at lenker i totrinnskontroll og andre steder som endrer url fungerer.

### **Andre endringer**


### **Skjermbilder** (hvis relevant)
