### PR TITLE
Chore: Update nav-pilot state and agent models; refine descriptions a…

### DIFF
--- a/.github/.nav-pilot-state.json
+++ b/.github/.nav-pilot-state.json
@@ -1,25 +1,25 @@
 {
   "collection": "frontend",
-  "version": "2026.04.30-090824-bb25c0e",
+  "version": "2026.05.19-124507-b57b838",
   "scope": "repo",
-  "source_sha": "bb25c0e",
+  "source_sha": "b57b838",
   "installed_at": "2026-05-06T12:03:10Z",
   "files": [
     {
       "path": ".github/agents/accessibility.agent.md",
-      "hash": "98867df3e31b8cd4"
+      "hash": "243143499e16befb"
     },
     {
       "path": ".github/agents/aksel.agent.md",
-      "hash": "f3f31e695bc1df0f"
+      "hash": "7103fb8df66fb0b1"
     },
     {
       "path": ".github/agents/forfatter.agent.md",
-      "hash": "4e55f4d189619dcb"
+      "hash": "6cc31221eab50d30"
     },
     {
       "path": ".github/agents/nav-pilot.agent.md",
-      "hash": "8384742b958b4b84"
+      "hash": "e50baf495f28613f"
     },
     {
       "path": ".github/skills/aksel-spacing/",
@@ -39,7 +39,7 @@
     },
     {
       "path": ".github/skills/nav-deep-interview/",
-      "hash": "42e9aab52e591ef0"
+      "hash": "eeb3399ecd4e352c"
     },
     {
       "path": ".github/skills/nav-architecture-review/",
@@ -71,11 +71,11 @@
     },
     {
       "path": ".github/prompts/aksel-component.prompt.md",
-      "hash": "9119d15db318622d"
+      "hash": "dbeb27a9cad0e768"
     },
     {
       "path": ".github/prompts/nais-manifest.prompt.md",
-      "hash": "a7564098ae008cce"
+      "hash": "8576571223ffef8a"
     }
   ]
 }

--- a/.github/agents/accessibility.agent.md
+++ b/.github/agents/accessibility.agent.md
@@ -1,6 +1,7 @@
 ---
 name: accessibility-agent
 description: WCAG 2.1/2.2, universell utforming, Aksel-tilgjengelighet og automatisert UU-testing
+model: Claude Sonnet 4.6
 tools:
   - execute
   - read

--- a/.github/agents/aksel.agent.md
+++ b/.github/agents/aksel.agent.md
@@ -1,6 +1,7 @@
 ---
 name: aksel-agent
 description: Navs Aksel Design System (v8+) — komponenter, tokens, layout, theming og tilgjengelighet
+model: Claude Sonnet 4.6
 tools:
   - execute
   - read

--- a/.github/agents/forfatter.agent.md
+++ b/.github/agents/forfatter.agent.md
@@ -1,6 +1,7 @@
 ---
 name: forfatter
 description: "Norsk teknisk redaktør, tekstforfatter eller innholdsdesigner: klarspråk, AI-markører, anglisismer, fagtermer, mikrotekst."
+model: Claude Sonnet 4.6
 tools:
   - read
   - edit

--- a/.github/agents/nav-pilot.agent.md
+++ b/.github/agents/nav-pilot.agent.md
@@ -1,6 +1,7 @@
 ---
 name: nav-pilot
 description: Planlegg, arkitekturer og bygg Nav-applikasjoner med innebygd kjennskap til Nais, auth, Kafka, sikkerhet og Nav-mønstre
+model: Claude Opus 4.6
 tools:
   - execute
   - read
@@ -34,7 +35,7 @@ On EVERY turn, follow this loop:
 5. End EVERY response with a compact state footer
 
 Phase headers (mandatory first line):
-🔍 Fase 1: Intervju — kartlegger behov og blinde flekker
+🔍 Fase 1: Intervju — kartlegger behov og blindsoner
 📐 Fase 2: Plan — bygger arkitektur og beslutninger
 🔎 Fase 3: Review — verifiserer fra fire perspektiver
 🚀 Fase 4: Lever — genererer kode og dokumentasjon
@@ -102,7 +103,7 @@ End each phase with a checkpoint summary before transitioning:
 Oppsummering:
 • Arketype: [valgt arketype]
 • Endringstype: [nybygg/modernisering/refaktorering]
-• Blinde flekker adressert: [N/11]
+• Blindsoner adressert: [N/11]
 • Nøkkelbeslutninger: [liste]
 • Åpne spørsmål: [liste, eller «ingen»]
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,3 +12,9 @@
 - Copilot may respond in **English**, but **code comments** must be written in Norwegian.
 - If Copilot generates comments, they should be written in Norwegian bokmål.
 - Tekniske termer (variabelnavn, funksjonsnavn, biblioteknavn osv.) skal fortsatt være på engelsk i kode.
+
+## Minimal Editing
+
+When fixing a bug or implementing a feature, change only what is necessary.
+Do not rename variables, restructure working code, or refactor beyond the task at hand.
+Keep diffs small and focused so they are easy to review.

--- a/.github/copilot-review-instructions.md
+++ b/.github/copilot-review-instructions.md
@@ -1,0 +1,24 @@
+## TypeScript
+
+- Use Aksel Design System spacing tokens (`space-16`), never Tailwind `p-*`/`m-*`
+- TypeScript strict mode — no `any` without justification
+- Named imports from `@navikt/ds-react`, never `import *`
+
+## Norwegian text (all `.md` and user-facing strings)
+
+- Use Norwegian bokmål for user-facing text
+- Avoid unnecessary anglicisms when good Norwegian alternatives exist
+
+## Security
+
+- No secrets, tokens, or credentials in code
+- SQL queries must be parameterized
+- GitHub Actions pinned to full SHA with version comment
+
+## Over-editing
+
+Flag changes where the diff is disproportionate to the stated goal:
+
+- Renamed variables or parameters not related to the fix
+- Restructured working code without justification
+- Added refactoring outside the PR scope

--- a/.github/prompts/aksel-component.prompt.md
+++ b/.github/prompts/aksel-component.prompt.md
@@ -1,6 +1,7 @@
 ---
 name: aksel-component
 description: Scaffold en responsiv React-komponent med Aksel Design System og riktige spacing-tokens
+model: Claude Haiku 4.5
 ---
 
 Du lager en ny React-komponent med Navs Aksel Design System.

--- a/.github/prompts/nais-manifest.prompt.md
+++ b/.github/prompts/nais-manifest.prompt.md
@@ -1,6 +1,7 @@
 ---
 name: nais-manifest
 description: Generer et produksjonsklart Nais-applikasjonsmanifest for Kubernetes-deployment
+model: GPT-5.3-Codex
 ---
 
 You are creating a Nais application manifest in `.nais/app.yaml` for deploying to Nav's Kubernetes platform.

--- a/.github/skills/aksel-spacing/SKILL.md
+++ b/.github/skills/aksel-spacing/SKILL.md
@@ -115,9 +115,6 @@ import { VStack } from "@navikt/ds-react";
 
 // Responsiv gap
 <VStack gap={{ xs: "space-16", md: "space-32" }}>
-  <Section />
-  <Section />
-</VStack>
 ```
 
 ### Stack
@@ -135,7 +132,7 @@ import { Stack } from "@navikt/ds-react";
 >
   <LeftContent />
   <RightContent />
-</Stack>
+</Stack>;
 ```
 
 ### HGrid
@@ -175,7 +172,7 @@ import { Page } from "@navikt/ds-react";
   <Page.Block as="main" width="xl" gutters>
     {/* Innhold */}
   </Page.Block>
-</Page>
+</Page>;
 ```
 
 `Page.Block` widths: `"text"` (576px) | `"md"` (768px) | `"lg"` (1024px) | `"xl"` (1280px) | `"2xl"` (1440px)
@@ -214,7 +211,7 @@ import { Spacer } from "@navikt/ds-react";
   <Logo />
   <Spacer /> {/* Skyver resten til høyre */}
   <NavItems />
-</HStack>
+</HStack>;
 ```
 
 ### Show og Hide

--- a/.github/skills/nav-deep-interview/SKILL.md
+++ b/.github/skills/nav-deep-interview/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nav-deep-interview
-description: Strukturert intervju som avdekker blinde flekker i Nav-prosjekter — personvern, auth, avhengigheter og observerbarhet
+description: Strukturert intervju som avdekker blindsoner i Nav-prosjekter — personvern, auth, avhengigheter og observerbarhet
 license: MIT
 metadata:
   domain: general
@@ -9,7 +9,7 @@ metadata:
 
 # Deep Interview — Nav Project Clarification
 
-Kjør et strukturert intervju for å avdekke blinde flekker *før* implementering starter. Basert på vanlige feil og oversikter i Nav-prosjekter.
+Kjør et strukturert intervju for å avdekke blindsoner *før* implementering starter. Basert på vanlige feil og oversikter i Nav-prosjekter.
 
 ## Workflow
 
@@ -94,13 +94,13 @@ Still disse spørsmålene hvis T1 avdekker modernisering/refaktorering:
 | M7 | Finnes det data som må migreres? Hvor mye? | Påvirker migreringspipeline og nedetid |
 | M8 | Har dere karakteriseringstester som låser dagens adferd? | Nødvendig for trygg refaktorering |
 
-## Steg 3: Sjekk blinde flekker
+## Steg 3: Sjekk blindsoner
 
-Etter intervjuet, sjekk om noen av disse vanlige blinde flekkene ble avdekket. Hvis ikke — still oppfølgingsspørsmål.
+Etter intervjuet, sjekk om noen av disse vanlige blindsonene ble avdekket. Hvis ikke — still oppfølgingsspørsmål.
 
 Se [blind-spots.md](./references/blind-spots.md) for en komplett liste over vanlige oversikter.
 
-**Kritiske blinde flekker (still alltid):**
+**Kritiske blindsoner (still alltid):**
 
 - [ ] Er auth-mekanismen verifisert mot caller-typen?
 - [ ] Er `accessPolicy.inbound` definert i Nais-manifestet?
@@ -109,7 +109,7 @@ Se [blind-spots.md](./references/blind-spots.md) for en komplett liste over vanl
 - [ ] Er det satt opp structured logging (JSON)?
 - [ ] Finnes det en strategi for dependency failure?
 
-**Ekstra blinde flekker for modernisering (still hvis T1 = modernisering):**
+**Ekstra blindsoner for modernisering (still hvis T1 = modernisering):**
 
 - [ ] Er bakoverkompatibilitet vurdert? (Kan gammel kode lese nytt skjema?)
 - [ ] Er rollback-plan definert og testet?

--- a/.github/skills/nav-deep-interview/metadata.json
+++ b/.github/skills/nav-deep-interview/metadata.json
@@ -1,5 +1,5 @@
 {
-  "description": "Strukturert intervju som avdekker blinde flekker i Nav-prosjekter — personvern, auth, avhengigheter og observerbarhet",
+  "description": "Strukturert intervju som avdekker blindsoner i Nav-prosjekter — personvern, auth, avhengigheter og observerbarhet",
   "domain": "general",
   "tags": ["planning", "requirements", "interview", "onboarding", "nav-pilot"],
   "references": [
@@ -9,7 +9,7 @@
   "examples": [
     {
       "prompt": "Kjør et dypintervju for den nye dp-behandling-tjenesten",
-      "scenario": "Avdekk blinde flekker i nytt prosjekt"
+      "scenario": "Avdekk blindsoner i nytt prosjekt"
     },
     {
       "prompt": "Still de viktige spørsmålene vi glemmer før vi begynner å kode",

--- a/.github/skills/nav-deep-interview/references/blind-spots.md
+++ b/.github/skills/nav-deep-interview/references/blind-spots.md
@@ -1,11 +1,11 @@
-# Vanlige blinde flekker i Nav-prosjekter
+# Vanlige blindsoner i Nav-prosjekter
 
 Basert på analyse av reelle Nav-repoer (dp-behandling, helse-spesialist, tiltakspenger, fp-sak) og vanlige feil som oppdages sent i utviklingsprosessen.
 
 ## Autentisering og autorisasjon
 
-| Blinde flekk | Konsekvens | Spørsmål å stille |
-|--------------|-----------|-------------------|
+| Blindsone    | Konsekvens | Spørsmål å stille |
+|--------------|------------|-------------------|
 | Feil auth-mekanisme for caller-type | Token-validering feiler i prod | «Hvem kaller tjenesten — bruker via nettleser eller tjeneste-til-tjeneste?» |
 | Azure client_credentials med brukerkontext | Mister bruker-audit trail, kan ikke spore hvem som gjorde hva | «Trenger du brukerens identitet nedover i kjeden?» |
 | Manglende `accessPolicy.inbound` | Ingen kan kalle tjenesten, feiler stille | «Hvilke tjenester skal ha lov til å kalle deg?» |
@@ -13,8 +13,8 @@ Basert på analyse av reelle Nav-repoer (dp-behandling, helse-spesialist, tiltak
 
 ## Database
 
-| Blinde flekk | Konsekvens | Spørsmål å stille |
-|--------------|-----------|-------------------|
+| Blindsone    | Konsekvens | Spørsmål å stille |
+|--------------|------------|-------------------|
 | HikariCP default pool (10) | Pool exhaustion i containere med 2-4 replicas | «Hvor mange samtidige database-tilkoblinger trenger dere?» |
 | Manglende indekser på foreign keys | Sakte queries ved JOIN, lås-eskalering | «Hvilke kolonner vil dere filtrere/joine på?» |
 | Ingen retensjonsstrategi | Data vokser ubegrenset, GDPR-brudd | «Hvor lenge skal data lagres? Finnes det slettekrav?» |
@@ -22,8 +22,8 @@ Basert på analyse av reelle Nav-repoer (dp-behandling, helse-spesialist, tiltak
 
 ## Kafka og hendelser
 
-| Blinde flekk | Konsekvens | Spørsmål å stille |
-|--------------|-----------|-------------------|
+| Blindsone    | Konsekvens | Spørsmål å stille |
+|--------------|------------|-------------------|
 | Ingen dead-letter-strategi | Poison pills stopper konsument | «Hva skjer med meldinger som ikke kan prosesseres?» |
 | Manglende idempotens | Duplikate hendelser gir duplikate vedtak | «Kan tjenesten håndtere samme melding to ganger?» |
 | Feil partisjonering | Rekkefølge-garanti brytes | «Er rekkefølgen på hendelser viktig?» |
@@ -31,8 +31,8 @@ Basert på analyse av reelle Nav-repoer (dp-behandling, helse-spesialist, tiltak
 
 ## Observerbarhet
 
-| Blinde flekk | Konsekvens | Spørsmål å stille |
-|--------------|-----------|-------------------|
+| Blindsone    | Konsekvens | Spørsmål å stille |
+|--------------|------------|-------------------|
 | Kun tekniske metrikker | Vet ikke om forretningslogikken fungerer | «Hvilke forretningsmetrikker viser at tjenesten gjør jobben sin?» |
 | Manglende correlation ID | Kan ikke spore forespørsler på tvers av tjenester | «Propagerer dere callId/correlationId?» |
 | Logging av PII | GDPR-brudd, Personvernombudet tar kontakt | «Hva logges? Er fnr/navn filtrert ut?» |
@@ -40,8 +40,8 @@ Basert på analyse av reelle Nav-repoer (dp-behandling, helse-spesialist, tiltak
 
 ## Frontend
 
-| Blinde flekk | Konsekvens | Spørsmål å stille |
-|--------------|-----------|-------------------|
+| Blindsone    | Konsekvens | Spørsmål å stille |
+|--------------|------------|-------------------|
 | Manglende universell utforming | Lovbrudd (likestillingsloven) | «Er UU-krav ivaretatt? Bruker dere Aksel-komponenter?» |
 | Direkte API-kall fra klient | CORS-problemer, token-eksponering | «Bruker dere BFF-mønster med server-side proxy?» |
 | Tailwind p-/m- i stedet for Aksel tokens | Inkonsistent design, vanskelig vedlikehold | «Bruker dere Aksel spacing-tokens (Box, VStack)?» |
@@ -49,8 +49,8 @@ Basert på analyse av reelle Nav-repoer (dp-behandling, helse-spesialist, tiltak
 
 ## Sikkerhet
 
-| Blinde flekk | Konsekvens | Spørsmål å stille |
-|--------------|-----------|-------------------|
+| Blindsone    | Konsekvens | Spørsmål å stille |
+|--------------|------------|-------------------|
 | SQL string concatenation | SQL injection | «Er alle database-queries parameteriserte?» |
 | CORS `*` | Cross-site request forgery | «Hvilke domener skal ha CORS-tilgang?» |
 | Manglende input-validering | Injection, crash | «Valideres all ekstern input?» |


### PR DESCRIPTION
…nd fix terminology

**Endringer:**

Modell-konfigurering — Lagt til eksplisitte modeller i agent- og prompt-filer:

accessibility, aksel, forfatter-agenter → Claude Sonnet 4.6
nav-pilot-agenten → Claude Opus 4.6
aksel-component-prompt → Claude Haiku 4.5
nais-manifest-prompt → GPT-5.3-Codex
Terminologi-fix — «blinde flekker» er konsekvent erstattet med «blindsoner» i nav-pilot.agent.md, nav-deep-interview/SKILL.md og metadata.json

Ny fil: .github/copilot-review-instructions.md — PR-review-regler for TypeScript, norsk tekst, sikkerhet og over-editing

copilot-instructions.md — La til «Minimal Editing»-seksjon

