### PR TITLE
Chore/behandlingsvelger forbedringer

### DIFF
--- a/packages/v2/gui/src/sak/behandling-velger/BehandlingVelgerSakIndex.stories.tsx
+++ b/packages/v2/gui/src/sak/behandling-velger/BehandlingVelgerSakIndex.stories.tsx
@@ -4,7 +4,6 @@ import {
   k9_kodeverk_behandling_BehandlingStatus as BehandlingDtoStatus,
   k9_kodeverk_behandling_BehandlingType as BehandlingDtoType,
   k9_kodeverk_behandling_BehandlingResultatType as BehandlingsresultatDtoType,
-  type k9_sak_kontrakt_behandling_BehandlingDto as BehandlingDto,
 } from '@k9-sak-web/backend/k9sak/generated/types.js';
 import { behandlingType } from '@k9-sak-web/backend/k9sak/kodeverk/behandling/BehandlingType.js';
 import { fagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
@@ -14,44 +13,43 @@ import withKodeverkContext from '../../storybook/decorators/withKodeverkContext.
 import withMaxWidth from '../../storybook/decorators/withMaxWidth.js';
 import { FakeBehandlingVelgerBackendApi } from '../../storybook/mocks/FakeBehandlingVelgerBackendApi.js';
 import BehandlingVelgerSakV2 from './BehandlingVelgerSakIndex';
+import type { Behandling } from './types/Behandling';
+
+const createBehandling = ({
+  id,
+  status = BehandlingDtoStatus.AVSLUTTET,
+  type = BehandlingDtoType.REVURDERING,
+  ansvarligSaksbehandler = 'saksbeh',
+}: {
+  id: number;
+  status?: Behandling['status'];
+  type?: Behandling['type'];
+  ansvarligSaksbehandler?: Behandling['ansvarligSaksbehandler'];
+}): Behandling => ({
+  ansvarligSaksbehandler,
+  avsluttet: status === BehandlingDtoStatus.AVSLUTTET ? '2021-12-20T09:23:01' : undefined,
+  behandlingsresultat:
+    status === BehandlingDtoStatus.AVSLUTTET
+      ? {
+          erRevurderingMedUendretUtfall: false,
+          type: BehandlingsresultatDtoType.INNVILGET,
+          vilkårResultat: {},
+          vedtaksdato: '2021-12-20',
+        }
+      : undefined,
+  id,
+  links: [],
+  opprettet: '2021-12-20T09:22:38',
+  status,
+  type,
+  uuid: `${id}`,
+  sakstype: BehandlingDtoSakstype.PLEIEPENGER_SYKT_BARN,
+  behandlingÅrsaker: [],
+});
 
 const behandlinger = [
-  {
-    ansvarligSaksbehandler: 'beslut',
-    avsluttet: '2021-12-20T09:23:01',
-    behandlingsresultat: {
-      erRevurderingMedUendretUtfall: false,
-      type: BehandlingsresultatDtoType.INNVILGET,
-      vilkårResultat: {},
-      vedtaksdato: '2021-12-20',
-    } satisfies BehandlingDto['behandlingsresultat'],
-    id: 999955,
-    links: [],
-    opprettet: '2021-12-20T09:22:38',
-    status: BehandlingDtoStatus.AVSLUTTET,
-    type: BehandlingDtoType.REVURDERING,
-    uuid: '1',
-    sakstype: BehandlingDtoSakstype.PLEIEPENGER_SYKT_BARN,
-    behandlingÅrsaker: [],
-  },
-  {
-    ansvarligSaksbehandler: 'saksbeh',
-    avsluttet: '2021-12-20T09:22:36',
-    behandlingsresultat: {
-      erRevurderingMedUendretUtfall: false,
-      type: BehandlingsresultatDtoType.INNVILGET,
-      vilkårResultat: {},
-      vedtaksdato: '2021-12-20',
-    },
-    id: 999951,
-    links: [],
-    opprettet: '2021-12-20T09:21:41',
-    status: BehandlingDtoStatus.AVSLUTTET,
-    type: BehandlingDtoType.FØRSTEGANGSSØKNAD,
-    uuid: '1',
-    sakstype: BehandlingDtoSakstype.PLEIEPENGER_SYKT_BARN,
-    behandlingÅrsaker: [],
-  },
+  createBehandling({ id: 999955, type: BehandlingDtoType.REVURDERING, ansvarligSaksbehandler: 'beslut' }),
+  createBehandling({ id: 999951, type: BehandlingDtoType.FØRSTEGANGSSØKNAD }),
 ];
 
 const fagsak = {
@@ -66,6 +64,13 @@ const locationMock = {
   hash: 'test',
 };
 
+const getBehandlingLocation = (behandlingId: number) => ({
+  ...locationMock,
+  pathname: `/behandling/${behandlingId}`,
+  search: '',
+  hash: '',
+});
+
 const meta = {
   title: 'gui/sak/behandling-velger',
   component: BehandlingVelgerSakV2,
@@ -78,7 +83,7 @@ const api = new FakeBehandlingVelgerBackendApi();
 
 export const Default: StoryObj<typeof meta> = {
   args: {
-    getBehandlingLocation: () => locationMock,
+    getBehandlingLocation,
     fagsak,
     behandlinger,
     noExistingBehandlinger: false,
@@ -96,7 +101,7 @@ export const Default: StoryObj<typeof meta> = {
 
 export const IngenBehandlinger: StoryObj<typeof meta> = {
   args: {
-    getBehandlingLocation: () => locationMock,
+    getBehandlingLocation,
     fagsak,
     behandlinger: [],
     noExistingBehandlinger: true,
@@ -105,6 +110,90 @@ export const IngenBehandlinger: StoryObj<typeof meta> = {
   play: async ({ canvas, step }) => {
     await step('skal vise forklarende tekst når det ikke finnes behandlinger', async () => {
       await expect(canvas.getByText('Ingen behandlinger er opprettet')).toBeInTheDocument();
+    });
+  },
+};
+
+export const EnApenBehandling: StoryObj<typeof meta> = {
+  args: {
+    getBehandlingLocation,
+    fagsak,
+    behandlinger: [
+      createBehandling({ id: 1001, status: BehandlingDtoStatus.OPPRETTET }),
+      createBehandling({ id: 1002 }),
+    ],
+    noExistingBehandlinger: false,
+    api,
+  },
+  play: async ({ canvas, step }) => {
+    await step('skal velge åpen behandling automatisk', async () => {
+      await expect(canvas.getByText('Se alle behandlinger')).toBeInTheDocument();
+      await expect(canvas.queryByText('Velg behandling (2)')).not.toBeInTheDocument();
+    });
+  },
+};
+
+export const FlereApneBehandlinger: StoryObj<typeof meta> = {
+  args: {
+    getBehandlingLocation,
+    fagsak,
+    behandlinger: [
+      createBehandling({ id: 2001, status: BehandlingDtoStatus.OPPRETTET }),
+      createBehandling({ id: 2002, status: BehandlingDtoStatus.OPPRETTET }),
+      createBehandling({ id: 2003 }),
+    ],
+    noExistingBehandlinger: false,
+    api,
+  },
+  play: async ({ canvas, step }) => {
+    await step('skal vise alle behandlinger når man åpner listen', async () => {
+      await userEvent.click(canvas.getByText('Se alle behandlinger'));
+      await expect(canvas.getByText('Velg behandling (3)')).toBeInTheDocument();
+      await expect(canvas.getAllByTestId('BehandlingPickerItem')).toHaveLength(3);
+    });
+  },
+};
+
+export const ViserHentFlereBehandlingerKnapp: StoryObj<typeof meta> = {
+  args: {
+    getBehandlingLocation,
+    fagsak,
+    behandlinger: Array.from({ length: 11 }, (_, index) =>
+      createBehandling({
+        id: 3000 + index,
+        type: index % 2 === 0 ? BehandlingDtoType.REVURDERING : BehandlingDtoType.FØRSTEGANGSSØKNAD,
+      }),
+    ),
+    noExistingBehandlinger: false,
+    api,
+  },
+  play: async ({ canvas, step }) => {
+    await step('skal vise knapp for å hente flere behandlinger', async () => {
+      await expect(canvas.getByText('Hent flere behandlinger')).toBeInTheDocument();
+      await expect(canvas.getAllByTestId('BehandlingPickerItem')).toHaveLength(10);
+    });
+
+    await step('skal hente og vise flere behandlinger ved klikk', async () => {
+      await userEvent.click(canvas.getByText('Hent flere behandlinger'));
+      await expect(canvas.getAllByTestId('BehandlingPickerItem')).toHaveLength(11);
+    });
+  },
+};
+
+export const NavigasjonTilValgtBehandling: StoryObj<typeof meta> = {
+  args: {
+    getBehandlingLocation,
+    fagsak,
+    behandlinger,
+    noExistingBehandlinger: false,
+    api,
+  },
+  play: async ({ canvas, step }) => {
+    await step('skal navigere til valgt behandling via lenke', async () => {
+      const lenke = canvas.getByRole('link', { name: /2\. Viderebehandling/i });
+      await expect(lenke).toHaveAttribute('href', '/behandling/999955');
+      await userEvent.click(lenke);
+      await expect(canvas.getByText('Se alle behandlinger')).toBeInTheDocument();
     });
   },
 };

--- a/packages/v2/gui/src/sak/behandling-velger/components/BehandlingFilter.tsx
+++ b/packages/v2/gui/src/sak/behandling-velger/components/BehandlingFilter.tsx
@@ -40,28 +40,15 @@ const BehandlingFilter = ({ text, filters, aktiveFilter, onFilterChange }: Behan
       </Button>
     </ActionMenu.Trigger>
     <ActionMenu.Content>
-      {filters.toSorted(sortFilters).map(({ label, value }) => {
-        if (value === automatiskBehandling) {
-          return (
-            <ActionMenu.CheckboxItem
-              checked={aktiveFilter.includes(automatiskBehandling)}
-              onCheckedChange={() => onFilterChange(automatiskBehandling)}
-              key={value}
-            >
-              {label}
-            </ActionMenu.CheckboxItem>
-          );
-        }
-        return (
-          <ActionMenu.CheckboxItem
-            key={value}
-            checked={aktiveFilter.includes(value)}
-            onCheckedChange={() => onFilterChange(value)}
-          >
-            {label}
-          </ActionMenu.CheckboxItem>
-        );
-      })}
+      {filters.toSorted(sortFilters).map(({ label, value }) => (
+        <ActionMenu.CheckboxItem
+          key={value}
+          checked={aktiveFilter.includes(value)}
+          onCheckedChange={() => onFilterChange(value)}
+        >
+          {label}
+        </ActionMenu.CheckboxItem>
+      ))}
     </ActionMenu.Content>
   </ActionMenu>
 );

--- a/packages/v2/gui/src/sak/behandling-velger/components/BehandlingListItems.tsx
+++ b/packages/v2/gui/src/sak/behandling-velger/components/BehandlingListItems.tsx
@@ -1,0 +1,114 @@
+import { behandlingType as k9KlageBehandlingType } from '@k9-sak-web/backend/k9klage/kodeverk/behandling/BehandlingType.js';
+import {
+  k9_kodeverk_behandling_BehandlingStatus as BehandlingDtoStatus,
+  k9_kodeverk_behandling_BehandlingType as BehandlingDtoType,
+} from '@k9-sak-web/backend/k9sak/generated/types.js';
+import { ung_sak_kontrakt_behandling_BehandlingVisningsnavn } from '@k9-sak-web/backend/ungsak/generated/types.js';
+import { finnKodeverkTypeForBehandlingType } from '@k9-sak-web/gui/utils/behandlingUtils.js';
+import { formaterVisningsnavn } from '@k9-sak-web/gui/utils/formaterVisningsnavn.js';
+import { type KodeverkNavnFraKodeType, KodeverkType } from '@k9-sak-web/lib/kodeverk/types.js';
+import { type UseQueryResult } from '@tanstack/react-query';
+import { type Location } from 'history';
+import { type Dispatch, type ReactElement, type SetStateAction } from 'react';
+import { NavLink } from 'react-router';
+import type { Behandling } from '../types/Behandling';
+import type { PerioderMedBehandlingsId } from '../types/PerioderMedBehandlingsId';
+import { automatiskBehandling } from './BehandlingFilter';
+import BehandlingPickerItemContent from './BehandlingPickerItemContent';
+import styles from './behandlingPicker.module.css';
+import { filterPerioderForBarnetillegg, filterPerioderForKontrollAvInntekt } from './behandlingVelgerUtils';
+
+export const getBehandlingNavn = (behandlingType: string, kodeverkNavnFraKode: KodeverkNavnFraKodeType) => {
+  switch (behandlingType) {
+    case BehandlingDtoType.FØRSTEGANGSSØKNAD:
+    case k9KlageBehandlingType.KLAGE:
+    case k9KlageBehandlingType.TILBAKEKREVING:
+    case k9KlageBehandlingType.REVURDERING_TILBAKEKREVING:
+      return kodeverkNavnFraKode(
+        behandlingType,
+        KodeverkType.BEHANDLING_TYPE,
+        finnKodeverkTypeForBehandlingType(behandlingType),
+      );
+    default:
+      return 'Viderebehandling';
+  }
+};
+
+export const erAutomatiskBehandlet = (behandling: Behandling) =>
+  !behandling.ansvarligSaksbehandler && behandling.status === BehandlingDtoStatus.AVSLUTTET;
+
+/**
+ * Henter søknadsperioder for valgt behandling.
+ * For "Kontroll av inntekt" behandlinger filtreres kun perioder med KONTROLL_AV_INNTEKT som årsak.
+ */
+export const getSøknadsperioderForValgtBehandling = (
+  søknadsperioder: UseQueryResult<PerioderMedBehandlingsId, unknown>[],
+  valgtBehandling?: Behandling,
+) => {
+  const dataForValgtBehandling = søknadsperioder.find(periode => periode.data?.id === valgtBehandling?.id)?.data;
+  if (valgtBehandling?.visningsnavn === ung_sak_kontrakt_behandling_BehandlingVisningsnavn.KONTROLL_AV_INNTEKT) {
+    return filterPerioderForKontrollAvInntekt(dataForValgtBehandling);
+  }
+  if (valgtBehandling?.visningsnavn === ung_sak_kontrakt_behandling_BehandlingVisningsnavn.ENDRING_AV_BARNETILLEGG) {
+    return filterPerioderForBarnetillegg(dataForValgtBehandling);
+  }
+  return dataForValgtBehandling?.perioder ?? [];
+};
+
+interface BehandlingListItemsProps {
+  behandlinger: Behandling[];
+  behandlingsnummerById: Map<number, number>;
+  getBehandlingLocation: (behandlingId: number) => Location;
+  setValgtBehandlingId: Dispatch<SetStateAction<number | undefined>>;
+  alleSøknadsperioder: UseQueryResult<PerioderMedBehandlingsId, unknown>[];
+  aktiveFilter: string[];
+  kodeverkNavnFraKode: KodeverkNavnFraKodeType;
+}
+
+const BehandlingListItems = ({
+  behandlinger,
+  behandlingsnummerById,
+  getBehandlingLocation,
+  setValgtBehandlingId,
+  alleSøknadsperioder,
+  aktiveFilter,
+  kodeverkNavnFraKode,
+}: BehandlingListItemsProps): ReactElement[] => {
+  const filtrerte = behandlinger.filter(behandling => {
+    if (aktiveFilter.length === 0) {
+      return true;
+    }
+    if (aktiveFilter.includes(automatiskBehandling)) {
+      return erAutomatiskBehandlet(behandling);
+    }
+    return aktiveFilter.includes(behandling.type);
+  });
+
+  return filtrerte.map(behandling => {
+    const visningsnavn = formaterVisningsnavn(behandling.visningsnavn);
+    const globalIndex = behandlingsnummerById.get(behandling.id) ?? 0;
+    return (
+      <li data-testid="BehandlingPickerItem" key={behandling.id}>
+        <NavLink
+          onClick={() => setValgtBehandlingId(behandling.id)}
+          className={styles.linkToBehandling}
+          to={getBehandlingLocation(behandling.id)}
+        >
+          <BehandlingPickerItemContent
+            behandling={behandling}
+            behandlingTypeNavn={
+              behandling.type !== BehandlingDtoType.FØRSTEGANGSSØKNAD && visningsnavn
+                ? visningsnavn
+                : getBehandlingNavn(behandling.type, kodeverkNavnFraKode)
+            }
+            erAutomatiskRevurdering={erAutomatiskBehandlet(behandling)}
+            søknadsperioder={getSøknadsperioderForValgtBehandling(alleSøknadsperioder, behandling)}
+            index={globalIndex}
+          />
+        </NavLink>
+      </li>
+    );
+  });
+};
+
+export default BehandlingListItems;

--- a/packages/v2/gui/src/sak/behandling-velger/components/BehandlingPicker.tsx
+++ b/packages/v2/gui/src/sak/behandling-velger/components/BehandlingPicker.tsx
@@ -123,7 +123,7 @@ const BehandlingPicker = ({
     if (indexOfValgtBehandling > -1 && indexOfValgtBehandling + 1 > numberOfBehandlingperioderToFetch) {
       setNumberOfBehandlingPerioderToFetch(indexOfValgtBehandling + 1);
     }
-  }, [valgtBehandlingId, sorterteBehandlinger]);
+  }, [valgtBehandlingId, sorterteBehandlinger, numberOfBehandlingperioderToFetch]);
 
   const behandlingerSomSkalVises = useMemo(() => {
     return getBehandlingerSomSkalVises(

--- a/packages/v2/gui/src/sak/behandling-velger/components/BehandlingPicker.tsx
+++ b/packages/v2/gui/src/sak/behandling-velger/components/BehandlingPicker.tsx
@@ -1,130 +1,35 @@
-import { behandlingType as k9KlageBehandlingType } from '@k9-sak-web/backend/k9klage/kodeverk/behandling/BehandlingType.js';
 import {
   k9_kodeverk_behandling_BehandlingStatus as BehandlingDtoStatus,
   k9_kodeverk_behandling_BehandlingType as BehandlingDtoType,
 } from '@k9-sak-web/backend/k9sak/generated/types.js';
-import { ung_sak_kontrakt_behandling_BehandlingVisningsnavn } from '@k9-sak-web/backend/ungsak/generated/types.js';
 import { useKodeverkContext } from '@k9-sak-web/gui/kodeverk/index.js';
 import { finnKodeverkTypeForBehandlingType } from '@k9-sak-web/gui/utils/behandlingUtils.js';
 import { formaterVisningsnavn } from '@k9-sak-web/gui/utils/formaterVisningsnavn.js';
-import { type KodeverkNavnFraKodeType, KodeverkType } from '@k9-sak-web/lib/kodeverk/types.js';
-import { ChevronLeftIcon } from '@navikt/aksel-icons';
-import { AddCircle } from '@navikt/ds-icons';
+import { KodeverkType } from '@k9-sak-web/lib/kodeverk/types.js';
+import { ChevronLeftIcon, PlusCircleIcon } from '@navikt/aksel-icons';
 import { BodyShort, Button, Heading } from '@navikt/ds-react';
-import { type UseQueryResult, useQueries } from '@tanstack/react-query';
+import { useQueries } from '@tanstack/react-query';
 import { type Location } from 'history';
-import { type ReactElement, useEffect, useMemo, useRef, useState } from 'react';
-import { NavLink, useNavigate } from 'react-router';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router';
 import type { BehandlingVelgerBackendApiType } from '../BehandlingVelgerBackendApiType';
 import type { Behandling } from '../types/Behandling';
-import type { PerioderMedBehandlingsId } from '../types/PerioderMedBehandlingsId';
 import BehandlingFilter, { automatiskBehandling } from './BehandlingFilter';
-import BehandlingPickerItemContent from './BehandlingPickerItemContent';
+import BehandlingListItems, {
+  erAutomatiskBehandlet,
+  getBehandlingNavn,
+  getSøknadsperioderForValgtBehandling,
+} from './BehandlingListItems';
 import BehandlingSelected from './BehandlingSelected';
 import styles from './behandlingPicker.module.css';
-import {
-  filterPerioderForBarnetillegg,
-  filterPerioderForKontrollAvInntekt,
-  sortBehandlinger,
-} from './behandlingVelgerUtils';
-
-const getBehandlingNavn = (behandlingType: string, kodeverkNavnFraKode: KodeverkNavnFraKodeType) => {
-  switch (behandlingType) {
-    case BehandlingDtoType.FØRSTEGANGSSØKNAD:
-    case k9KlageBehandlingType.KLAGE:
-    case k9KlageBehandlingType.TILBAKEKREVING:
-    case k9KlageBehandlingType.REVURDERING_TILBAKEKREVING:
-      return kodeverkNavnFraKode(
-        behandlingType,
-        KodeverkType.BEHANDLING_TYPE,
-        finnKodeverkTypeForBehandlingType(behandlingType),
-      );
-    default:
-      return 'Viderebehandling';
-  }
-};
-
-const erAutomatiskBehandlet = (behandling: Behandling) =>
-  !behandling.ansvarligSaksbehandler && behandling.status === BehandlingDtoStatus.AVSLUTTET;
-
-/**
- * Henter søknadsperioder for valgt behandling.
- * For "Kontroll av inntekt" behandlinger filtreres kun perioder med KONTROLL_AV_INNTEKT som årsak.
- */
-const getSøknadsperioderForValgtBehandling = (
-  søknadsperioder: UseQueryResult<PerioderMedBehandlingsId, unknown>[],
-  valgtBehandling?: Behandling,
-) => {
-  const dataForValgtBehandling = søknadsperioder.find(periode => periode.data?.id === valgtBehandling?.id)?.data;
-  if (valgtBehandling?.visningsnavn === ung_sak_kontrakt_behandling_BehandlingVisningsnavn.KONTROLL_AV_INNTEKT) {
-    return filterPerioderForKontrollAvInntekt(dataForValgtBehandling);
-  }
-  if (valgtBehandling?.visningsnavn === ung_sak_kontrakt_behandling_BehandlingVisningsnavn.ENDRING_AV_BARNETILLEGG) {
-    return filterPerioderForBarnetillegg(dataForValgtBehandling);
-  }
-  return dataForValgtBehandling?.perioder ?? [];
-};
-
-const renderListItems = ({
-  behandlinger,
-  behandlingsnummerById,
-  getBehandlingLocation,
-  setValgtBehandlingId,
-  alleSøknadsperioder,
-  aktiveFilter,
-  kodeverkNavnFraKode,
-}: {
-  behandlinger: Behandling[];
-  behandlingsnummerById: Map<number, number>;
-  getBehandlingLocation: (behandlingId: number) => Location;
-  setValgtBehandlingId: React.Dispatch<React.SetStateAction<number | undefined>>;
-  alleSøknadsperioder: UseQueryResult<PerioderMedBehandlingsId, unknown>[];
-  aktiveFilter: string[];
-  kodeverkNavnFraKode: KodeverkNavnFraKodeType;
-}): ReactElement<void>[] => {
-  const sorterteOgFiltrerteBehandlinger = behandlinger.filter(behandling => {
-    if (aktiveFilter.length === 0) {
-      return true;
-    }
-    if (aktiveFilter.includes(automatiskBehandling)) {
-      return erAutomatiskBehandlet(behandling);
-    }
-    return aktiveFilter.includes(behandling.type);
-  });
-
-  return sorterteOgFiltrerteBehandlinger.map(behandling => {
-    const visningsnavn = formaterVisningsnavn(behandling.visningsnavn);
-    const globalIndex = behandlingsnummerById.get(behandling.id) ?? 0;
-    return (
-      <li data-testid="BehandlingPickerItem" key={behandling.id}>
-        <NavLink
-          onClick={() => setValgtBehandlingId(behandling.id)}
-          className={styles.linkToBehandling}
-          to={getBehandlingLocation(behandling.id)}
-        >
-          <BehandlingPickerItemContent
-            behandling={behandling}
-            behandlingTypeNavn={
-              behandling.type !== BehandlingDtoType.FØRSTEGANGSSØKNAD && visningsnavn
-                ? visningsnavn
-                : getBehandlingNavn(behandling.type, kodeverkNavnFraKode)
-            }
-            erAutomatiskRevurdering={erAutomatiskBehandlet(behandling)}
-            søknadsperioder={getSøknadsperioderForValgtBehandling(alleSøknadsperioder, behandling)}
-            index={globalIndex}
-          />
-        </NavLink>
-      </li>
-    );
-  });
-};
+import { sortBehandlinger } from './behandlingVelgerUtils';
 
 const usePrevious = (value: number | undefined): number | undefined => {
   const ref = useRef<number>(undefined);
   useEffect(() => {
     ref.current = value;
   });
-  return ref.current ?? undefined;
+  return ref.current;
 };
 
 const behandlingPerioderÅrsakRel = 'behandling-perioder-årsak-med-vilkår';
@@ -187,8 +92,9 @@ const BehandlingPicker = ({
       }
     };
     void effect();
-  }, [behandlingId, åpenBehandlingId, firstRender.current]);
+  }, [behandlingId, åpenBehandlingId]);
 
+  // Side-effekt-fri beregning av hvilke behandlinger som skal vises
   const getBehandlingerSomSkalVises = (
     sorterteBehandlinger: Behandling[],
     valgtBehandlingId: number | undefined,
@@ -198,9 +104,6 @@ const BehandlingPicker = ({
     const indexOfValgtBehandling = sorterteBehandlinger.findIndex(behandling => behandling.id === valgtBehandlingId);
     const valgtBehandlingFinnes = indexOfValgtBehandling > -1;
     if (valgtBehandlingFinnes) {
-      if (indexOfValgtBehandling + 1 > numberOfBehandlingperioderToFetch) {
-        setNumberOfBehandlingPerioderToFetch(indexOfValgtBehandling + 1);
-      }
       // Returner valgt behandling
       return sorterteBehandlinger.slice(indexOfValgtBehandling, indexOfValgtBehandling + 1);
     }
@@ -213,6 +116,14 @@ const BehandlingPicker = ({
   };
 
   const sorterteBehandlinger = useMemo(() => sortBehandlinger(behandlinger), [behandlinger]);
+
+  // Utvid grensen dersom valgt behandling er utenfor gjeldende vindu
+  useEffect(() => {
+    const indexOfValgtBehandling = sorterteBehandlinger.findIndex(b => b.id === valgtBehandlingId);
+    if (indexOfValgtBehandling > -1 && indexOfValgtBehandling + 1 > numberOfBehandlingperioderToFetch) {
+      setNumberOfBehandlingPerioderToFetch(indexOfValgtBehandling + 1);
+    }
+  }, [valgtBehandlingId, sorterteBehandlinger]);
 
   const behandlingerSomSkalVises = useMemo(() => {
     return getBehandlingerSomSkalVises(
@@ -262,48 +173,47 @@ const BehandlingPicker = ({
     }
   };
 
-  const getFilterListe = () => {
-    const filterListe: { value: string; label: string }[] = [];
+  const filterListe = useMemo(() => {
+    const result: { value: string; label: string }[] = [];
     behandlinger.forEach(behandling => {
-      if (!filterListe.some(filter => filter.value === behandling.type)) {
+      if (!result.some(filter => filter.value === behandling.type)) {
         const visningsnavn = formaterVisningsnavn(behandling.visningsnavn);
-        filterListe.push({
+        result.push({
           value: behandling.type,
           label: visningsnavn || getBehandlingNavn(behandling.type, kodeverkNavnFraKode),
         });
       }
-      if (erAutomatiskBehandlet(behandling) && !filterListe.some(filter => filter.value === automatiskBehandling)) {
-        filterListe.push({
+      if (erAutomatiskBehandlet(behandling) && !result.some(filter => filter.value === automatiskBehandling)) {
+        result.push({
           value: automatiskBehandling,
           label: 'Automatisk behandling',
         });
       }
     });
-    return filterListe;
-  };
+    return result;
+  }, [behandlinger, kodeverkNavnFraKode]);
 
-  const getÅrsaksliste = (): string[] => {
-    const søknadsperiode = søknadsperioder.find(periode => periode.data?.id === valgtBehandling?.id);
-    if (!søknadsperiode) {
+  const valgtSøknadsperiodeData = søknadsperioder.find(periode => periode.data?.id === valgtBehandling?.id)?.data;
+
+  const årsaksliste = useMemo((): string[] => {
+    if (!valgtSøknadsperiodeData) {
       return [];
     }
     const årsaker: string[] = [];
-    if (søknadsperiode.data) {
-      søknadsperiode.data.perioderMedÅrsak.toReversed().forEach(periode =>
-        periode.årsaker
-          ?.filter(årsak => årsak !== null)
-          .forEach(årsak => {
-            // TODO: try/catch skal ikke være nødvendig etter at backend har lagt inn alle behandlingsårsaker
-            try {
-              årsaker.push(kodeverkNavnFraKode(årsak, KodeverkType.ÅRSAK_TIL_VURDERING));
-            } catch {
-              årsaker.push(årsak);
-            }
-          }),
-      );
-    }
+    valgtSøknadsperiodeData.perioderMedÅrsak.toReversed().forEach(periode =>
+      periode.årsaker
+        ?.filter(årsak => årsak !== null)
+        .forEach(årsak => {
+          // TODO: try/catch skal ikke være nødvendig etter at backend har lagt inn alle behandlingsårsaker
+          try {
+            årsaker.push(kodeverkNavnFraKode(årsak, KodeverkType.ÅRSAK_TIL_VURDERING));
+          } catch {
+            årsaker.push(årsak);
+          }
+        }),
+    );
     return årsaker;
-  };
+  }, [valgtSøknadsperiodeData, kodeverkNavnFraKode]);
 
   return (
     <div className={styles.behandlingPicker} data-testid="BehandlingPicker">
@@ -327,7 +237,7 @@ const BehandlingPicker = ({
               {`Velg behandling (${behandlinger.length})`}
             </Heading>
             <BehandlingFilter
-              filters={getFilterListe()}
+              filters={filterListe}
               aktiveFilter={aktiveFilter}
               onFilterChange={updateFilter}
               text="Filtrer"
@@ -339,16 +249,17 @@ const BehandlingPicker = ({
                 Ingen behandlinger er opprettet
               </BodyShort>
             )}
-            {!noExistingBehandlinger &&
-              renderListItems({
-                behandlinger: behandlingerSomSkalVises,
-                behandlingsnummerById,
-                getBehandlingLocation,
-                setValgtBehandlingId,
-                alleSøknadsperioder: søknadsperioder,
-                aktiveFilter,
-                kodeverkNavnFraKode,
-              })}
+            {!noExistingBehandlinger && (
+              <BehandlingListItems
+                behandlinger={behandlingerSomSkalVises}
+                behandlingsnummerById={behandlingsnummerById}
+                getBehandlingLocation={getBehandlingLocation}
+                setValgtBehandlingId={setValgtBehandlingId}
+                alleSøknadsperioder={søknadsperioder}
+                aktiveFilter={aktiveFilter}
+                kodeverkNavnFraKode={kodeverkNavnFraKode}
+              />
+            )}
           </ul>
         </>
       )}
@@ -368,7 +279,7 @@ const BehandlingPicker = ({
           behandlingsresultatTypeKode={
             valgtBehandling.behandlingsresultat ? valgtBehandling.behandlingsresultat.type : undefined
           }
-          behandlingsårsaker={getÅrsaksliste()}
+          behandlingsårsaker={årsaksliste}
           behandlingTypeNavn={
             valgtBehandling.type !== BehandlingDtoType.FØRSTEGANGSSØKNAD &&
             formaterVisningsnavn(valgtBehandling.visningsnavn)
@@ -385,7 +296,7 @@ const BehandlingPicker = ({
         <Button
           variant="tertiary"
           onClick={() => setNumberOfBehandlingPerioderToFetch(numberOfBehandlingperioderToFetch + 10)}
-          icon={<AddCircle />}
+          icon={<PlusCircleIcon aria-hidden />}
           size="small"
           className="mt-5"
         >

--- a/packages/v2/gui/src/sak/behandling-velger/components/BehandlingPicker.tsx
+++ b/packages/v2/gui/src/sak/behandling-velger/components/BehandlingPicker.tsx
@@ -92,7 +92,7 @@ const BehandlingPicker = ({
       }
     };
     void effect();
-  }, [behandlingId, åpenBehandlingId]);
+  }, [behandlingId, åpenBehandlingId, firstRender.current]);
 
   // Side-effekt-fri beregning av hvilke behandlinger som skal vises
   const getBehandlingerSomSkalVises = (

--- a/packages/v2/gui/src/sak/behandling-velger/components/BehandlingPickerItemContent.tsx
+++ b/packages/v2/gui/src/sak/behandling-velger/components/BehandlingPickerItemContent.tsx
@@ -5,7 +5,7 @@ import { finnKodeverkTypeForBehandlingType } from '@k9-sak-web/gui/utils/behandl
 import { KodeverkType } from '@k9-sak-web/lib/kodeverk/types.js';
 import { CalendarIcon, ChevronRightIcon } from '@navikt/aksel-icons';
 import { BodyShort, Box, Heading, HStack } from '@navikt/ds-react';
-import React from 'react';
+import type { FC } from 'react';
 import DateLabel from '../../../shared/dateLabel/DateLabel';
 import type { Behandling } from '../types/Behandling';
 import type { K9UngPeriode } from '../types/PerioderMedBehandlingsId';
@@ -34,7 +34,7 @@ interface OwnProps {
  *
  * Presentasjonskomponent. Håndterer formatering av innholdet i den enkelte behandling i behandlingsvelgeren.
  */
-const BehandlingPickerItemContent: React.FC<OwnProps> = ({
+const BehandlingPickerItemContent: FC<OwnProps> = ({
   erAutomatiskRevurdering,
   behandlingTypeNavn,
   søknadsperioder,
@@ -107,11 +107,7 @@ const BehandlingPickerItemContent: React.FC<OwnProps> = ({
         </div>
         <div className={styles.åpneText}>
           <BodyShort size="small">Åpne</BodyShort>
-          <ChevronRightIcon
-            title="Åpne"
-            fontSize="1.5rem"
-            style={{ color: 'var(--ax-accent-600)', fontSize: '1.5rem' }}
-          />
+          <ChevronRightIcon title="Åpne" fontSize="1.5rem" className={styles.åpneChevron} />
         </div>
       </div>
     </Box>

--- a/packages/v2/gui/src/sak/behandling-velger/components/BehandlingSelected.tsx
+++ b/packages/v2/gui/src/sak/behandling-velger/components/BehandlingSelected.tsx
@@ -8,6 +8,7 @@ import { CalendarIcon } from '@navikt/aksel-icons';
 import { BodyShort, Heading, HStack, Label, Link } from '@navikt/ds-react';
 import { NavLink, useLocation } from 'react-router';
 import DateLabel from '../../../shared/dateLabel/DateLabel';
+import { createPathForSkjermlenke } from '../../../utils/skjermlenke/createPathForSkjermlenke.js';
 import type { K9UngPeriode } from '../types/PerioderMedBehandlingsId';
 import styles from './behandlingSelected.module.css';
 import {
@@ -16,7 +17,13 @@ import {
   getStatusIcon,
   getStatusText,
 } from './behandlingVelgerUtils';
-import { createPathForSkjermlenke } from '../../../utils/skjermlenke/createPathForSkjermlenke.js';
+
+const TILSTØTENDE_PERIODE = 'Tilstøtende periode';
+
+const ytelserMedFaktapanelSøknadsperioder = [
+  fagsakYtelsesType.PLEIEPENGER_SYKT_BARN,
+  fagsakYtelsesType.PLEIEPENGER_NÆRSTÅENDE,
+];
 
 interface BehandlingSelectedProps {
   opprettetDato: string;
@@ -55,7 +62,7 @@ const BehandlingSelected = ({
     }
     const funnedeÅrsaker: string[] = [];
     const unikeÅrsaker = behandlingsårsaker.filter(årsak => {
-      if (årsak === 'Tilstøtende periode') {
+      if (årsak === TILSTØTENDE_PERIODE) {
         return false;
       }
       const erDuplikat = funnedeÅrsaker.includes(årsak);
@@ -79,11 +86,6 @@ const BehandlingSelected = ({
       </div>
     );
   };
-
-  const ytelserMedFaktapanelSøknadsperioder = [
-    fagsakYtelsesType.PLEIEPENGER_SYKT_BARN,
-    fagsakYtelsesType.PLEIEPENGER_NÆRSTÅENDE,
-  ];
 
   const visLenkeTilFaktapanel = ytelserMedFaktapanelSøknadsperioder.some(ytelse => ytelse === sakstypeKode);
   const erEndringAvBarnetillegg =

--- a/packages/v2/gui/src/sak/behandling-velger/components/behandlingPicker.module.css
+++ b/packages/v2/gui/src/sak/behandling-velger/components/behandlingPicker.module.css
@@ -55,7 +55,7 @@
 
 .linkToBehandling:focus,
 .toggleShowAllButton:focus {
-  outline: none;
+  outline: revert;
 }
 
 .headerContainer {

--- a/packages/v2/gui/src/sak/behandling-velger/components/behandlingPickerItemContent.module.css
+++ b/packages/v2/gui/src/sak/behandling-velger/components/behandlingPickerItemContent.module.css
@@ -1,68 +1,7 @@
-.starImage {
-  cursor: pointer;
-  height: 20px;
-  margin-left: 10px;
-  width: 25px;
-}
-
-.resultatStatusImage {
-  height: 16px;
-  width: 16px;
-}
-
-.pushRight {
-  margin-left: auto;
-}
-
-.pushRightCorner {
-  margin-left: auto;
-  margin-top: auto;
-}
-
-.line {
-  border: 0;
-  border-top: 1px solid #c9c9c9;
-  height: 1px;
-}
-
-.arsakPadding {
-  padding: 0 0 0 8px;
-}
-
-.timePadding {
-  padding-left: 10px;
-}
-
-.resultatPadding {
-  padding-left: 5px;
-}
-
-.inline {
-  display: inline;
-}
-
-.firstColumnWidth {
-  width: 150px;
-}
-
 .behandlingPicker {
   align-items: center;
   display: flex;
   justify-content: space-between;
-}
-
-.behandlingPicker .dateContainer {
-  display: flex;
-  margin-top: 0.25rem;
-}
-
-.behandlingPicker .resultContainer {
-  display: flex;
-  margin-top: 0.5rem;
-}
-
-.behandlingPicker .resultContainer span {
-  margin-left: 0.25rem;
 }
 
 .behandlingPicker .åpneText {
@@ -73,12 +12,14 @@
 }
 
 .behandlingPicker .åpneChevron {
+  color: var(--ax-accent-600);
+  font-size: 1.5rem;
   margin-left: 0.5rem;
 }
 
-.behandlingPicker .kalenderIcon {
+.behandlingPicker .utfallImage {
   height: 1.25rem;
-  margin-right: 0.75rem;
+  margin-right: 0.625rem;
   margin-top: -0.125rem;
   width: 1.25rem;
 }
@@ -87,13 +28,6 @@
   font-size: 1.125rem;
   font-weight: 400;
   margin-left: 0.25rem;
-}
-
-.behandlingPicker .utfallImage {
-  height: 1.25rem;
-  margin-right: 0.625rem;
-  margin-top: -0.125rem;
-  width: 1.25rem;
 }
 
 .indent {

--- a/packages/v2/gui/src/sak/behandling-velger/components/behandlingPickerItemContent.module.d.css.ts
+++ b/packages/v2/gui/src/sak/behandling-velger/components/behandlingPickerItemContent.module.d.css.ts
@@ -1,24 +1,10 @@
 declare const styles: {
-  readonly "arsakPadding": string;
-  readonly "behandlingPicker": string;
-  readonly "dateContainer": string;
-  readonly "firstColumnWidth": string;
-  readonly "indent": string;
-  readonly "inline": string;
-  readonly "kalenderIcon": string;
-  readonly "line": string;
-  readonly "opprettetDatoContainer": string;
-  readonly "pushRight": string;
-  readonly "pushRightCorner": string;
-  readonly "resultContainer": string;
-  readonly "resultatPadding": string;
-  readonly "resultatStatusImage": string;
-  readonly "smallerUndertittel": string;
-  readonly "starImage": string;
-  readonly "timePadding": string;
-  readonly "utfallImage": string;
-  readonly "åpneChevron": string;
-  readonly "åpneText": string;
+  readonly behandlingPicker: string;
+  readonly indent: string;
+  readonly opprettetDatoContainer: string;
+  readonly smallerUndertittel: string;
+  readonly utfallImage: string;
+  readonly åpneChevron: string;
+  readonly åpneText: string;
 };
 export = styles;
-

--- a/packages/v2/gui/src/sak/behandling-velger/components/behandlingPickerItemContent.module.d.css.ts
+++ b/packages/v2/gui/src/sak/behandling-velger/components/behandlingPickerItemContent.module.d.css.ts
@@ -1,10 +1,11 @@
 declare const styles: {
-  readonly behandlingPicker: string;
-  readonly indent: string;
-  readonly opprettetDatoContainer: string;
-  readonly smallerUndertittel: string;
-  readonly utfallImage: string;
-  readonly åpneChevron: string;
-  readonly åpneText: string;
+  readonly "behandlingPicker": string;
+  readonly "indent": string;
+  readonly "opprettetDatoContainer": string;
+  readonly "smallerUndertittel": string;
+  readonly "utfallImage": string;
+  readonly "åpneChevron": string;
+  readonly "åpneText": string;
 };
 export = styles;
+

--- a/packages/v2/gui/src/sak/behandling-velger/components/behandlingVelgerUtils.tsx
+++ b/packages/v2/gui/src/sak/behandling-velger/components/behandlingVelgerUtils.tsx
@@ -5,7 +5,7 @@ import {
   ung_sak_kontrakt_krav_ÅrsakTilVurdering as UngÅrsakTilVurdering,
 } from '@k9-sak-web/backend/ungsak/generated/types.js';
 import { CheckmarkCircleFillIcon, ExclamationmarkTriangleFillIcon, XMarkOctagonFillIcon } from '@navikt/aksel-icons';
-import React from 'react';
+import { Fragment } from 'react';
 import DateLabel from '../../../shared/dateLabel/DateLabel';
 import type { Behandling } from '../types/Behandling';
 import type { K9UngPeriode, PerioderMedBehandlingsId } from '../types/PerioderMedBehandlingsId';
@@ -20,19 +20,19 @@ export const getFormattedSøknadserioder = (søknadsperioder: K9UngPeriode[], vi
     }
     if (periode.fom === periode.tom) {
       return (
-        <React.Fragment key={periode.fom}>
+        <Fragment key={periode.fom}>
           {index > 0 && ', '}
           <DateLabel dateString={periode.fom} />
-        </React.Fragment>
+        </Fragment>
       );
     }
     return (
-      <React.Fragment key={`${periode.fom}_${periode.tom}`}>
+      <Fragment key={`${periode.fom}_${periode.tom}`}>
         {index > 0 && ', '}
         <DateLabel dateString={periode.fom} />
         {` - `}
         <DateLabel dateString={periode.tom} />
-      </React.Fragment>
+      </Fragment>
     );
   });
 


### PR DESCRIPTION
**Opprydding og forbedringer** i BehandlingPicker

Gjennomgang og forbedring av BehandlingPicker og tilhørende komponenter i behandling-velger/. Endringene er rent refaktorering — ingen funksjonalitet er endret.

**Korrekthet**

- Fjernet side-effekt (setNumberOfBehandlingPerioderToFetch) fra ren beregningsfunksjon — flyttet til dedikert useEffect
- Stabilisert useMemo-avhengighet: useQueries returnerer ny array-referanse hver render; erstattet med stabil .data-referanse

**Tilgjengelighet**

- Fjernet outline: none på :focus (WCAG-brudd) — erstattet med outline: revert
- Komponentstruktur
- Trukket ut BehandlingListItems til egen fil — konsistent med eksisterende mønster i mappen
- Konvertert renderListItems-hjelpefunksjon til ekte React-komponent

**Ytelse**

- Memoisert filterListe og årsaksliste med useMemo
- Flyttet ytelserMedFaktapanelSøknadsperioder ut av renderingssyklusen

**Kodekvalitet**

- Erstattet utdatert AddCircle (@navikt/ds-icons) med PlusCircleIcon (@navikt/aksel-icons)
- Fjernet redundant if/else i BehandlingFilter (begge grener var identiske)
- Introdusert TILSTØTENDE_PERIODE-konstant — fjernet hardkodet streng
- Fjernet 10 ubrukte CSS-klasser
- Erstattet inline style-prop med CSS-klasse (.åpneChevron)
- Fjernet ubrukte importer