### PR TITLE
chore: bumper react-router til 7.16.0

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,6 +10,7 @@ npmMinimalAgeGate: 7d
 
 npmPreapprovedPackages:
   - "@navikt/*"
+  - "react-router@7.16.0"
 
 npmScopes:
   navikt:

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "react-dom": "19.2.6",
     "react-hook-form": "7.76.0",
     "react-intl": "10.1.8",
-    "react-router": "7.15.1",
+    "react-router": "7.16.0",
     "vite-plugin-svgr": "5.2.0"
   },
   "devDependencies": {

--- a/packages/prosess-aarskvantum-oms/package.json
+++ b/packages/prosess-aarskvantum-oms/package.json
@@ -19,7 +19,7 @@
     "react-dom": "19.2.6",
     "react-intl": "10.1.8",
     "react-redux": "9.3.0",
-    "react-router": "7.15.1",
+    "react-router": "7.16.0",
     "redux": "5.0.1",
     "redux-form": "8.3.10"
   },

--- a/packages/sak-app/package.json
+++ b/packages/sak-app/package.json
@@ -48,7 +48,7 @@
     "react-hook-form": "7.76.0",
     "react-intl": "10.1.8",
     "react-redux": "9.3.0",
-    "react-router": "7.15.1",
+    "react-router": "7.16.0",
     "redux": "5.0.1",
     "redux-form": "8.3.10",
     "redux-thunk": "3.1.0"

--- a/packages/ung/sak-app/package.json
+++ b/packages/ung/sak-app/package.json
@@ -33,7 +33,7 @@
     "react-hook-form": "7.76.0",
     "react-intl": "10.1.8",
     "react-redux": "9.3.0",
-    "react-router": "7.15.1",
+    "react-router": "7.16.0",
     "redux": "5.0.1"
   },
   "devDependencies": {

--- a/packages/v2/gui/package.json
+++ b/packages/v2/gui/package.json
@@ -50,7 +50,7 @@
     "react-dom": "19.2.6",
     "react-hook-form": "7.76.0",
     "react-intl": "10.1.8",
-    "react-router": "7.15.1",
+    "react-router": "7.16.0",
     "yup": "1.7.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2718,7 +2718,7 @@ __metadata:
     react-dom: "npm:19.2.6"
     react-hook-form: "npm:7.76.0"
     react-intl: "npm:10.1.8"
-    react-router: "npm:7.15.1"
+    react-router: "npm:7.16.0"
     yup: "npm:1.7.1"
   languageName: unknown
   linkType: soft
@@ -2776,7 +2776,7 @@ __metadata:
     react-dom: "npm:19.2.6"
     react-intl: "npm:10.1.8"
     react-redux: "npm:9.3.0"
-    react-router: "npm:7.15.1"
+    react-router: "npm:7.16.0"
     redux: "npm:5.0.1"
     redux-form: "npm:8.3.10"
   languageName: unknown
@@ -2961,7 +2961,7 @@ __metadata:
     react-hook-form: "npm:7.76.0"
     react-intl: "npm:10.1.8"
     react-redux: "npm:9.3.0"
-    react-router: "npm:7.15.1"
+    react-router: "npm:7.16.0"
     redux: "npm:5.0.1"
     redux-form: "npm:8.3.10"
     redux-thunk: "npm:3.1.0"
@@ -3007,7 +3007,7 @@ __metadata:
     react-hook-form: "npm:7.76.0"
     react-intl: "npm:10.1.8"
     react-redux: "npm:9.3.0"
-    react-router: "npm:7.15.1"
+    react-router: "npm:7.16.0"
     redux: "npm:5.0.1"
   languageName: unknown
   linkType: soft
@@ -10686,7 +10686,7 @@ __metadata:
     react-dom: "npm:19.2.6"
     react-hook-form: "npm:7.76.0"
     react-intl: "npm:10.1.8"
-    react-router: "npm:7.15.1"
+    react-router: "npm:7.16.0"
     storybook: "npm:10.4.1"
     stylelint: "npm:17.12.0"
     stylelint-config-standard: "npm:40.0.0"
@@ -12784,9 +12784,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router@npm:7.15.1":
-  version: 7.15.1
-  resolution: "react-router@npm:7.15.1"
+"react-router@npm:7.16.0":
+  version: 7.16.0
+  resolution: "react-router@npm:7.16.0"
   dependencies:
     cookie: "npm:^1.0.1"
     set-cookie-parser: "npm:^2.6.0"
@@ -12796,7 +12796,7 @@ __metadata:
   peerDependenciesMeta:
     react-dom:
       optional: true
-  checksum: 10/0d9f352839708f13586e41bc21d4e74d1ef94ac747d8ba99a424734d17c7f9512926b16ac28a7659cc44ee4dd60b64f63ed58c704deb1cc68800056b377d3b40
+  checksum: 10/2c77d27170eab1dfa6f0593e846f9d352424cc789a505aaee9bee9c9da1ed9d6a044d0a476e3eaf240e73b09169b4ffb85b5910d026a34abd055aed5b2f5a5cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Behov / Bakgrunn
Det er oppdaget sikkerhetshull i react-router. Anbefales å patche til 7.16.0.
https://nav-it.slack.com/archives/C06P91VN27M/p1780465896541369

### Løsning
Bumper react-router.

### Andre endringer

