### PR TITLE
fix: viser paneler i lesemodus når de ikke har aksjonspunkt

### DIFF
--- a/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/AktivitetspengerInngangsvilkår.tsx
+++ b/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/AktivitetspengerInngangsvilkår.tsx
@@ -207,7 +207,7 @@ export const AktivitetspengerInngangsvilkår = ({
                 api={api}
                 behandling={behandling}
                 onAksjonspunktBekreftet={onAksjonspunktBekreftet}
-                isPermanentlyReadOnly={!!inngangsvilkårdata.lokalkontorBeslutterAp}
+                isPermanentlyReadOnly={!inngangsvilkårdata.bostedAp || !!inngangsvilkårdata.lokalkontorBeslutterAp}
                 bosattFakta={bosattFakta}
               />
             )}
@@ -222,7 +222,9 @@ export const AktivitetspengerInngangsvilkår = ({
                 api={api}
                 behandling={behandling}
                 onAksjonspunktBekreftet={onAksjonspunktBekreftet}
-                isPermanentlyReadOnly={!!inngangsvilkårdata.lokalkontorBeslutterAp}
+                isPermanentlyReadOnly={
+                  !inngangsvilkårdata.andreLivsoppholdytelserAp || !!inngangsvilkårdata.lokalkontorBeslutterAp
+                }
               />
             )}
           </Tabs.Panel>
@@ -236,7 +238,9 @@ export const AktivitetspengerInngangsvilkår = ({
                 behandling={behandling}
                 onAksjonspunktBekreftet={onAksjonspunktBekreftet}
                 readOnly={!kanSaksbehandle}
-                isPermanentlyReadOnly={!!inngangsvilkårdata.lokalkontorBeslutterAp}
+                isPermanentlyReadOnly={
+                  !inngangsvilkårdata.vurderBistandsvilkårAp || !!inngangsvilkårdata.lokalkontorBeslutterAp
+                }
               />
             )}
           </Tabs.Panel>

--- a/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/AndreLivsoppholdytelser.stories.tsx
+++ b/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/AndreLivsoppholdytelser.stories.tsx
@@ -5,6 +5,7 @@ import { vilkarType } from '@k9-sak-web/backend/ungsak/kodeverk/vilkår/VilkårT
 import type { AksjonspunktDto } from '@k9-sak-web/backend/ungsak/kontrakt/aksjonspunkt/AksjonspunktDto.js';
 import type { BehandlingDto } from '@k9-sak-web/backend/ungsak/kontrakt/behandling/BehandlingDto.js';
 import type { Meta, StoryObj } from '@storybook/react-vite';
+import { expect, within } from 'storybook/test';
 import { fakeAktivitetspengerApi } from '../../storybook/mocks/FakeAktivitetspengerApi';
 import { AndreLivsoppholdytelser } from './AndreLivsoppholdytelser';
 
@@ -117,5 +118,30 @@ export const FlerePerioder: Story = {
       AksjonspunktStatus.UTFØRT,
     ),
     isPermanentlyReadOnly: false,
+  },
+};
+
+export const MedKunVilkårUtenAksjonspunkt: Story = {
+  args: {
+    andreLivsoppholdytelserAp: undefined,
+    lokalkontorForeslårVilkårAp: undefined,
+    andreLivsoppholdytelserVilkår: {
+      vilkarType: vilkarType.ANDRE_LIVSOPPHOLDSYTELSER_VILKÅR,
+      perioder: [{ periode, vilkarStatus: Utfall.OPPFYLT, begrunnelse: 'Søker har ingen andre livsoppholdytelser.' }],
+    },
+    isPermanentlyReadOnly: true,
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('viser ikke advarsel når aksjonspunkt mangler', async () => {
+      await expect(
+        canvas.queryByText('Vurder om søker har andre livsoppholdsytelser på søknadstidspunktet.', { exact: false }),
+      ).not.toBeInTheDocument();
+    });
+
+    await step('viser ikke bekreft-knapp når panelet er permanent låst', async () => {
+      await expect(canvas.queryByRole('button', { name: 'Bekreft og fortsett' })).not.toBeInTheDocument();
+    });
   },
 };

--- a/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/AndreLivsoppholdytelser.tsx
+++ b/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/AndreLivsoppholdytelser.tsx
@@ -1,5 +1,4 @@
 import { AksjonspunktDefinisjon } from '@k9-sak-web/backend/ungsak/kodeverk/behandling/aksjonspunkt/AksjonspunktDefinisjon.js';
-import { AksjonspunktStatus } from '@k9-sak-web/backend/ungsak/kodeverk/behandling/aksjonspunkt/AksjonspunktStatus.js';
 import { Avslagsårsak } from '@k9-sak-web/backend/ungsak/kodeverk/vilkår/Avslagsårsak.js';
 import { Utfall } from '@k9-sak-web/backend/ungsak/kodeverk/vilkår/Utfall.js';
 import type { AksjonspunktDto } from '@k9-sak-web/backend/ungsak/kontrakt/aksjonspunkt/AksjonspunktDto.js';
@@ -75,7 +74,8 @@ export const AndreLivsoppholdytelser = ({
     periode: p.periode,
   }));
   const [selectedId, setSelectedId] = useState(periods[0]?.id ?? '');
-  const isAksjonspunktSolved = andreLivsoppholdytelserAp?.status === AksjonspunktStatus.UTFØRT;
+  const isAndreLivsoppholdytelserApSolved =
+    !andreLivsoppholdytelserAp || (andreLivsoppholdytelserAp && !aksjonspunktErÅpent(andreLivsoppholdytelserAp));
   const formHook = useForm<FormData>({
     defaultValues: buildInitialValues(andreLivsoppholdytelserVilkår),
   });
@@ -151,7 +151,7 @@ export const AndreLivsoppholdytelser = ({
 
   return (
     <VStack gap="space-20">
-      {!isAksjonspunktSolved && (
+      {!isAndreLivsoppholdytelserApSolved && (
         <Alert variant="warning" size="small">
           Vurder om søker har andre livsoppholdsytelser på søknadstidspunktet.
         </Alert>
@@ -162,7 +162,7 @@ export const AndreLivsoppholdytelser = ({
         onItemSelect={setSelectedId}
         detailHeading="Vurdering av andre livsoppholdytelser"
         lovreferanse={andreLivsoppholdytelserVilkår.lovReferanse}
-        defaultIsLocked={isAksjonspunktSolved}
+        defaultIsLocked={isAndreLivsoppholdytelserApSolved}
         readOnly={readOnly}
         isPermanentlyReadOnly={isPermanentlyReadOnly}
         afterEditButton={
@@ -187,7 +187,9 @@ export const AndreLivsoppholdytelser = ({
           ) : null
         }
         lockedContent={
-          isAksjonspunktSolved ? <VurdertAv ident={andreLivsoppholdytelserAp.ansvarligSaksbehandler} /> : undefined
+          isAndreLivsoppholdytelserApSolved ? (
+            <VurdertAv ident={andreLivsoppholdytelserAp?.ansvarligSaksbehandler} />
+          ) : undefined
         }
       >
         {(isFormLocked: boolean, setIsFormLocked: React.Dispatch<React.SetStateAction<boolean>>) => (

--- a/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/AndreLivsoppholdytelser.tsx
+++ b/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/AndreLivsoppholdytelser.tsx
@@ -16,7 +16,7 @@ import { Lovreferanse } from '../../shared/lovreferanse/Lovreferanse';
 import { VurdertAv } from '../../shared/vurdert-av/VurdertAv';
 import type { AktivitetspengerApi } from '../aktivitetspenger-prosess/AktivitetspengerApi';
 import { sendTilBeslutter } from './utils/sendTilBeslutter';
-import { aksjonspunktErÅpent } from './utils/utils';
+import { aksjonspunktErLøst, aksjonspunktErÅpent } from './utils/utils';
 import { getPeriodStatus, VilkårSplittPanel, type VilkårSplittPanelPeriod } from './VilkårSplittPanel';
 
 interface Props {
@@ -74,8 +74,7 @@ export const AndreLivsoppholdytelser = ({
     periode: p.periode,
   }));
   const [selectedId, setSelectedId] = useState(periods[0]?.id ?? '');
-  const isAndreLivsoppholdytelserApSolved =
-    !andreLivsoppholdytelserAp || (andreLivsoppholdytelserAp && !aksjonspunktErÅpent(andreLivsoppholdytelserAp));
+  const isAndreLivsoppholdytelserApSolved = aksjonspunktErLøst(andreLivsoppholdytelserAp);
   const formHook = useForm<FormData>({
     defaultValues: buildInitialValues(andreLivsoppholdytelserVilkår),
   });

--- a/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/BehovForBistand.stories.tsx
+++ b/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/BehovForBistand.stories.tsx
@@ -78,6 +78,37 @@ export const IkkeSaksbehandler: Story = {
   },
 };
 
+export const MedKunVilkårUtenAksjonspunkt: Story = {
+  args: {
+    vurderBistandsvilkårAp: undefined,
+    lokalkontorForeslårVilkårAp: undefined,
+    vurderBistandsvilkårVilkår: {
+      vilkarType: vilkarType.BISTANDSVILKÅR,
+      perioder: [
+        {
+          periode: { fom: '2024-01-01', tom: '2024-12-31' },
+          vilkarStatus: Utfall.OPPFYLT,
+          begrunnelse: 'Søker har behov for bistand.',
+        },
+      ],
+    },
+    isPermanentlyReadOnly: true,
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('viser ikke advarsel når aksjonspunkt mangler', async () => {
+      await expect(
+        canvas.queryByText('Vurder behov for bistand på søknadstidspunktet.', { exact: false }),
+      ).not.toBeInTheDocument();
+    });
+
+    await step('viser ikke bekreft-knapp når panelet er permanent låst', async () => {
+      await expect(canvas.queryByRole('button', { name: 'Bekreft og fortsett' })).not.toBeInTheDocument();
+    });
+  },
+};
+
 export const ReadOnly: Story = {
   args: {
     readOnly: true,

--- a/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/BehovForBistand.tsx
+++ b/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/BehovForBistand.tsx
@@ -16,7 +16,7 @@ import { Lovreferanse } from '../../shared/lovreferanse/Lovreferanse';
 import { VurdertAv } from '../../shared/vurdert-av/VurdertAv';
 import type { AktivitetspengerApi } from '../aktivitetspenger-prosess/AktivitetspengerApi';
 import { sendTilBeslutter } from './utils/sendTilBeslutter';
-import { aksjonspunktErÅpent } from './utils/utils';
+import { aksjonspunktErLøst, aksjonspunktErÅpent } from './utils/utils';
 import { getPeriodStatus, VilkårSplittPanel, type VilkårSplittPanelPeriod } from './VilkårSplittPanel';
 
 interface Props {
@@ -131,8 +131,7 @@ export const BehovForBistand = ({
 
   const behovForBistand = formHook.watch(`vurderinger.${selectedId}.behovForBistand`);
   const avslagsårsak = formHook.watch(`vurderinger.${selectedId}.avslagsårsak`);
-  const isVurderBistandsvilkårApSolved =
-    !vurderBistandsvilkårAp || (vurderBistandsvilkårAp && !aksjonspunktErÅpent(vurderBistandsvilkårAp));
+  const isVurderBistandsvilkårApSolved = aksjonspunktErLøst(vurderBistandsvilkårAp);
 
   if (!vurderBistandsvilkårVilkår) {
     return null;

--- a/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/BehovForBistand.tsx
+++ b/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/BehovForBistand.tsx
@@ -131,7 +131,8 @@ export const BehovForBistand = ({
 
   const behovForBistand = formHook.watch(`vurderinger.${selectedId}.behovForBistand`);
   const avslagsårsak = formHook.watch(`vurderinger.${selectedId}.avslagsårsak`);
-  const isVurderBistandsvilkårApSolved = vurderBistandsvilkårAp && !aksjonspunktErÅpent(vurderBistandsvilkårAp);
+  const isVurderBistandsvilkårApSolved =
+    !vurderBistandsvilkårAp || (vurderBistandsvilkårAp && !aksjonspunktErÅpent(vurderBistandsvilkårAp));
 
   if (!vurderBistandsvilkårVilkår) {
     return null;
@@ -196,7 +197,7 @@ export const BehovForBistand = ({
         }
         lockedContent={
           isVurderBistandsvilkårApSolved ? (
-            <VurdertAv ident={vurderBistandsvilkårAp.ansvarligSaksbehandler} />
+            <VurdertAv ident={vurderBistandsvilkårAp?.ansvarligSaksbehandler} />
           ) : undefined
         }
       >

--- a/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/Bosted.stories.tsx
+++ b/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/Bosted.stories.tsx
@@ -103,6 +103,31 @@ export const FlerePerioder: Story = {
   },
 };
 
+export const MedKunVilkårUtenAksjonspunkt: Story = {
+  args: {
+    bostedAp: undefined,
+    lokalkontorForeslårVilkårAp: undefined,
+    bostedVilkår: {
+      vilkarType: vilkarType.BOSTEDSVILKÅR,
+      perioder: [{ periode, vilkarStatus: Utfall.OPPFYLT, begrunnelse: 'Søker er bosatt i Trondheim kommune.' }],
+    },
+    isPermanentlyReadOnly: true,
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('viser ikke advarsel når aksjonspunkt mangler', async () => {
+      await expect(
+        canvas.queryByText('Vurder om søker er bosatt i Trondheim kommune på søknadstidspunktet.', { exact: false }),
+      ).not.toBeInTheDocument();
+    });
+
+    await step('viser ikke bekreft-knapp når panelet er permanent låst', async () => {
+      await expect(canvas.queryByRole('button', { name: 'Bekreft og fortsett' })).not.toBeInTheDocument();
+    });
+  },
+};
+
 export const ViserFritekstVedAvslag: Story = {
   args: {
     bostedVilkår: {

--- a/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/Bosted.tsx
+++ b/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/Bosted.tsx
@@ -1,5 +1,4 @@
 import { AksjonspunktDefinisjon } from '@k9-sak-web/backend/ungsak/kodeverk/behandling/aksjonspunkt/AksjonspunktDefinisjon.js';
-import { AksjonspunktStatus } from '@k9-sak-web/backend/ungsak/kodeverk/behandling/aksjonspunkt/AksjonspunktStatus.js';
 import { Kilde } from '@k9-sak-web/backend/ungsak/kodeverk/bosatt/Kilde.js';
 import { Avslagsårsak } from '@k9-sak-web/backend/ungsak/kodeverk/vilkår/Avslagsårsak.js';
 import { Utfall } from '@k9-sak-web/backend/ungsak/kodeverk/vilkår/Utfall.js';
@@ -116,7 +115,7 @@ export const Bosted = ({
     },
   });
 
-  const isAksjonspunktSolved = bostedAp?.status === AksjonspunktStatus.UTFØRT;
+  const isBostedApSolved = !bostedAp || (bostedAp && !aksjonspunktErÅpent(bostedAp));
   const selectedBosattFaktaPeriode = bosattFakta.perioder.find(p => p.fom === selectedId);
   const bosatt = formHook.watch(`vurderinger.${selectedId}.bosatt`);
   const avslagsårsak = formHook.watch(`vurderinger.${selectedId}.avslagsårsak`);
@@ -136,7 +135,7 @@ export const Bosted = ({
 
   return (
     <VStack gap="space-20">
-      {!isAksjonspunktSolved && (
+      {!isBostedApSolved && (
         <Alert variant="warning" size="small">
           Vurder om søker er bosatt i Trondheim kommune på søknadstidspunktet.
         </Alert>
@@ -147,9 +146,9 @@ export const Bosted = ({
         onItemSelect={setSelectedId}
         detailHeading="Vurdering av bostedsvilkår"
         lovreferanse={bostedVilkår.lovReferanse}
-        defaultIsLocked={isAksjonspunktSolved}
+        defaultIsLocked={isBostedApSolved}
         readOnly={readOnly}
-        lockedContent={isAksjonspunktSolved ? <VurdertAv ident={bostedAp.ansvarligSaksbehandler} /> : undefined}
+        lockedContent={isBostedApSolved ? <VurdertAv ident={bostedAp?.ansvarligSaksbehandler} /> : undefined}
         afterEditButton={
           skalViseSendTilBeslutter ? (
             <VStack gap="space-20">

--- a/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/Bosted.tsx
+++ b/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/Bosted.tsx
@@ -18,7 +18,7 @@ import { Lovreferanse } from '../../shared/lovreferanse/Lovreferanse';
 import { VurdertAv } from '../../shared/vurdert-av/VurdertAv';
 import type { AktivitetspengerApi } from '../aktivitetspenger-prosess/AktivitetspengerApi';
 import { sendTilBeslutter } from './utils/sendTilBeslutter';
-import { aksjonspunktErÅpent } from './utils/utils';
+import { aksjonspunktErLøst, aksjonspunktErÅpent } from './utils/utils';
 import { getPeriodStatus, VilkårSplittPanel, type VilkårSplittPanelPeriod } from './VilkårSplittPanel';
 
 interface Props {
@@ -115,7 +115,7 @@ export const Bosted = ({
     },
   });
 
-  const isBostedApSolved = !bostedAp || (bostedAp && !aksjonspunktErÅpent(bostedAp));
+  const isBostedApSolved = aksjonspunktErLøst(bostedAp);
   const selectedBosattFaktaPeriode = bosattFakta.perioder.find(p => p.fom === selectedId);
   const bosatt = formHook.watch(`vurderinger.${selectedId}.bosatt`);
   const avslagsårsak = formHook.watch(`vurderinger.${selectedId}.avslagsårsak`);

--- a/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/utils/utils.ts
+++ b/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/utils/utils.ts
@@ -2,3 +2,5 @@ import { AksjonspunktStatus } from '@k9-sak-web/backend/ungsak/kodeverk/behandli
 import type { AksjonspunktDto } from '@k9-sak-web/backend/ungsak/kontrakt/aksjonspunkt/AksjonspunktDto.js';
 
 export const aksjonspunktErÅpent = (ap?: AksjonspunktDto) => (ap ? ap.status !== AksjonspunktStatus.UTFØRT : false);
+
+export const aksjonspunktErLøst = (ap?: AksjonspunktDto) => !aksjonspunktErÅpent(ap);

--- a/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/utils/utils.ts
+++ b/packages/v2/gui/src/prosess/aktivitetspenger-inngangsvilkår/utils/utils.ts
@@ -3,4 +3,8 @@ import type { AksjonspunktDto } from '@k9-sak-web/backend/ungsak/kontrakt/aksjon
 
 export const aksjonspunktErÅpent = (ap?: AksjonspunktDto) => (ap ? ap.status !== AksjonspunktStatus.UTFØRT : false);
 
+/**
+ * Returnerer true når aksjonspunktet ikke krever handling.
+ * Udefinert aksjonspunkt tolkes som at steget ikke har aksjonspunkt og dermed er løst.
+ */
 export const aksjonspunktErLøst = (ap?: AksjonspunktDto) => !aksjonspunktErÅpent(ap);


### PR DESCRIPTION
### Behov / Bakgrunn
Paneler vises som åpne og med aksjonspunkt når aksjonspunkt ikke finnes.
https://nav.atlassian.net/browse/TSFF-2698

### Løsning
Sjekker om aksjonspunkt finnes og setter lesevisning deretter

### Andre endringer

