### PR TITLE
fix: overstyring i uttak bør komme etter vurdering av dato

### DIFF
--- a/packages/v2/gui/src/prosess/uttak/UttakInnhold.tsx
+++ b/packages/v2/gui/src/prosess/uttak/UttakInnhold.tsx
@@ -1,15 +1,15 @@
-import { useEffect, useState, type JSX } from 'react';
-import { useUttakContext } from './context/UttakContext';
 import { k9_kodeverk_behandling_aksjonspunkt_AksjonspunktStatus as aksjonspunktStatus } from '@k9-sak-web/backend/k9sak/generated/types.js';
 import { Alert, Heading, HStack, VStack } from '@navikt/ds-react';
-import ContentMaxWidth from '../../shared/ContentMaxWidth/ContentMaxWidth';
-import UtsattePerioderStripe from './components/utsattePerioderStripe/UtsattePerioderStripe';
-import OverstyrUttak from './overstyr-uttak/OverstyrUttak';
 import { OverstyringKnapp } from '@navikt/ft-ui-komponenter';
-import VurderOverlappendeSak from './vurder-overlappende-sak/VurderOverlappendeSak';
-import UttaksperiodeListe from './uttaksperiode-liste/UttaksperiodeListe';
+import { useEffect, useState, type JSX } from 'react';
+import ContentMaxWidth from '../../shared/ContentMaxWidth/ContentMaxWidth';
 import Infostripe from './components/infostripe/Infostripe';
+import UtsattePerioderStripe from './components/utsattePerioderStripe/UtsattePerioderStripe';
+import { useUttakContext } from './context/UttakContext';
+import OverstyrUttak from './overstyr-uttak/OverstyrUttak';
+import UttaksperiodeListe from './uttaksperiode-liste/UttaksperiodeListe';
 import VurderDato from './vurder-dato/VurderDato';
+import VurderOverlappendeSak from './vurder-overlappende-sak/VurderOverlappendeSak';
 
 const UttakInnhold = (): JSX.Element => {
   const {
@@ -51,16 +51,18 @@ const UttakInnhold = (): JSX.Element => {
           </Alert>
         </ContentMaxWidth>
       )}
-      {!harEtUløstAksjonspunktIUttak && <OverstyrUttak overstyringAktiv={overstyringAktiv} />}
-      {aksjonspunktVurderOverlappendeSaker && <VurderOverlappendeSak />}
-      <UtsattePerioderStripe />
-      {(harOpprettetAksjonspunktVurderDato || redigerVirkningsdato) && <VurderDato />}
-      {!aksjonspunktVentAnnenPSBSak && (
-        <UttaksperiodeListe
-          redigerVirkningsdatoFunc={() => setRedigervirkningsdato(true)}
-          redigerVirkningsdato={redigerVirkningsdato}
-        />
-      )}
+      <VStack gap="space-32">
+        {aksjonspunktVurderOverlappendeSaker && <VurderOverlappendeSak />}
+        <UtsattePerioderStripe />
+        {(harOpprettetAksjonspunktVurderDato || redigerVirkningsdato) && <VurderDato />}
+        {!harEtUløstAksjonspunktIUttak && <OverstyrUttak overstyringAktiv={overstyringAktiv} />}
+        {!aksjonspunktVentAnnenPSBSak && (
+          <UttaksperiodeListe
+            redigerVirkningsdatoFunc={() => setRedigervirkningsdato(true)}
+            redigerVirkningsdato={redigerVirkningsdato}
+          />
+        )}
+      </VStack>
     </VStack>
   );
 };

--- a/packages/v2/gui/src/prosess/uttak/components/utsattePerioderStripe/utsattePerioderStripe.module.css
+++ b/packages/v2/gui/src/prosess/uttak/components/utsattePerioderStripe/utsattePerioderStripe.module.css
@@ -1,5 +1,4 @@
 .utsattePerioderStripe {
-  margin-bottom: 1.875rem;
   max-width: 64.375rem;
 }
 

--- a/packages/v2/gui/src/prosess/uttak/overstyr-uttak/OverstyrUttak.tsx
+++ b/packages/v2/gui/src/prosess/uttak/overstyr-uttak/OverstyrUttak.tsx
@@ -1,19 +1,19 @@
-import { useState, type FC } from 'react';
-import { PlusCircleIcon } from '@navikt/aksel-icons';
-import { Alert, BodyShort, Button, Heading, HelpText, HStack, Loader, Modal, Table } from '@navikt/ds-react';
-import AktivitetRad from './AktivitetRad';
-import OverstyringUttakForm from './OverstyringUttakForm';
-import { erOverstyringInnenforPerioderTilVurdering } from '../utils/overstyringUtils';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { aksjonspunktCodes } from '@k9-sak-web/backend/k9sak/kodeverk/AksjonspunktCodes.js';
-import type { OverstyringUttakHandling } from '../types/OverstyringUttakTypes';
-import { useRefetchBehandling } from '@k9-sak-web/gui/context/BehandlingContext.js';
-import { useUttakContext } from '../context/UttakContext';
 import {
   k9_kodeverk_behandling_aksjonspunkt_AksjonspunktDefinisjon as AksjonspunktDefinisjon,
   type k9_sak_kontrakt_aksjonspunkt_OverstyringAksjonspunktDto,
 } from '@k9-sak-web/backend/k9sak/generated/types.js';
+import { aksjonspunktCodes } from '@k9-sak-web/backend/k9sak/kodeverk/AksjonspunktCodes.js';
 import type { DTOWithDiscriminatorType } from '@k9-sak-web/backend/shared/typeutils.js';
+import { useRefetchBehandling } from '@k9-sak-web/gui/context/BehandlingContext.js';
+import { PlusCircleIcon } from '@navikt/aksel-icons';
+import { Alert, BodyShort, Button, Heading, HelpText, HStack, Loader, Modal, Table } from '@navikt/ds-react';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { useState, type FC } from 'react';
+import { useUttakContext } from '../context/UttakContext';
+import type { OverstyringUttakHandling } from '../types/OverstyringUttakTypes';
+import { erOverstyringInnenforPerioderTilVurdering } from '../utils/overstyringUtils';
+import AktivitetRad from './AktivitetRad';
+import OverstyringUttakForm from './OverstyringUttakForm';
 import styles from './overstyrUttakForm.module.css';
 
 export enum OverstyrUttakHandling {
@@ -133,7 +133,7 @@ const OverstyrUttak: FC<OverstyrUttakProps> = ({ overstyringAktiv }) => {
 
   if (harNoeÅVise) {
     return (
-      <div className="mt-4 mb-8">
+      <div>
         {harAksjonspunkt(AksjonspunktDefinisjon.OVERSTYRING_AV_UTTAK) && (
           <Alert variant="warning">
             <Heading spacing size="xsmall" level="3">

--- a/packages/v2/gui/src/prosess/uttak/vurder-dato/VurderDato.module.css
+++ b/packages/v2/gui/src/prosess/uttak/vurder-dato/VurderDato.module.css
@@ -1,5 +1,4 @@
 .vurderDatoContainer {
-  margin-top: 1rem;
   max-width: 44rem;
 }
 

--- a/packages/v2/gui/src/prosess/uttak/vurder-dato/VurderDato.tsx
+++ b/packages/v2/gui/src/prosess/uttak/vurder-dato/VurderDato.tsx
@@ -1,9 +1,9 @@
-import { useEffect } from 'react';
-import { Accordion, Alert, BodyLong, Label } from '@navikt/ds-react';
-import { useUttakContext } from '../context/UttakContext';
-import VurderDatoAksjonspunkt from './VurderDatoAksjonspunkt';
-import styles from './VurderDato.module.css';
 import { k9_kodeverk_behandling_aksjonspunkt_AksjonspunktDefinisjon as AksjonspunktDefinisjon } from '@k9-sak-web/backend/k9sak/generated/types.js';
+import { Accordion, Alert, BodyLong, Label } from '@navikt/ds-react';
+import { useEffect } from 'react';
+import { useUttakContext } from '../context/UttakContext';
+import styles from './VurderDato.module.css';
+import VurderDatoAksjonspunkt from './VurderDatoAksjonspunkt';
 
 const scrollToVurderDatoContainer = () => {
   const vurderDatoContainer = document.querySelector('#uttakApp');
@@ -45,7 +45,7 @@ const VurderDato = () => {
 
   return (
     <div className={styles['vurderDatoContainer']}>
-      <Alert variant="warning" size="small" className="mt-4">
+      <Alert variant="warning" size="small">
         <Label size="small">Vurder hvilken dato endringer i uttak skal gjelde fra</Label>
         <BodyLong size="small">
           Det er lansert endringer for hvordan utbetalingsgrad settes for nye aktiviteter, ikke yrkesaktiv og kun

--- a/packages/v2/gui/src/prosess/uttak/vurder-dato/VurderDatoAksjonspunkt.module.css
+++ b/packages/v2/gui/src/prosess/uttak/vurder-dato/VurderDatoAksjonspunkt.module.css
@@ -4,7 +4,6 @@
   gap: 1.9rem;
   padding: 1.3rem 1.95rem 1.7rem 1.5rem;
   border: 1px solid #ff9100;
-  margin-bottom: 3.4rem;
 }
 
 .knapper {


### PR DESCRIPTION
### Behov / Bakgrunn
Ønsker at behandling av overstyring i uttak skal komme etter vurdering av dato.
https://nav-it.slack.com/archives/C050W78B6A0/p1779885054771469

### Løsning
Flytter overstyring av uttak lengere ned i komponent-treet.

### Andre endringer
Justerer spacing mellom paneler.
