### PR TITLE
Update dependabot.yml to remove eslint-plugin-vitest

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,7 +25,6 @@ updates:
           - 'react*'
           - '@types/react'
           - '@navikt*'
-          - 'eslint-plugin-vitest' # version 0.5.4 requires eslint version 9
       react:
         patterns:
           - 'react'


### PR DESCRIPTION
Removed eslint-plugin-vitest exclusion from dependabot config.

### **Behov / Bakgrunn**


### **Løsning**


### **Andre endringer**


### **Skjermbilder** (hvis relevant)
