### PR TITLE
fix: retter feil i opptjening ved å legge på sjekk om opptjening finnes

### DIFF
--- a/packages/v2/gui/src/prosess/vilkar-opptjening/OpptjeningVilkarProsessIndex.tsx
+++ b/packages/v2/gui/src/prosess/vilkar-opptjening/OpptjeningVilkarProsessIndex.tsx
@@ -22,7 +22,7 @@ import type { SubmitCallback } from './types/SubmitCallback';
 interface OpptjeningVilkarProsessIndexProps {
   fagsak: Fagsak;
   behandling: Behandling;
-  opptjening: k9_sak_kontrakt_opptjening_OpptjeningerDto;
+  opptjening?: k9_sak_kontrakt_opptjening_OpptjeningerDto;
   aksjonspunkter: k9_sak_kontrakt_aksjonspunkt_AksjonspunktDto[];
   vilkar: k9_sak_kontrakt_vilkår_VilkårMedPerioderDto[];
   lovReferanse?: string;
@@ -36,7 +36,7 @@ const getIconForOpptjeningStatus = (
   vilkarStatus: VilkårPeriodeDtoVilkarStatus,
   isAksjonspunktOpen: boolean,
   periode: k9_sak_typer_Periode,
-  opptjeninger: k9_sak_kontrakt_opptjening_OpptjeningerDto['opptjeninger'],
+  opptjeninger?: k9_sak_kontrakt_opptjening_OpptjeningerDto['opptjeninger'],
 ) => {
   const vurderesIAksjonspunkt = opptjeninger && skalPeriodeVurderesIAksjonspunkt(periode, opptjeninger);
   if (vurderesIAksjonspunkt && isAksjonspunktOpen) {
@@ -87,7 +87,7 @@ const OpptjeningVilkarProsessIndex = ({
             links={perioder.map(({ periode, vilkarStatus }, index) => ({
               active: activeTab === index,
               label: `${formatDate(periode.fom)} - ${formatDate(periode.tom)}`,
-              icon: getIconForOpptjeningStatus(vilkarStatus, isAksjonspunktOpen, periode, opptjening.opptjeninger),
+              icon: getIconForOpptjeningStatus(vilkarStatus, isAksjonspunktOpen, periode, opptjening?.opptjeninger),
             }))}
             onClick={setActiveTab}
             heading="Perioder"


### PR DESCRIPTION
### Behov / Bakgrunn
Ønsker å rette feil som oppstår i prosesspanelet for opptjening når opptjening ikke finnes.
450/?project=38&project=105&project=31&project=176&query=is%3Aunresolved+issue.priority%3A[high%2C+medium]&referrer=issue-stream&statsPeriod=90d&stream_index=9

### Løsning
Legger på sjekk om opptjening er definert.

### Andre endringer

