### PR TITLE
feat: add pre-push hooks for eslint and prettier checks

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -19,3 +19,21 @@ pre-commit:
       glob: "packages/**/*.css"
       run: yarn prettier --write {staged_files}
       stage_fixed: true
+
+pre-push:
+  parallel: false
+  commands:
+    eslint-check:
+      glob: "packages/**/*.{ts,tsx,js,jsx}"
+      exclude: '\.module\.d\.css\.(ts|tsx|js|jsx)$'
+      run: yarn eslint --cache {push_files}
+    prettier-check-ts:
+      glob: "packages/**/*.{ts,tsx,js,jsx}"
+      exclude: '\.module\.d\.css\.(ts|tsx|js|jsx)$'
+      run: yarn prettier --check {push_files}
+    stylelint-check:
+      glob: "packages/**/*.css"
+      run: yarn stylelint {push_files}
+    prettier-check-css:
+      glob: "packages/**/*.css"
+      run: yarn prettier --check {push_files}


### PR DESCRIPTION
**Problem**
Utviklere som pusher fra IntelliJ ser ut til å kunne omgå lokal formattering i pre-commit. Det ga ulik kodeformattering i repoet.

**Hva som er endret**

- Lagt til pre-push-hook i lefthook.yml.
- Beholdt eksisterende pre-commit-oppsett uendret i lefthook.yml.
- Ny pre-push kjører kun sjekker (ikke auto-fix), avgrenset til packages:
- eslint-check for TS/TSX/JS/JSX
- prettier-check for TS/TSX/JS/JSX
- stylelint-check for CSS
- prettier-check for CSS

**Hvorfor denne endringen**
Gir et ekstra sikkerhetsnett ved push når pre-commit ikke trigges som forventet i enkelte IDE-flyt, uten å innføre ny CI-blokkering.

**Omfang**
Kun filer under packages påvirkes, i tråd med dagens scope.