### PR TITLE
fix: Viser riktig status for prosessteg for vedtak når behandling er …

### DIFF
--- a/packages/behandling-aktivitetspenger/src/components/Prosessmotor.spec.tsx
+++ b/packages/behandling-aktivitetspenger/src/components/Prosessmotor.spec.tsx
@@ -1,5 +1,7 @@
+import { BehandlingResultatType } from '@k9-sak-web/backend/combined/kodeverk/behandling/BehandlingResultatType.js';
 import { aksjonspunktStatus } from '@k9-sak-web/backend/k9sak/kodeverk/AksjonspunktStatus.js';
 import { AksjonspunktDefinisjon } from '@k9-sak-web/backend/ungsak/kodeverk/behandling/aksjonspunkt/AksjonspunktDefinisjon.js';
+import { BehandlingStatus } from '@k9-sak-web/backend/ungsak/kodeverk/behandling/BehandlingStatus.js';
 import { Utfall } from '@k9-sak-web/backend/ungsak/kodeverk/vilkår/Utfall.js';
 import type { AktivitetspengerApi } from '@k9-sak-web/gui/prosess/aktivitetspenger-prosess/AktivitetspengerApi.js';
 import { FakeAktivitetspengerApi } from '@k9-sak-web/gui/storybook/mocks/FakeAktivitetspengerApi.js';
@@ -38,7 +40,8 @@ const createVilkår = (vilkarStatus: Utfall, type: ung_kodeverk_vilkår_VilkårT
 const createBehandling = (overrides = {}) => ({
   uuid: 'behandling-uuid',
   versjon: 1,
-  behandlingsresultat: { type: { kode: 'INNVILGET', kodeverk: 'BEHANDLING_RESULTAT_TYPE' } },
+  behandlingsresultat: { type: BehandlingResultatType.INNVILGET },
+  status: BehandlingStatus.OPPRETTET,
   ...overrides,
 });
 

--- a/packages/behandling-aktivitetspenger/src/components/Prosessmotor.spec.tsx
+++ b/packages/behandling-aktivitetspenger/src/components/Prosessmotor.spec.tsx
@@ -153,6 +153,36 @@ describe('Prossesmotor', () => {
     });
   });
 
+  test('setter vedtak til success når behandling er FATTER_VEDTAK og resultat er innvilget', async () => {
+    const api = createApi({
+      vilkår: [createVilkår(Utfall.OPPFYLT, ung_kodeverk_vilkår_VilkårType.SØKNADSFRIST)],
+      aksjonspunkter: [
+        {
+          definisjon: AksjonspunktDefinisjon.FORESLÅ_VEDTAK,
+          status: aksjonspunktStatus.OPPRETTET,
+        },
+      ],
+    });
+
+    const { result } = renderHook(
+      () =>
+        useProsessmotor({
+          api,
+          behandling: createBehandling({
+            status: BehandlingStatus.FATTER_VEDTAK,
+            behandlingsresultat: { type: BehandlingResultatType.INNVILGET },
+          }),
+        }),
+      {
+        wrapper: createWrapper(queryClient),
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current[4].type).toBe(ProcessMenuStepType.success);
+    });
+  });
+
   test('setter beregnet utbetaling til warning når panelet har åpent aksjonspunkt', async () => {
     const api = createApi({
       vilkår: [

--- a/packages/behandling-aktivitetspenger/src/components/Prosessmotor.ts
+++ b/packages/behandling-aktivitetspenger/src/components/Prosessmotor.ts
@@ -1,6 +1,7 @@
 import { isAvslag } from '@fpsak-frontend/kodeverk/src/behandlingResultatType';
 import { VilkårMedPerioderDto } from '@k9-sak-web/backend/combined/kontrakt/vilkår/VilkårMedPerioderDto.js';
 import { AksjonspunktDefinisjon } from '@k9-sak-web/backend/ungsak/kodeverk/behandling/aksjonspunkt/AksjonspunktDefinisjon.js';
+import { BehandlingStatus } from '@k9-sak-web/backend/ungsak/kodeverk/behandling/BehandlingStatus.js';
 import { Utfall } from '@k9-sak-web/backend/ungsak/kodeverk/vilkår/Utfall.js';
 import { vilkarType } from '@k9-sak-web/backend/ungsak/kodeverk/vilkår/VilkårType.js';
 import { AksjonspunktDto } from '@k9-sak-web/backend/ungsak/kontrakt/aksjonspunkt/AksjonspunktDto.js';
@@ -134,7 +135,7 @@ const byggPanelUtenVilkår = (
 const beregnVedtakType = (
   vilkår: VilkårMedPerioderDto[],
   aksjonspunkter: AksjonspunktDto[],
-  behandling: Pick<BehandlingDto, 'uuid' | 'versjon' | 'behandlingsresultat'>,
+  behandling: Pick<BehandlingDto, 'uuid' | 'versjon' | 'behandlingsresultat' | 'status'>,
   vedtakAksjonspunkter: readonly string[],
 ): ProcessMenuStepType => {
   if (!vilkår || vilkår.length === 0) {
@@ -158,6 +159,9 @@ const beregnVedtakType = (
   }
   if (harÅpneIkkeVedtakAksjonspunkter) {
     return ProcessMenuStepType.default;
+  }
+  if (behandling?.status === BehandlingStatus.FATTER_VEDTAK && behandling?.behandlingsresultat?.type) {
+    return isAvslag(behandling.behandlingsresultat.type) ? ProcessMenuStepType.danger : ProcessMenuStepType.success;
   }
   if (harÅpneVedtakAksjonspunkter) {
     return ProcessMenuStepType.warning;
@@ -228,7 +232,7 @@ const byggInngangsvilkårPanel = (
 
 interface ProsessmotorProps {
   api: AktivitetspengerApi;
-  behandling: Pick<BehandlingDto, 'uuid' | 'versjon'>;
+  behandling: Pick<BehandlingDto, 'uuid' | 'versjon' | 'status' | 'behandlingsresultat'>;
 }
 
 export const useProsessmotor = ({ api, behandling }: ProsessmotorProps) => {

--- a/packages/behandling-aktivitetspenger/src/components/prosess/VedtakProsessStegInitPanel.tsx
+++ b/packages/behandling-aktivitetspenger/src/components/prosess/VedtakProsessStegInitPanel.tsx
@@ -51,7 +51,8 @@ export function VedtakProsessStegInitPanel({ api, behandling, onVedtakAksjonspun
     return (
       (!innloggetBruker.aktivitetspengerDel2SaksbehandlerTilgang?.kanBeslutte &&
         !innloggetBruker.aktivitetspengerDel2SaksbehandlerTilgang?.kanSaksbehandle) ||
-      behandling.status === BehandlingStatus.AVSLUTTET
+      behandling.status === BehandlingStatus.AVSLUTTET ||
+      behandling.status === BehandlingStatus.FATTER_VEDTAK
     );
   }, [innloggetBruker, behandling]);
   const erValgt = prosessPanelContext?.erValgt(PANEL_ID);

--- a/packages/behandling-pleiepenger/src/prosess/api/Prosessmotor.spec.tsx
+++ b/packages/behandling-pleiepenger/src/prosess/api/Prosessmotor.spec.tsx
@@ -612,7 +612,7 @@ describe('Prosessmotor', () => {
           relevanteInnvilgetMerknader: [],
         },
       ];
-      const behandling = createMockBehandling({ behandlingsresultat: { type: 'INNVILGET' } });
+      const behandling = createMockBehandling({ behandlingsresultat: { type: { kode: 'INNVILGET', kodeverk: '' } } });
 
       const result = beregnVedtakType(vilkår, [], behandling, []);
 
@@ -627,7 +627,7 @@ describe('Prosessmotor', () => {
           relevanteInnvilgetMerknader: [],
         },
       ];
-      const behandling = createMockBehandling({ behandlingsresultat: { type: 'AVSLÅTT' } });
+      const behandling = createMockBehandling({ behandlingsresultat: { type: { kode: 'AVSLÅTT', kodeverk: '' } } });
 
       const result = beregnVedtakType(vilkår, [], behandling, []);
 

--- a/packages/behandling-pleiepenger/src/prosess/api/Prosessmotor.ts
+++ b/packages/behandling-pleiepenger/src/prosess/api/Prosessmotor.ts
@@ -271,7 +271,9 @@ export const beregnVedtakType = (
     return ProcessMenuStepType.warning;
   }
   if (behandling?.behandlingsresultat?.type) {
-    return isAvslag(behandling.behandlingsresultat.type) ? ProcessMenuStepType.danger : ProcessMenuStepType.success;
+    return isAvslag(behandling.behandlingsresultat.type.kode)
+      ? ProcessMenuStepType.danger
+      : ProcessMenuStepType.success;
   }
   return ProcessMenuStepType.default;
 };

--- a/packages/kodeverk/src/behandlingResultatType.ts
+++ b/packages/kodeverk/src/behandlingResultatType.ts
@@ -42,7 +42,7 @@ export const isInnvilget = behandlingResultatTypeKode =>
 export const isDelvisInnvilget = behandlingResultatTypeKode =>
   behandlingResultatTypeKode === behandlingResultatType.DELVIS_INNVILGET;
 
-export const isAvslag = behandlingResultatTypeKode =>
+export const isAvslag = (behandlingResultatTypeKode: string) =>
   behandlingResultatTypeKode === behandlingResultatType.AVSLATT ||
   behandlingResultatTypeKode === behandlingResultatType.KLAGE_AVVIST ||
   behandlingResultatTypeKode === behandlingResultatType.KLAGE_YTELSESVEDTAK_OPPHEVET;


### PR DESCRIPTION
…sendt til beslutter

### Behov / Bakgrunn
Prosessteg for vedtak vises som åpent og aktivt selv om sak er sendt til beslutter.
https://nav.atlassian.net/browse/TSFF-2689

### Løsning
Sjekker om sak har status fatter vedtak og vises riktig status hvis ja.


### Andre endringer

