### PR TITLE
fix: viser riktig tekst i vedtakssteget ved totrinn

### DIFF
--- a/packages/behandling-aktivitetspenger/src/components/Prosessmotor.spec.tsx
+++ b/packages/behandling-aktivitetspenger/src/components/Prosessmotor.spec.tsx
@@ -32,7 +32,7 @@ const createApi = (overrides?: ApiOverrides): AktivitetspengerApi =>
 
 const createVilkår = (vilkarStatus: Utfall, type: ung_kodeverk_vilkår_VilkårType) => ({
   vilkarType: type,
-  perioder: [{ vilkarStatus, periode: { fom: '2024-01-01', tom: '2024-01-31' } }],
+  perioder: [{ vilkarStatus, vurderesIBehandlingen: true, periode: { fom: '2024-01-01', tom: '2024-01-31' } }],
 });
 
 const createBehandling = (overrides = {}) => ({
@@ -147,6 +147,30 @@ describe('Prossesmotor', () => {
 
     await waitFor(() => {
       expect(result.current[4].type).toBe(ProcessMenuStepType.warning);
+    });
+  });
+
+  test('setter beregnet utbetaling til warning når panelet har åpent aksjonspunkt', async () => {
+    const api = createApi({
+      vilkår: [
+        createVilkår(Utfall.OPPFYLT, ung_kodeverk_vilkår_VilkårType.SØKNADSFRIST),
+        createVilkår(Utfall.OPPFYLT, ung_kodeverk_vilkår_VilkårType.FORUTGÅENDE_MEDLEMSKAPSVILKÅRET),
+      ],
+      aksjonspunkter: [
+        {
+          definisjon: AksjonspunktDefinisjon.KONTROLLER_INNTEKT,
+          status: aksjonspunktStatus.OPPRETTET,
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useProsessmotor({ api, behandling: createBehandling() }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current[2].type).toBe(ProcessMenuStepType.success);
+      expect(result.current[3].type).toBe(ProcessMenuStepType.warning);
     });
   });
 

--- a/packages/behandling-aktivitetspenger/src/components/Prosessmotor.ts
+++ b/packages/behandling-aktivitetspenger/src/components/Prosessmotor.ts
@@ -192,6 +192,23 @@ const beregnInngangsvilkårType = (aksjonspunkter: AksjonspunktDto[], vilkår: V
   return ProcessMenuStepType.success;
 };
 
+const beregnBeregnetUtbetalingType = (
+  beregningPanelType: ProcessMenuStepType,
+  aksjonspunkter: AksjonspunktDto[],
+  beregnetUtbetalingAksjonspunkter: readonly string[],
+): ProcessMenuStepType => {
+  if (beregningPanelType !== ProcessMenuStepType.success) {
+    return ProcessMenuStepType.default;
+  }
+
+  const harÅpentAksjonspunkt = aksjonspunkter?.some(
+    ap =>
+      beregnetUtbetalingAksjonspunkter.some(vap => vap === ap.definisjon) && ap.status && isAksjonspunktOpen(ap.status),
+  );
+
+  return harÅpentAksjonspunkt ? ProcessMenuStepType.warning : ProcessMenuStepType.success;
+};
+
 const byggInngangsvilkårPanel = (
   aksjonspunkter: AksjonspunktDto[],
   vilkår: VilkårMedPerioderDto[],
@@ -241,8 +258,11 @@ export const useProsessmotor = ({ api, behandling }: ProsessmotorProps) => {
     const beregnetUtbetalingPanel = {
       id: PANEL_KONFIG.beregnetUtbetaling.id,
       label: PANEL_KONFIG.beregnetUtbetaling.label,
-      type:
-        beregningPanel.type === ProcessMenuStepType.success ? ProcessMenuStepType.success : ProcessMenuStepType.default,
+      type: beregnBeregnetUtbetalingType(
+        beregningPanel.type,
+        aksjonspunkter,
+        PANEL_KONFIG.beregnetUtbetaling.aksjonspunkter,
+      ),
     };
     const vedtakType = beregnVedtakType(vilkår, aksjonspunkter, behandling, PANEL_KONFIG.vedtak.aksjonspunkter);
     const vedtakPanel = {

--- a/packages/behandling-aktivitetspenger/src/components/prosess/VedtakProsessStegInitPanel.tsx
+++ b/packages/behandling-aktivitetspenger/src/components/prosess/VedtakProsessStegInitPanel.tsx
@@ -87,6 +87,7 @@ export function VedtakProsessStegInitPanel({ api, behandling, onVedtakAksjonspun
     <UngVedtakIndex
       behandling={behandling}
       aksjonspunkter={vedtakAksjonspunkter}
+      totrinnAksjonspunkter={aksjonspunkter}
       vilkar={vilkår}
       isReadOnly={isReadOnly}
       vedtakBekreftelseCallback={bekreftAksjonspunktMutation}

--- a/packages/v2/gui/src/prosess/ung-vedtak/UngVedtak.tsx
+++ b/packages/v2/gui/src/prosess/ung-vedtak/UngVedtak.tsx
@@ -4,6 +4,7 @@ import {
   type ung_kodeverk_KodeverdiSomObjektUng_kodeverk_dokument_DokumentMalType,
   type ung_sak_kontrakt_formidling_vedtaksbrev_VedtaksbrevValgResponse as VedtaksbrevValgResponse,
 } from '@k9-sak-web/backend/ungsak/generated/types.js';
+import type { AksjonspunktDto } from '@k9-sak-web/backend/ungsak/kontrakt/aksjonspunkt/AksjonspunktDto.js';
 import { Alert, BodyShort, Box, Button, Label, VStack } from '@navikt/ds-react';
 import { RhfForm } from '@navikt/ft-form-hooks';
 import { useMutation, type QueryObserverResult, type RefetchOptions } from '@tanstack/react-query';
@@ -13,16 +14,17 @@ import ContentMaxWidth from '../../shared/ContentMaxWidth/ContentMaxWidth';
 import AvslagsårsakListe from './AvslagsårsakListe';
 import { FritekstBrevpanel } from './brev/FritekstBrevpanel';
 import type { FormData } from './FormData';
+import { type VedtakAksjonspunktDto, type VedtakBekreftetAksjonspunktDto } from './ungVedtakAksjonspunktAvgrensing.js';
 import type { UngVedtakBackendApiType } from './UngVedtakBackendApiType';
 import type { UngVedtakBehandlingDto } from './UngVedtakBehandlingDto';
 import type { UngVedtakTekster } from './UngVedtakTekster';
 import type { UngVedtakVilkårDto } from './UngVedtakVilkårDto';
-import { type VedtakAksjonspunktDto, type VedtakBekreftetAksjonspunktDto } from './ungVedtakAksjonspunktAvgrensing.js';
 
 type UngVedtakBekreftelseCallback = (bekreftet: VedtakBekreftetAksjonspunktDto[]) => Promise<void>;
 
 export interface UngVedtakProps {
   aksjonspunkter: VedtakAksjonspunktDto[];
+  totrinnAksjonspunkter?: Pick<AksjonspunktDto, 'erAktivt' | 'toTrinnsBehandling'>[];
   api: UngVedtakBackendApiType;
   behandling: UngVedtakBehandlingDto;
   vedtakBekreftelseCallback: UngVedtakBekreftelseCallback;
@@ -44,6 +46,7 @@ export const UngVedtak = ({
   api,
   behandling,
   aksjonspunkter,
+  totrinnAksjonspunkter,
   vedtakBekreftelseCallback,
   vilkår,
   readOnly,
@@ -58,8 +61,9 @@ export const UngVedtak = ({
   const behandlingErAvslått = behandling.behandlingsresultat?.type === BehandlingDtoBehandlingResultatType.AVSLÅTT;
   const behandlingErIkkeFastsatt =
     behandling.behandlingsresultat?.type === BehandlingDtoBehandlingResultatType.IKKE_FASTSATT;
+  const totrinnKilde = totrinnAksjonspunkter ?? aksjonspunkter;
   const harAksjonspunkt = aksjonspunkter.some(ap => ap.kanLoses);
-  const harAksjonspunktMedTotrinnsbehandling = aksjonspunkter.some(ap => ap.erAktivt === true && ap.toTrinnsBehandling);
+  const harAksjonspunktMedTotrinnsbehandling = totrinnKilde.some(ap => ap.erAktivt === true && ap.toTrinnsBehandling);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const {

--- a/packages/v2/gui/src/prosess/ung-vedtak/UngVedtakIndex.tsx
+++ b/packages/v2/gui/src/prosess/ung-vedtak/UngVedtakIndex.tsx
@@ -8,6 +8,7 @@ import type { UngVedtakVilkårDto } from './UngVedtakVilkårDto';
 
 export interface UngVedtakIndexProps {
   aksjonspunkter: UngVedtakProps['aksjonspunkter'];
+  totrinnAksjonspunkter?: UngVedtakProps['totrinnAksjonspunkter'];
   behandling: UngVedtakBehandlingDto;
   vedtakBekreftelseCallback: UngVedtakProps['vedtakBekreftelseCallback'];
   vilkar: UngVedtakVilkårDto[];
@@ -17,6 +18,7 @@ export interface UngVedtakIndexProps {
 
 export const UngVedtakIndex = ({
   aksjonspunkter,
+  totrinnAksjonspunkter,
   behandling,
   vedtakBekreftelseCallback,
   vilkar,
@@ -44,6 +46,7 @@ export const UngVedtakIndex = ({
       {!isLoading && (
         <UngVedtak
           aksjonspunkter={aksjonspunkter}
+          totrinnAksjonspunkter={totrinnAksjonspunkter}
           api={api}
           behandling={behandling}
           vedtakBekreftelseCallback={vedtakBekreftelseCallback}


### PR DESCRIPTION
### Behov / Bakgrunn
Knapp i vedtak viser "Fatt vedtak" når saken skal sendes til beslutter.
[TSFF-2697](https://nav.atlassian.net/browse/TSFF-2697)[TSFF-2697](https://nav.atlassian.net/browse/TSFF-2697)

### Løsning
Sender inn alle aksjonspunkt slik at totrinnssjekk blir riktig og knapp får riktig tekst.

### Andre endringer
Retting av visning av aksjonspunkt for steget Beregnet Utbetaling

