### PR TITLE
fix: retter styling i alert i inntektsmelding

### DIFF
--- a/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
@@ -1,11 +1,11 @@
 import { finnAktivtAksjonspunkt } from '@k9-sak-web/gui/utils/aksjonspunktUtils.js';
-import { Accordion, Alert, BodyLong, Box, Button, Heading } from '@navikt/ds-react';
+import { Accordion, Alert, Bleed, BodyLong, Box, Button, Heading } from '@navikt/ds-react';
 import { useMemo, useState } from 'react';
 import { useForm, type FieldValues } from 'react-hook-form';
 import { useKompletthetsoversikt } from '../../api/inntektsmeldingQueries';
 import { useInntektsmeldingContext } from '../../context/InntektsmeldingContext';
-import { FieldName, InntektsmeldingVurderingRequestKode } from '../../types';
 import type { Tilstand, TilstandMedUiState } from '../../types';
+import { FieldName, InntektsmeldingVurderingRequestKode } from '../../types';
 import {
   finnSisteAksjonspunkt,
   finnTilstanderSomRedigeres,
@@ -32,11 +32,13 @@ const InntektsmeldingManglerInfo = () => (
       <Alert variant="info" size="small">
         <Accordion>
           <Accordion.Item>
-            <Accordion.Header className="before:hidden after:hidden">
-              <Heading className="!mb-0 font-normal" spacing size="xsmall" level="3">
-                Når kan du gå videre uten inntektsmelding?
-              </Heading>
-            </Accordion.Header>
+            <Bleed marginBlock="space-12">
+              <Accordion.Header className="before:hidden after:hidden">
+                <Heading className="!mb-0 font-normal" spacing size="xsmall" level="3">
+                  Når kan du gå videre uten inntektsmelding?
+                </Heading>
+              </Accordion.Header>
+            </Bleed>
             <Accordion.Content>
               Vurder om du kan gå videre uten alle inntektsmeldinger hvis:
               <ul className="m-0 pl-6">


### PR DESCRIPTION
### Behov / Bakgrunn
<img width="583" height="110" alt="Skjermbilde 2026-05-27 kl  16 08 38" src="https://github.com/user-attachments/assets/61acb2e8-b47c-440c-a533-ca344ad0bd96" />


### Løsning
<img width="493" height="96" alt="Skjermbilde 2026-05-27 kl  16 08 43" src="https://github.com/user-attachments/assets/c31a32f9-2cdb-475d-821f-abb911227abf" />


### Andre endringer

