### PR TITLE
fix: dersom første og siste uke i periode er samme, vis uten bindestrek

### DIFF
--- a/packages/v2/gui/src/prosess/uttak/utils/periodUtils.ts
+++ b/packages/v2/gui/src/prosess/uttak/utils/periodUtils.ts
@@ -32,5 +32,10 @@ export function prettifyPeriod(fom: string, tom: string): string {
 }
 
 export function getFirstAndLastWeek(fom: string, tom: string): string {
-  return `${initializeDate(fom).startOf('week').week()} - ${initializeDate(tom).endOf('week').week()}`;
+  const fomWeek = initializeDate(fom).startOf('week').week();
+  const tomWeek = initializeDate(tom).endOf('week').week();
+  if (fomWeek === tomWeek) {
+    return `${fomWeek}`;
+  }
+  return `${fomWeek} - ${tomWeek}`;
 }


### PR DESCRIPTION
### Behov / Bakgrunn
Periodefelt i tabell vises som feks "11 - 11" for uke. Det holder å vise "11"

### Løsning
Sjekker om uke er samme og setter visning etter det.

### Andre endringer

