### PR TITLE
TSFF-567: Snu rekkefølge i etablert tilsyn til nyeste periode først

### DIFF
--- a/packages/fakta-etablert-tilsyn/src/ui/components/etablertTilsyn/EtablertTilsynMedSmoring.helpers.spec.ts
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/etablertTilsyn/EtablertTilsynMedSmoring.helpers.spec.ts
@@ -42,7 +42,7 @@ describe('EtablertTilsynMedSmoring helpers', () => {
     expect(enkeltdager.every(e => e.periode.fom === e.periode.tom)).toBe(true);
   });
 
-  it('finnUker returnerer unike uke+år i kronologisk rekkefølge', () => {
+  it('finnUker returnerer unike uke+år med nyeste først', () => {
     const tilsyn = [
       lagTilsyn('2024-01-02', '2024-01-02', 5, Kilde.SØKER), // uke 1 (antatt ISO)
       lagTilsyn('2024-01-10', '2024-01-10', 5, Kilde.SØKER), // uke 2
@@ -50,8 +50,8 @@ describe('EtablertTilsynMedSmoring helpers', () => {
     ];
     const uker = finnUker(tilsyn);
     expect(uker).toEqual([
-      { uke: 1, år: 2024 },
       { uke: 2, år: 2024 },
+      { uke: 1, år: 2024 },
     ]);
   });
 
@@ -63,8 +63,23 @@ describe('EtablertTilsynMedSmoring helpers', () => {
 
     const uker = finnUker(tilsyn);
     expect(uker).toEqual([
-      { uke: 33, år: 2022 },
       { uke: 33, år: 2023 },
+      { uke: 33, år: 2022 },
+    ]);
+  });
+
+  it('finnUker sorterer omvendt kronologisk uavhengig av inputrekkefølge', () => {
+    const tilsyn = [
+      lagTilsyn('2023-08-14', '2023-08-14', 5, Kilde.SØKER),
+      lagTilsyn('2022-08-15', '2022-08-15', 5, Kilde.SØKER),
+      lagTilsyn('2023-01-03', '2023-01-03', 5, Kilde.SØKER),
+    ];
+
+    const uker = finnUker(tilsyn);
+    expect(uker).toEqual([
+      { uke: 33, år: 2023 },
+      { uke: 1, år: 2023 },
+      { uke: 33, år: 2022 },
     ]);
   });
 
@@ -80,9 +95,9 @@ describe('EtablertTilsynMedSmoring helpers', () => {
     const uker = finnUker(etablert);
     const grupper = grupperTilsynPerUke(uker, etablert, smurt);
     expect(grupper.length).toBe(2);
-    expect(grupper[0].uke).toBe(1);
-    expect(grupper[0].etablertTilsyn[0].periode.fom).toBe('2024-01-02');
-    expect(grupper[1].uke).toBe(2);
+    expect(grupper[0].uke).toBe(2);
+    expect(grupper[0].etablertTilsyn[0].periode.fom).toBe('2024-01-10');
+    expect(grupper[1].uke).toBe(1);
   });
 
   it('splittSmurtePerioder deler i sammenhengende blokker og skiller på hull / tidPerDag', () => {

--- a/packages/fakta-etablert-tilsyn/src/ui/components/etablertTilsyn/EtablertTilsynMedSmoring.helpers.spec.ts
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/etablertTilsyn/EtablertTilsynMedSmoring.helpers.spec.ts
@@ -42,14 +42,30 @@ describe('EtablertTilsynMedSmoring helpers', () => {
     expect(enkeltdager.every(e => e.periode.fom === e.periode.tom)).toBe(true);
   });
 
-  it('finnUker returnerer unike uker i kronologisk rekkefølge', () => {
+  it('finnUker returnerer unike uke+år i kronologisk rekkefølge', () => {
     const tilsyn = [
       lagTilsyn('2024-01-02', '2024-01-02', 5, Kilde.SØKER), // uke 1 (antatt ISO)
       lagTilsyn('2024-01-10', '2024-01-10', 5, Kilde.SØKER), // uke 2
       lagTilsyn('2024-01-11', '2024-01-11', 5, Kilde.SØKER), // uke 2
     ];
     const uker = finnUker(tilsyn);
-    expect(uker).toEqual([1, 2]);
+    expect(uker).toEqual([
+      { uke: 1, år: 2024 },
+      { uke: 2, år: 2024 },
+    ]);
+  });
+
+  it('finnUker skiller like ukenummer på ulike år', () => {
+    const tilsyn = [
+      lagTilsyn('2022-08-15', '2022-08-15', 5, Kilde.SØKER),
+      lagTilsyn('2023-08-14', '2023-08-14', 5, Kilde.SØKER),
+    ];
+
+    const uker = finnUker(tilsyn);
+    expect(uker).toEqual([
+      { uke: 33, år: 2022 },
+      { uke: 33, år: 2023 },
+    ]);
   });
 
   it('grupperTilsynPerUke grupperer riktig', () => {
@@ -93,6 +109,7 @@ describe('EtablertTilsynMedSmoring helpers', () => {
           lagTilsyn('2024-05-03', '2024-05-03', 3, Kilde.SØKER), // hull -> ny gruppe
         ],
         uke: 18,
+        år: 2024,
       },
     ];
     const oppdelt = byggOppdeltSmoring(ukeGrupper);
@@ -100,26 +117,28 @@ describe('EtablertTilsynMedSmoring helpers', () => {
     expect(oppdelt.map(o => o.delAvUke)).toEqual([1, 2]);
   });
 
-  it('flettOgSorterTilsyn fletter og sorterer kronologisk', () => {
+  it('flettOgSorterTilsyn fletter og sorterer med nyeste først', () => {
     const perUke = [
       {
         etablertTilsyn: [lagTilsyn('2024-06-10', '2024-06-10', 5, Kilde.SØKER)],
         etablertTilsynSmurt: [lagTilsyn('2024-06-10', '2024-06-10', 3, Kilde.SØKER)],
         uke: 24,
+        år: 2024,
       },
       {
         etablertTilsyn: [lagTilsyn('2024-06-01', '2024-06-01', 5, Kilde.SØKER)],
         etablertTilsynSmurt: [lagTilsyn('2024-06-01', '2024-06-01', 3, Kilde.SØKER)],
         uke: 23,
+        år: 2024,
       },
     ];
     const oppdelt = byggOppdeltSmoring(perUke);
     const flettet = flettOgSorterTilsyn(perUke, oppdelt);
-    expect(flettet[0].etablertTilsynSmurt[0].periode.fom).toBe('2024-06-01');
-    expect(flettet[1].etablertTilsynSmurt[0].periode.fom).toBe('2024-06-10');
+    expect(flettet[0].etablertTilsynSmurt[0].periode.fom).toBe('2024-06-10');
+    expect(flettet[1].etablertTilsynSmurt[0].periode.fom).toBe('2024-06-01');
   });
 
-  it('flettOgSorterTilsyn håndterer oppdelt smøring og enkel uke etterpå', () => {
+  it('flettOgSorterTilsyn håndterer oppdelt smøring og enkel uke etterpå med nyeste først', () => {
     const perUke = [
       {
         etablertTilsyn: [lagTilsyn('2024-07-01', '2024-07-01', 5, Kilde.SØKER)],
@@ -128,19 +147,21 @@ describe('EtablertTilsynMedSmoring helpers', () => {
           lagTilsyn('2024-07-03', '2024-07-03', 3, Kilde.SØKER), // hull -> egen gruppe
         ],
         uke: 27,
+        år: 2024,
       },
       {
         etablertTilsyn: [lagTilsyn('2024-07-08', '2024-07-08', 5, Kilde.SØKER)],
         etablertTilsynSmurt: [lagTilsyn('2024-07-08', '2024-07-08', 3, Kilde.SØKER)],
         uke: 28,
+        år: 2024,
       },
     ];
     const oppdelt = byggOppdeltSmoring(perUke);
     const flettet = flettOgSorterTilsyn(perUke, oppdelt);
     const fomRekkefolge = flettet.map(f => f.etablertTilsynSmurt[0].periode.fom);
-    expect(fomRekkefolge).toEqual(['2024-07-01', '2024-07-03', '2024-07-08']);
-    expect(flettet[0].delAvUke).toBe(1);
+    expect(fomRekkefolge).toEqual(['2024-07-08', '2024-07-03', '2024-07-01']);
+    expect(flettet[0].delAvUke).toBeUndefined();
     expect(flettet[1].delAvUke).toBe(2);
-    expect(flettet[2].delAvUke).toBeUndefined();
+    expect(flettet[2].delAvUke).toBe(1);
   });
 });

--- a/packages/fakta-etablert-tilsyn/src/ui/components/etablertTilsyn/EtablertTilsynMedSmoring.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/etablertTilsyn/EtablertTilsynMedSmoring.tsx
@@ -71,7 +71,7 @@ export const ekspanderTilEnkeltdager = (
       .map(date => ({ ...v, periode: new Period(date, date) })),
   );
 
-// Henter uke-nummer for alle enkeltdager (unike)
+// Henter uke-nøkler for alle enkeltdager og sorterer dem omvendt kronologisk
 export const finnUker = (enkeltdager: EtablertTilsynType[]): UkeNøkkel[] => {
   const uker = new Map<string, UkeNøkkel>();
   enkeltdager.forEach(d => {
@@ -79,7 +79,8 @@ export const finnUker = (enkeltdager: EtablertTilsynType[]): UkeNøkkel[] => {
     const år = dayjs(d.periode.fom).year();
     uker.set(`${år}-${uke}`, { uke, år });
   });
-  return [...uker.values()];
+  // ukessammenligning skjer kun hvis år er lik, ellers sorteres på år først
+  return [...uker.values()].sort((a, b) => b.år - a.år || b.uke - a.uke);
 };
 
 // Grupperer tilsyn per uke

--- a/packages/fakta-etablert-tilsyn/src/ui/components/etablertTilsyn/EtablertTilsynMedSmoring.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/etablertTilsyn/EtablertTilsynMedSmoring.tsx
@@ -18,6 +18,7 @@ export interface EtablertTilsynMappet {
   etablertTilsyn: EtablertTilsynType[];
   etablertTilsynSmurt: EtablertTilsynType[];
   uke: number;
+  år: number;
   delAvUke?: number;
 }
 
@@ -25,6 +26,12 @@ export interface TilsynPerUke {
   etablertTilsyn: EtablertTilsynType[];
   etablertTilsynSmurt: EtablertTilsynType[];
   uke: number;
+  år: number;
+}
+
+export interface UkeNøkkel {
+  uke: number;
+  år: number;
 }
 
 export const erHelg = (dag: string) => [6, 0].includes(dayjs(dag).day());
@@ -65,20 +72,27 @@ export const ekspanderTilEnkeltdager = (
   );
 
 // Henter uke-nummer for alle enkeltdager (unike)
-export const finnUker = (enkeltdager: EtablertTilsynType[]): number[] => [
-  ...new Set(enkeltdager.map(d => dayjs(d.periode.fom).week())),
-];
+export const finnUker = (enkeltdager: EtablertTilsynType[]): UkeNøkkel[] => {
+  const uker = new Map<string, UkeNøkkel>();
+  enkeltdager.forEach(d => {
+    const uke = dayjs(d.periode.fom).week();
+    const år = dayjs(d.periode.fom).year();
+    uker.set(`${år}-${uke}`, { uke, år });
+  });
+  return [...uker.values()];
+};
 
 // Grupperer tilsyn per uke
 export const grupperTilsynPerUke = (
-  uker: number[],
+  uker: UkeNøkkel[],
   etablerte: EtablertTilsynType[],
   smurte: EtablertTilsynType[],
 ): TilsynPerUke[] =>
-  uker.map(uke => ({
-    etablertTilsyn: etablerte.filter(v => dayjs(v.periode.fom).week() === uke),
-    etablertTilsynSmurt: smurte.filter(v => dayjs(v.periode.fom).week() === uke),
+  uker.map(({ uke, år }) => ({
+    etablertTilsyn: etablerte.filter(v => dayjs(v.periode.fom).week() === uke && dayjs(v.periode.fom).year() === år),
+    etablertTilsynSmurt: smurte.filter(v => dayjs(v.periode.fom).week() === uke && dayjs(v.periode.fom).year() === år),
     uke,
+    år,
   }));
 
 // Deler smurte perioder i sammenhengende blokker basert på tidPerDag og kronologi
@@ -107,6 +121,7 @@ export const byggOppdeltSmoring = (perUke: TilsynPerUke[]): EtablertTilsynMappet
         etablertTilsyn: v.etablertTilsyn,
         etablertTilsynSmurt: gruppe,
         uke: v.uke,
+        år: v.år,
         delAvUke: arr.length > 1 ? idx + 1 : undefined,
       });
     });
@@ -126,8 +141,8 @@ export const flettOgSorterTilsyn = (
   const samlet: EtablertTilsynMappet[] = [...utenOppdelt.map(v => ({ ...v })), ...oppdelt];
   return samlet.sort(
     (a, b) =>
-      new Date(a.etablertTilsynSmurt[0]?.periode?.fom).getTime() -
-      new Date(b.etablertTilsynSmurt[0]?.periode?.fom).getTime(),
+      new Date(b.etablertTilsynSmurt[0]?.periode?.fom).getTime() -
+      new Date(a.etablertTilsynSmurt[0]?.periode?.fom).getTime(),
   );
 };
 
@@ -203,7 +218,7 @@ const EtablertTilsyn = ({
             const parter = tilsyn.etablertTilsyn.map(v => v.kilde);
             return (
               <Table.ExpandableRow
-                key={ukeVisning(tilsyn.uke, tilsyn.delAvUke)}
+                key={`${tilsyn.år}-${ukeVisning(tilsyn.uke, tilsyn.delAvUke)}`}
                 content={
                   <EtablertTilsynRowContent
                     etablertTilsyn={tilsyn.etablertTilsyn}


### PR DESCRIPTION
### Andre endringer
Dersom det er forskjellig tilsynsgrad innad i en uke skal vi dele opp uken på forskjellige rader i visningen og markere med A, B og evt C. Oppdaget en bug som har eksistert siden dette ble utviklet i 2022 hvor samme ukenummer på forskjellige år vurderes som samme uke i visningen. Har kun ført til merkelig oppførsel i hva som rendres i uke-kolonnen

Slik er det forventet at periodene splittes
<img width="949" height="295" alt="image" src="https://github.com/user-attachments/assets/97280799-2d38-4aff-8225-905bcc8f3ae7" />

Sånn ser den feilaktige visningen ut. Skulle blitt vist som uke 33 begge årene
<img width="859" height="285" alt="image" src="https://github.com/user-attachments/assets/83660495-f522-4926-88a6-257d50dd70b3" />
<img width="959" height="132" alt="image" src="https://github.com/user-attachments/assets/9bca253f-b445-4f34-9d7f-479ca10bef7a" />
