### PR TITLE
La til default for sluttfaseDokumentSteg

### DIFF
--- a/packages/fakta-medisinsk-vilkår/src/util/statusUtils.ts
+++ b/packages/fakta-medisinsk-vilkår/src/util/statusUtils.ts
@@ -75,7 +75,7 @@ export const finnNesteStegForLivetsSluttfase = (
     return livetsSluttfaseSteg;
   }
 
-  return null;
+  return sluttfaseDokumentSteg;
 };
 export const finnNesteStegForOpplæringspenger = (
   {


### PR DESCRIPTION
### Behov / Bakgrunn
"Dokumentasjon av livets sluttfase" er blank når man, etter å ha allerede vurdert dette, klikker tilbake til Livets sluttfase

### Løsning
Legge til en default at dokumentasjonssteget skal vises og ikke null

### Andre endringer

