### PR TITLE
Feat/refaktor vedtakstatus utleder

### DIFF
--- a/packages/behandling-felles/index.ts
+++ b/packages/behandling-felles/index.ts
@@ -26,5 +26,6 @@ export type { default as SettPaVentParams } from './src/types/settPaVentParamsTs
 export { default as lagDokumentdata } from './src/util/lagDokumentdata';
 export { default as BehandlingUtil } from './src/util/BehandlingUtil';
 export { default as ArbeidsgiverOpplysningerUtil } from './src/util/ArbeidsgiverOpplysningerUtil';
+export { default as utledVedtakStatus } from './src/util/utledVedtakStatus';
 
 export { default as globalMessages } from './src/i18n/globalMessages.json';

--- a/packages/behandling-felles/src/util/utledVedtakStatus.spec.ts
+++ b/packages/behandling-felles/src/util/utledVedtakStatus.spec.ts
@@ -2,38 +2,61 @@ import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import aksjonspunktStatus from '@fpsak-frontend/kodeverk/src/aksjonspunktStatus';
 import behandlingResultatType from '@fpsak-frontend/kodeverk/src/behandlingResultatType';
 import vilkarUtfallType from '@fpsak-frontend/kodeverk/src/vilkarUtfallType';
+import { Aksjonspunkt, Behandlingsresultat, Vilkar } from '@k9-sak-web/types';
 
 import utledVedtakStatus from './utledVedtakStatus';
 
-const lagAksjonspunkt = (definisjonKode, statusKode) => ({
-  definisjon: {
-    kode: definisjonKode,
-  },
-  status: {
-    kode: statusKode,
-  },
-});
+const lagAksjonspunkt = (definisjonKode: string, statusKode: string): Aksjonspunkt => {
+  const aksjonspunkt: Aksjonspunkt = {
+    definisjon: {
+      kode: definisjonKode,
+      kodeverk: 'AKSJONSPUNKT_KODE',
+    },
+    status: {
+      kode: statusKode,
+      kodeverk: 'AKSJONSPUNKT_STATUS',
+    },
+    kanLoses: true,
+    erAktivt: true,
+  };
 
-const lagVilkår = vilkarStatusKode => [
-  {
+  return aksjonspunkt;
+};
+
+const lagVilkår = (vilkarStatusKode: string): Vilkar[] => {
+  const vilkar: Vilkar = {
+    vilkarType: {
+      kode: 'TEST_VILKAR',
+      kodeverk: 'VILKAR_TYPE',
+    },
+    overstyrbar: true,
+    relevanteInnvilgetMerknader: [],
     perioder: [
       {
         vilkarStatus: {
           kode: vilkarStatusKode,
+          kodeverk: 'VILKAR_UTFALL_TYPE',
+        },
+        merknadParametere: {},
+        periode: {
+          fom: '2024-01-01',
+          tom: '2024-01-02',
         },
       },
     ],
-  },
-];
+  };
+
+  return [vilkar];
+};
 
 describe('utledVedtakStatus', () => {
   const vedtakAksjonspunkter = [lagAksjonspunkt('VEDTAK_AP', aksjonspunktStatus.UTFORT)];
-  const innvilgetResultat = {
+  const innvilgetResultat: Behandlingsresultat = {
     type: {
       kode: behandlingResultatType.INNVILGET,
     },
   };
-  const avslagResultat = {
+  const avslagResultat: Behandlingsresultat = {
     type: {
       kode: behandlingResultatType.AVSLATT,
     },

--- a/packages/behandling-felles/src/util/utledVedtakStatus.spec.ts
+++ b/packages/behandling-felles/src/util/utledVedtakStatus.spec.ts
@@ -1,0 +1,104 @@
+import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
+import aksjonspunktStatus from '@fpsak-frontend/kodeverk/src/aksjonspunktStatus';
+import behandlingResultatType from '@fpsak-frontend/kodeverk/src/behandlingResultatType';
+import vilkarUtfallType from '@fpsak-frontend/kodeverk/src/vilkarUtfallType';
+
+import utledVedtakStatus from './utledVedtakStatus';
+
+const lagAksjonspunkt = (definisjonKode, statusKode) => ({
+  definisjon: {
+    kode: definisjonKode,
+  },
+  status: {
+    kode: statusKode,
+  },
+});
+
+const lagVilkår = vilkarStatusKode => [
+  {
+    perioder: [
+      {
+        vilkarStatus: {
+          kode: vilkarStatusKode,
+        },
+      },
+    ],
+  },
+];
+
+describe('utledVedtakStatus', () => {
+  const vedtakAksjonspunkter = [lagAksjonspunkt('VEDTAK_AP', aksjonspunktStatus.UTFORT)];
+  const innvilgetResultat = {
+    type: {
+      kode: behandlingResultatType.INNVILGET,
+    },
+  };
+  const avslagResultat = {
+    type: {
+      kode: behandlingResultatType.AVSLATT,
+    },
+  };
+
+  it('returnerer IKKE_VURDERT når vilkårsliste er tom', () => {
+    const status = utledVedtakStatus([], [], vedtakAksjonspunkter, innvilgetResultat);
+
+    expect(status).toBe(vilkarUtfallType.IKKE_VURDERT);
+  });
+
+  it('returnerer IKKE_OPPFYLT når vilkår er IKKE_OPPFYLT og alle relevante aksjonspunkt er lukket', () => {
+    const vilkar = lagVilkår(vilkarUtfallType.IKKE_OPPFYLT);
+    const aksjonspunkter = [lagAksjonspunkt('ANNET_AP', aksjonspunktStatus.UTFORT)];
+
+    const status = utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, innvilgetResultat);
+
+    expect(status).toBe(vilkarUtfallType.IKKE_OPPFYLT);
+  });
+
+  it('returnerer OPPFYLT når sjekk for IKKE_OPPFYLT-vilkår er slått av', () => {
+    const vilkar = lagVilkår(vilkarUtfallType.IKKE_OPPFYLT);
+    const aksjonspunkter = [lagAksjonspunkt('ANNET_AP', aksjonspunktStatus.UTFORT)];
+
+    const status = utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, innvilgetResultat, false);
+
+    expect(status).toBe(vilkarUtfallType.OPPFYLT);
+  });
+
+  it('returnerer IKKE_VURDERT når det finnes åpent OVERSTYR_BEREGNING-aksjonspunkt', () => {
+    const vilkar = lagVilkår(vilkarUtfallType.OPPFYLT);
+    const aksjonspunkter = [
+      lagAksjonspunkt(aksjonspunktCodes.OVERSTYR_BEREGNING, aksjonspunktStatus.OPPRETTET),
+      lagAksjonspunkt('ANNET_AP', aksjonspunktStatus.UTFORT),
+    ];
+
+    const status = utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, innvilgetResultat);
+
+    expect(status).toBe(vilkarUtfallType.IKKE_VURDERT);
+  });
+
+  it('returnerer IKKE_VURDERT når et ikke-vedtak-aksjonspunkt er åpent', () => {
+    const vilkar = lagVilkår(vilkarUtfallType.OPPFYLT);
+    const aksjonspunkter = [lagAksjonspunkt('ANNET_AP', aksjonspunktStatus.OPPRETTET)];
+
+    const status = utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, innvilgetResultat);
+
+    expect(status).toBe(vilkarUtfallType.IKKE_VURDERT);
+  });
+
+  it('returnerer IKKE_OPPFYLT ved avslag når øvrige sjekker passerer', () => {
+    const vilkar = lagVilkår(vilkarUtfallType.OPPFYLT);
+    const aksjonspunkter = [lagAksjonspunkt('ANNET_AP', aksjonspunktStatus.UTFORT)];
+
+    const status = utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, avslagResultat);
+
+    expect(status).toBe(vilkarUtfallType.IKKE_OPPFYLT);
+  });
+
+  it('returnerer OPPFYLT når vilkår er oppfylt, aksjonspunkt er lukket og resultat er innvilget', () => {
+    const vilkar = lagVilkår(vilkarUtfallType.OPPFYLT);
+    const aksjonspunkter = [lagAksjonspunkt('ANNET_AP', aksjonspunktStatus.UTFORT)];
+
+    const status = utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, innvilgetResultat);
+
+    expect(status).toBe(vilkarUtfallType.OPPFYLT);
+  });
+});

--- a/packages/behandling-felles/src/util/utledVedtakStatus.spec.ts
+++ b/packages/behandling-felles/src/util/utledVedtakStatus.spec.ts
@@ -58,7 +58,9 @@ describe('utledVedtakStatus', () => {
     const vilkar = lagVilkår(vilkarUtfallType.IKKE_OPPFYLT);
     const aksjonspunkter = [lagAksjonspunkt('ANNET_AP', aksjonspunktStatus.UTFORT)];
 
-    const status = utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, innvilgetResultat, false);
+    const status = utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, innvilgetResultat, {
+      skalSjekkeIkkeOppfyltVilkår: false,
+    });
 
     expect(status).toBe(vilkarUtfallType.OPPFYLT);
   });
@@ -73,6 +75,19 @@ describe('utledVedtakStatus', () => {
     const status = utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, innvilgetResultat);
 
     expect(status).toBe(vilkarUtfallType.IKKE_VURDERT);
+  });
+
+  it('kan slå av sjekk for åpent OVERSTYR_BEREGNING-aksjonspunkt', () => {
+    const vilkar = lagVilkår(vilkarUtfallType.OPPFYLT);
+    const aksjonspunkter = [lagAksjonspunkt(aksjonspunktCodes.OVERSTYR_BEREGNING, aksjonspunktStatus.OPPRETTET)];
+    const vedtakAksjonspunkter = [lagAksjonspunkt(aksjonspunktCodes.OVERSTYR_BEREGNING, aksjonspunktStatus.OPPRETTET)];
+
+    const status = utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, innvilgetResultat, {
+      skalSjekkeIkkeOppfyltVilkår: false,
+      skalSjekkeOverstyrBeregningAksjonspunkt: false,
+    });
+
+    expect(status).toBe(vilkarUtfallType.OPPFYLT);
   });
 
   it('returnerer IKKE_VURDERT når et ikke-vedtak-aksjonspunkt er åpent', () => {

--- a/packages/behandling-felles/src/util/utledVedtakStatus.ts
+++ b/packages/behandling-felles/src/util/utledVedtakStatus.ts
@@ -2,25 +2,53 @@ import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
 import { isAksjonspunktOpen } from '@fpsak-frontend/kodeverk/src/aksjonspunktStatus';
 import { isAvslag } from '@fpsak-frontend/kodeverk/src/behandlingResultatType';
 import vilkarUtfallType from '@fpsak-frontend/kodeverk/src/vilkarUtfallType';
+import { Aksjonspunkt, Behandlingsresultat, Vilkar } from '@k9-sak-web/types';
 
-const hasOnlyClosedAps = (aksjonspunkter, vedtakAksjonspunkter) =>
+const hasOnlyClosedAps = (aksjonspunkter: Aksjonspunkt[], vedtakAksjonspunkter: Aksjonspunkt[]) =>
   aksjonspunkter
     .filter(ap => !vedtakAksjonspunkter.some(vap => vap.definisjon.kode === ap.definisjon.kode))
     .every(ap => !isAksjonspunktOpen(ap.status.kode));
 
-const hasOpenOverstyrBeregningAksjonspunkt = ap =>
+const hasOpenOverstyrBeregningAksjonspunkt = (ap: Aksjonspunkt) =>
   ap.definisjon.kode === aksjonspunktCodes.OVERSTYR_BEREGNING && isAksjonspunktOpen(ap.status.kode);
 
-const harVilkårMedStatus = (vilkar, status) =>
+const harVilkårMedStatus = (vilkar: Vilkar[], status: string) =>
   vilkar.some(v => v.perioder.some(periode => periode.vilkarStatus.kode === status));
 
+interface VedtakStatusInnstillinger {
+  /**
+   * Når true: returnerer IKKE_OPPFYLT tidlig dersom alle relevante aksjonspunkt er lukket
+   * og minst ett vilkår har status IKKE_OPPFYLT.
+   */
+  skalSjekkeIkkeOppfyltVilkår?: boolean;
+  /**
+   * Når true: åpent OVERSTYR_BEREGNING-aksjonspunkt gir IKKE_VURDERT.
+   */
+  skalSjekkeOverstyrBeregningAksjonspunkt?: boolean;
+}
+
+/**
+ * Utleder vedtakstatus basert på vilkår, aksjonspunkt og behandlingsresultat.
+ *
+ * Standardregler brukes for:
+ * - Omsorgspenger
+ * - Frisinn
+ * - Pleiepenger sluttfase
+ * - Unntak
+ *
+ * Ytelser med avvik:
+ * - Opplæringspenger og pleiepenger: skalSjekkeIkkeOppfyltVilkår = false
+ * - Ungdomsytelse: skalSjekkeIkkeOppfyltVilkår = false og skalSjekkeOverstyrBeregningAksjonspunkt = false
+ */
 const utledVedtakStatus = (
-  vilkar,
-  aksjonspunkter,
-  vedtakAksjonspunkter,
-  behandlingsresultat,
-  skalSjekkeIkkeOppfyltVilkår = true,
+  vilkar: Vilkar[],
+  aksjonspunkter: Aksjonspunkt[],
+  vedtakAksjonspunkter: Aksjonspunkt[],
+  behandlingsresultat: Behandlingsresultat,
+  innstillinger: VedtakStatusInnstillinger = {},
 ) => {
+  const { skalSjekkeIkkeOppfyltVilkår = true, skalSjekkeOverstyrBeregningAksjonspunkt = true } = innstillinger;
+
   if (vilkar.length === 0) {
     return vilkarUtfallType.IKKE_VURDERT;
   }
@@ -35,7 +63,7 @@ const utledVedtakStatus = (
 
   if (
     harVilkårMedStatus(vilkar, vilkarUtfallType.IKKE_VURDERT) ||
-    aksjonspunkter.some(hasOpenOverstyrBeregningAksjonspunkt)
+    (skalSjekkeOverstyrBeregningAksjonspunkt && aksjonspunkter.some(hasOpenOverstyrBeregningAksjonspunkt))
   ) {
     return vilkarUtfallType.IKKE_VURDERT;
   }

--- a/packages/behandling-felles/src/util/utledVedtakStatus.ts
+++ b/packages/behandling-felles/src/util/utledVedtakStatus.ts
@@ -1,0 +1,54 @@
+import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
+import { isAksjonspunktOpen } from '@fpsak-frontend/kodeverk/src/aksjonspunktStatus';
+import { isAvslag } from '@fpsak-frontend/kodeverk/src/behandlingResultatType';
+import vilkarUtfallType from '@fpsak-frontend/kodeverk/src/vilkarUtfallType';
+
+const hasOnlyClosedAps = (aksjonspunkter, vedtakAksjonspunkter) =>
+  aksjonspunkter
+    .filter(ap => !vedtakAksjonspunkter.some(vap => vap.definisjon.kode === ap.definisjon.kode))
+    .every(ap => !isAksjonspunktOpen(ap.status.kode));
+
+const hasOpenOverstyrBeregningAksjonspunkt = ap =>
+  ap.definisjon.kode === aksjonspunktCodes.OVERSTYR_BEREGNING && isAksjonspunktOpen(ap.status.kode);
+
+const harVilkårMedStatus = (vilkar, status) =>
+  vilkar.some(v => v.perioder.some(periode => periode.vilkarStatus.kode === status));
+
+const utledVedtakStatus = (
+  vilkar,
+  aksjonspunkter,
+  vedtakAksjonspunkter,
+  behandlingsresultat,
+  skalSjekkeIkkeOppfyltVilkår = true,
+) => {
+  if (vilkar.length === 0) {
+    return vilkarUtfallType.IKKE_VURDERT;
+  }
+
+  if (
+    skalSjekkeIkkeOppfyltVilkår &&
+    hasOnlyClosedAps(aksjonspunkter, vedtakAksjonspunkter) &&
+    harVilkårMedStatus(vilkar, vilkarUtfallType.IKKE_OPPFYLT)
+  ) {
+    return vilkarUtfallType.IKKE_OPPFYLT;
+  }
+
+  if (
+    harVilkårMedStatus(vilkar, vilkarUtfallType.IKKE_VURDERT) ||
+    aksjonspunkter.some(hasOpenOverstyrBeregningAksjonspunkt)
+  ) {
+    return vilkarUtfallType.IKKE_VURDERT;
+  }
+
+  if (!hasOnlyClosedAps(aksjonspunkter, vedtakAksjonspunkter)) {
+    return vilkarUtfallType.IKKE_VURDERT;
+  }
+
+  if (isAvslag(behandlingsresultat.type.kode)) {
+    return vilkarUtfallType.IKKE_OPPFYLT;
+  }
+
+  return vilkarUtfallType.OPPFYLT;
+};
+
+export default utledVedtakStatus;

--- a/packages/behandling-frisinn/src/panelDefinisjoner/vedtakStatusUtlederFrisinn.ts
+++ b/packages/behandling-frisinn/src/panelDefinisjoner/vedtakStatusUtlederFrisinn.ts
@@ -1,46 +1,6 @@
-import { isAksjonspunktOpen } from '@fpsak-frontend/kodeverk/src/aksjonspunktStatus';
-import { isAvslag } from '@fpsak-frontend/kodeverk/src/behandlingResultatType';
-import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
-import vilkarUtfallType from '@fpsak-frontend/kodeverk/src/vilkarUtfallType';
+import { utledVedtakStatus } from '@k9-sak-web/behandling-felles';
 
-// TODO (TOR) Kan denne skrivast om? For høg kompleksitet.
+const vedtakStatusUtlederFrisinn = (vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat) =>
+  utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat);
 
-const hasOnlyClosedAps = (aksjonspunkter, vedtakAksjonspunkter) =>
-  aksjonspunkter
-    .filter(ap => !vedtakAksjonspunkter.some(vap => vap.definisjon.kode === ap.definisjon.kode))
-    .every(ap => !isAksjonspunktOpen(ap.status.kode));
-
-const hasAksjonspunkt = ap => ap.definisjon.kode === aksjonspunktCodes.OVERSTYR_BEREGNING;
-
-const isAksjonspunktOpenAndOfType = ap => hasAksjonspunkt(ap) && isAksjonspunktOpen(ap.status.kode);
-
-const findStatusForVedtak = (vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat) => {
-  if (vilkar.length === 0) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (
-    hasOnlyClosedAps(aksjonspunkter, vedtakAksjonspunkter) &&
-    vilkar.some(v => v.perioder.some(periode => periode.vilkarStatus.kode === vilkarUtfallType.IKKE_OPPFYLT))
-  ) {
-    return vilkarUtfallType.IKKE_OPPFYLT;
-  }
-
-  if (
-    vilkar.some(v => v.perioder.some(periode => periode.vilkarStatus.kode === vilkarUtfallType.IKKE_VURDERT)) ||
-    aksjonspunkter.some(isAksjonspunktOpenAndOfType)
-  ) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (!hasOnlyClosedAps(aksjonspunkter, vedtakAksjonspunkter)) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (isAvslag(behandlingsresultat.type.kode)) {
-    return vilkarUtfallType.IKKE_OPPFYLT;
-  }
-  return vilkarUtfallType.OPPFYLT;
-};
-
-export default findStatusForVedtak;
+export default vedtakStatusUtlederFrisinn;

--- a/packages/behandling-omsorgspenger/src/panelDefinisjoner/vedtakStatusUtlederOmsorgspenger.ts
+++ b/packages/behandling-omsorgspenger/src/panelDefinisjoner/vedtakStatusUtlederOmsorgspenger.ts
@@ -1,46 +1,6 @@
-import { isAksjonspunktOpen } from '@fpsak-frontend/kodeverk/src/aksjonspunktStatus';
-import { isAvslag } from '@fpsak-frontend/kodeverk/src/behandlingResultatType';
-import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
-import vilkarUtfallType from '@fpsak-frontend/kodeverk/src/vilkarUtfallType';
+import { utledVedtakStatus } from '@k9-sak-web/behandling-felles';
 
-// TODO (TOR) Kan denne skrivast om? For høg kompleksitet.
+const vedtakStatusUtlederOmsorgspenger = (vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat) =>
+  utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat);
 
-const hasOnlyClosedAps = (aksjonspunkter, vedtakAksjonspunkter) =>
-  aksjonspunkter
-    .filter(ap => !vedtakAksjonspunkter.some(vap => vap.definisjon.kode === ap.definisjon.kode))
-    .every(ap => !isAksjonspunktOpen(ap.status.kode));
-
-const hasAksjonspunkt = ap => ap.definisjon.kode === aksjonspunktCodes.OVERSTYR_BEREGNING;
-
-const isAksjonspunktOpenAndOfType = ap => hasAksjonspunkt(ap) && isAksjonspunktOpen(ap.status.kode);
-
-const harVilkårSomIkkeErOppfylt = vilkar =>
-  vilkar.some(v => v.perioder.some(periode => periode.vilkarStatus.kode === vilkarUtfallType.IKKE_OPPFYLT));
-
-const harVilkårSomIkkeErVurdert = vilkar =>
-  vilkar.some(v => v.perioder.some(periode => periode.vilkarStatus.kode === vilkarUtfallType.IKKE_VURDERT));
-
-const findStatusForVedtak = (vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat) => {
-  if (vilkar.length === 0) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (hasOnlyClosedAps(aksjonspunkter, vedtakAksjonspunkter) && harVilkårSomIkkeErOppfylt(vilkar)) {
-    return vilkarUtfallType.IKKE_OPPFYLT;
-  }
-
-  if (harVilkårSomIkkeErVurdert(vilkar) || aksjonspunkter.some(isAksjonspunktOpenAndOfType)) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (!hasOnlyClosedAps(aksjonspunkter, vedtakAksjonspunkter)) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (isAvslag(behandlingsresultat.type.kode)) {
-    return vilkarUtfallType.IKKE_OPPFYLT;
-  }
-  return vilkarUtfallType.OPPFYLT;
-};
-
-export default findStatusForVedtak;
+export default vedtakStatusUtlederOmsorgspenger;

--- a/packages/behandling-opplaeringspenger/src/panelDefinisjoner/vedtakStatusUtlederOpplaeringspenger.ts
+++ b/packages/behandling-opplaeringspenger/src/panelDefinisjoner/vedtakStatusUtlederOpplaeringspenger.ts
@@ -1,6 +1,9 @@
 import { utledVedtakStatus } from '@k9-sak-web/behandling-felles';
 
+/** Opplæringspenger bruker ikke tidlig IKKE_OPPFYLT-sjekk. */
 const vedtakStatusUtlederOpplaeringspenger = (vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat) =>
-  utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat, false);
+  utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat, {
+    skalSjekkeIkkeOppfyltVilkår: false,
+  });
 
 export default vedtakStatusUtlederOpplaeringspenger;

--- a/packages/behandling-opplaeringspenger/src/panelDefinisjoner/vedtakStatusUtlederOpplaeringspenger.ts
+++ b/packages/behandling-opplaeringspenger/src/panelDefinisjoner/vedtakStatusUtlederOpplaeringspenger.ts
@@ -1,39 +1,6 @@
-import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
-import { isAksjonspunktOpen } from '@fpsak-frontend/kodeverk/src/aksjonspunktStatus';
-import { isAvslag } from '@fpsak-frontend/kodeverk/src/behandlingResultatType';
-import vilkarUtfallType from '@fpsak-frontend/kodeverk/src/vilkarUtfallType';
+import { utledVedtakStatus } from '@k9-sak-web/behandling-felles';
 
-// TODO (TOR) Kan denne skrivast om? For høg kompleksitet.
+const vedtakStatusUtlederOpplaeringspenger = (vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat) =>
+  utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat, false);
 
-const hasOnlyClosedAps = (aksjonspunkter, vedtakAksjonspunkter) =>
-  aksjonspunkter
-    .filter(ap => !vedtakAksjonspunkter.some(vap => vap.definisjon.kode === ap.definisjon.kode))
-    .every(ap => !isAksjonspunktOpen(ap.status.kode));
-
-const hasAksjonspunkt = ap => ap.definisjon.kode === aksjonspunktCodes.OVERSTYR_BEREGNING;
-
-const isAksjonspunktOpenAndOfType = ap => hasAksjonspunkt(ap) && isAksjonspunktOpen(ap.status.kode);
-
-const findStatusForVedtak = (vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat) => {
-  if (vilkar.length === 0) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (
-    vilkar.some(v => v.perioder.some(periode => periode.vilkarStatus.kode === vilkarUtfallType.IKKE_VURDERT)) ||
-    aksjonspunkter.some(isAksjonspunktOpenAndOfType)
-  ) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (!hasOnlyClosedAps(aksjonspunkter, vedtakAksjonspunkter)) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (isAvslag(behandlingsresultat.type.kode)) {
-    return vilkarUtfallType.IKKE_OPPFYLT;
-  }
-  return vilkarUtfallType.OPPFYLT;
-};
-
-export default findStatusForVedtak;
+export default vedtakStatusUtlederOpplaeringspenger;

--- a/packages/behandling-pleiepenger-sluttfase/src/panelDefinisjoner/vedtakStatusUtlederPleiepengerSluttfase.ts
+++ b/packages/behandling-pleiepenger-sluttfase/src/panelDefinisjoner/vedtakStatusUtlederPleiepengerSluttfase.ts
@@ -1,46 +1,6 @@
-import { isAksjonspunktOpen } from '@fpsak-frontend/kodeverk/src/aksjonspunktStatus';
-import { isAvslag } from '@fpsak-frontend/kodeverk/src/behandlingResultatType';
-import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
-import vilkarUtfallType from '@fpsak-frontend/kodeverk/src/vilkarUtfallType';
+import { utledVedtakStatus } from '@k9-sak-web/behandling-felles';
 
-// TODO (TOR) Kan denne skrivast om? For høg kompleksitet.
+const vedtakStatusUtlederPleiepengerSluttfase = (vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat) =>
+  utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat);
 
-const hasOnlyClosedAps = (aksjonspunkter, vedtakAksjonspunkter) =>
-  aksjonspunkter
-    .filter(ap => !vedtakAksjonspunkter.some(vap => vap.definisjon.kode === ap.definisjon.kode))
-    .every(ap => !isAksjonspunktOpen(ap.status.kode));
-
-const hasAksjonspunkt = ap => ap.definisjon.kode === aksjonspunktCodes.OVERSTYR_BEREGNING;
-
-const isAksjonspunktOpenAndOfType = ap => hasAksjonspunkt(ap) && isAksjonspunktOpen(ap.status.kode);
-
-const findStatusForVedtak = (vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat) => {
-  if (vilkar.length === 0) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (
-    hasOnlyClosedAps(aksjonspunkter, vedtakAksjonspunkter) &&
-    vilkar.some(v => v.perioder.some(periode => periode.vilkarStatus.kode === vilkarUtfallType.IKKE_OPPFYLT))
-  ) {
-    return vilkarUtfallType.IKKE_OPPFYLT;
-  }
-
-  if (
-    vilkar.some(v => v.perioder.some(periode => periode.vilkarStatus.kode === vilkarUtfallType.IKKE_VURDERT)) ||
-    aksjonspunkter.some(isAksjonspunktOpenAndOfType)
-  ) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (!hasOnlyClosedAps(aksjonspunkter, vedtakAksjonspunkter)) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (isAvslag(behandlingsresultat.type.kode)) {
-    return vilkarUtfallType.IKKE_OPPFYLT;
-  }
-  return vilkarUtfallType.OPPFYLT;
-};
-
-export default findStatusForVedtak;
+export default vedtakStatusUtlederPleiepengerSluttfase;

--- a/packages/behandling-pleiepenger/src/panelDefinisjoner/vedtakStatusUtlederPleiepenger.ts
+++ b/packages/behandling-pleiepenger/src/panelDefinisjoner/vedtakStatusUtlederPleiepenger.ts
@@ -1,39 +1,9 @@
-import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
-import { isAksjonspunktOpen } from '@fpsak-frontend/kodeverk/src/aksjonspunktStatus';
-import { isAvslag } from '@fpsak-frontend/kodeverk/src/behandlingResultatType';
-import vilkarUtfallType from '@fpsak-frontend/kodeverk/src/vilkarUtfallType';
+import { utledVedtakStatus } from '@k9-sak-web/behandling-felles';
 
-// TODO (TOR) Kan denne skrivast om? For høg kompleksitet.
+/** Pleiepenger bruker ikke tidlig IKKE_OPPFYLT-sjekk. */
+const vedtakStatusUtlederPleiepenger = (vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat) =>
+  utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat, {
+    skalSjekkeIkkeOppfyltVilkår: false,
+  });
 
-const hasOnlyClosedAps = (aksjonspunkter, vedtakAksjonspunkter) =>
-  aksjonspunkter
-    .filter(ap => !vedtakAksjonspunkter.some(vap => vap.definisjon.kode === ap.definisjon.kode))
-    .every(ap => !isAksjonspunktOpen(ap.status.kode));
-
-const hasAksjonspunkt = ap => ap.definisjon.kode === aksjonspunktCodes.OVERSTYR_BEREGNING;
-
-const isAksjonspunktOpenAndOfType = ap => hasAksjonspunkt(ap) && isAksjonspunktOpen(ap.status.kode);
-
-const findStatusForVedtak = (vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat) => {
-  if (vilkar.length === 0) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (
-    vilkar.some(v => v.perioder.some(periode => periode.vilkarStatus.kode === vilkarUtfallType.IKKE_VURDERT)) ||
-    aksjonspunkter.some(isAksjonspunktOpenAndOfType)
-  ) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (!hasOnlyClosedAps(aksjonspunkter, vedtakAksjonspunkter)) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (isAvslag(behandlingsresultat.type.kode)) {
-    return vilkarUtfallType.IKKE_OPPFYLT;
-  }
-  return vilkarUtfallType.OPPFYLT;
-};
-
-export default findStatusForVedtak;
+export default vedtakStatusUtlederPleiepenger;

--- a/packages/behandling-ungdomsytelse/src/panelDefinisjoner/vedtakStatusUtlederUngdomsytelse.ts
+++ b/packages/behandling-ungdomsytelse/src/panelDefinisjoner/vedtakStatusUtlederUngdomsytelse.ts
@@ -1,35 +1,19 @@
-import { isAksjonspunktOpen } from '@fpsak-frontend/kodeverk/src/aksjonspunktStatus';
-import { isAvslag } from '@fpsak-frontend/kodeverk/src/behandlingResultatType';
-import vilkarUtfallType from '@fpsak-frontend/kodeverk/src/vilkarUtfallType';
+import { utledVedtakStatus } from '@k9-sak-web/behandling-felles';
 import { Aksjonspunkt, Behandlingsresultat, Vilkar } from '@k9-sak-web/types';
 
-const hasOnlyClosedAps = (aksjonspunkter: Aksjonspunkt[], vedtakAksjonspunkter: Aksjonspunkt[]) =>
-  aksjonspunkter
-    .filter(ap => !vedtakAksjonspunkter.some(vap => vap.definisjon.kode === ap.definisjon.kode))
-    .every(ap => !isAksjonspunktOpen(ap.status.kode));
-
-const findStatusForVedtak = (
+/**
+ * Ungdomsytelse bruker ikke tidlig IKKE_OPPFYLT-sjekk
+ * og ignorerer åpent OVERSTYR_BEREGNING-aksjonspunkt.
+ */
+const vedtakStatusUtlederUngdomsytelse = (
   vilkar: Vilkar[],
   aksjonspunkter: Aksjonspunkt[],
   vedtakAksjonspunkter: Aksjonspunkt[],
   behandlingsresultat: Behandlingsresultat,
-) => {
-  if (vilkar.length === 0) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
+) =>
+  utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat, {
+    skalSjekkeIkkeOppfyltVilkår: false,
+    skalSjekkeOverstyrBeregningAksjonspunkt: false,
+  });
 
-  if (vilkar.some(v => v.perioder.some(periode => periode.vilkarStatus.kode === vilkarUtfallType.IKKE_VURDERT))) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (!hasOnlyClosedAps(aksjonspunkter, vedtakAksjonspunkter)) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (isAvslag(behandlingsresultat.type.kode)) {
-    return vilkarUtfallType.IKKE_OPPFYLT;
-  }
-  return vilkarUtfallType.OPPFYLT;
-};
-
-export default findStatusForVedtak;
+export default vedtakStatusUtlederUngdomsytelse;

--- a/packages/behandling-unntak/src/panelDefinisjoner/vedtakStatusUtleder.ts
+++ b/packages/behandling-unntak/src/panelDefinisjoner/vedtakStatusUtleder.ts
@@ -1,47 +1,6 @@
-import { isAksjonspunktOpen } from '@fpsak-frontend/kodeverk/src/aksjonspunktStatus';
-import { isAvslag } from '@fpsak-frontend/kodeverk/src/behandlingResultatType';
-import aksjonspunktCodes from '@fpsak-frontend/kodeverk/src/aksjonspunktCodes';
-import vilkarUtfallType from '@fpsak-frontend/kodeverk/src/vilkarUtfallType';
+import { utledVedtakStatus } from '@k9-sak-web/behandling-felles';
 
-// TODO (TOR) Kan denne skrivast om? For høg kompleksitet.
+const vedtakStatusUtleder = (vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat) =>
+  utledVedtakStatus(vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat);
 
-const hasOnlyClosedAps = (aksjonspunkter, vedtakAksjonspunkter) =>
-  aksjonspunkter
-    .filter(ap => !vedtakAksjonspunkter.some(vap => vap.definisjon.kode === ap.definisjon.kode))
-    .every(ap => !isAksjonspunktOpen(ap.status.kode));
-
-const hasAksjonspunkt = ap => ap.definisjon.kode === aksjonspunktCodes.OVERSTYR_BEREGNING;
-
-const isAksjonspunktOpenAndOfType = ap => hasAksjonspunkt(ap) && isAksjonspunktOpen(ap.status.kode);
-
-const harVilkårSomIkkeErOppfylt = vilkar =>
-  vilkar.some(v => v.perioder.some(periode => periode.vilkarStatus.kode === vilkarUtfallType.IKKE_OPPFYLT));
-
-const harVilkårSomIkkeErVurdert = vilkar =>
-  vilkar.some(v => v.perioder.some(periode => periode.vilkarStatus.kode === vilkarUtfallType.IKKE_VURDERT));
-
-const findStatusForVedtak = (vilkar, aksjonspunkter, vedtakAksjonspunkter, behandlingsresultat) => {
-  if (vilkar.length === 0) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (hasOnlyClosedAps(aksjonspunkter, vedtakAksjonspunkter) && harVilkårSomIkkeErOppfylt(vilkar)) {
-    return vilkarUtfallType.IKKE_OPPFYLT;
-  }
-
-  // TODO (Magnus) Burde ikke denne sjekke om vilkår ikke er oppfyllt snarere enn om de ikke er vurdert?
-  if (harVilkårSomIkkeErVurdert(vilkar) || aksjonspunkter.some(isAksjonspunktOpenAndOfType)) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (!hasOnlyClosedAps(aksjonspunkter, vedtakAksjonspunkter)) {
-    return vilkarUtfallType.IKKE_VURDERT;
-  }
-
-  if (isAvslag(behandlingsresultat.type.kode)) {
-    return vilkarUtfallType.IKKE_OPPFYLT;
-  }
-  return vilkarUtfallType.OPPFYLT;
-};
-
-export default findStatusForVedtak;
+export default vedtakStatusUtleder;


### PR DESCRIPTION
### Behov / Bakgrunn
Vi har mye duplisert logikk for utleding av vedtakstatus.
Bør samles felles sted og ha tilhørende tester.

### Løsning
Samler logikk for utleding av vedtakstatus i behandling-felles. Bruker old-school typer.
Lager tester for logikk.
Dokumenterer logikk.

### Andre endringer

