### PR TITLE
fix: håndtere at ti dager prosess er automatisk vurdert

### DIFF
--- a/packages/v2/gui/src/prosess/ti-dager/TiDagerProsess.stories.tsx
+++ b/packages/v2/gui/src/prosess/ti-dager/TiDagerProsess.stories.tsx
@@ -85,6 +85,29 @@ const meta = {
     saksnummer: '123456789',
     arbeidsgiverOpplysningerPerId,
     submitCallback: asyncAction('submitCallback'),
+    vilkar: [
+      {
+        vilkarType: 'K9_VK_9_8',
+        lovReferanse: '9-8 tredje ledd',
+        overstyrbar: true,
+        perioder: [
+          {
+            avslagKode: undefined,
+            merknadParametere: {},
+            vilkarStatus: 'IKKE_VURDERT',
+            periode: {
+              fom: '2026-04-06',
+              tom: '2026-04-10',
+            },
+            begrunnelse: undefined,
+            vurderesIBehandlingen: true,
+            vurdersIBehandlingen: true,
+            merknad: '-',
+          },
+        ],
+        relevanteInnvilgetMerknader: [],
+      },
+    ],
   },
 } satisfies Meta<typeof TiDagerProsessIndex>;
 

--- a/packages/v2/gui/src/prosess/ti-dager/TiDagerProsess.tsx
+++ b/packages/v2/gui/src/prosess/ti-dager/TiDagerProsess.tsx
@@ -1,5 +1,7 @@
 import { AksjonspunktDefinisjon } from '@k9-sak-web/backend/combined/kodeverk/behandling/aksjonspunkt/AksjonspunktDefinisjon.js';
+import type { VilkårMedPerioderDto } from '@k9-sak-web/backend/combined/kontrakt/vilkår/VilkårMedPerioderDto.js';
 import { aksjonspunktStatus } from '@k9-sak-web/backend/k9sak/kodeverk/AksjonspunktStatus.js';
+import { vilkårStatus } from '@k9-sak-web/backend/k9sak/kodeverk/behandling/VilkårStatus.js';
 import type { AksjonspunktDto } from '@k9-sak-web/backend/k9sak/kontrakt/aksjonspunkt/AksjonspunktDto.js';
 import type { AvklarRettFraDagEnDto_JournalpostVurderingDto as JournalpostVurderingDto } from '@k9-sak-web/backend/k9sak/kontrakt/inngangsvilkår/AvklarRettFraDagEnDto.js';
 import type { RettFraDagEnVisningDto_JournalpostVisningDto as JournalpostVisningDto } from '@k9-sak-web/backend/k9sak/kontrakt/inngangsvilkår/RettFraDagEnVisningDto.js';
@@ -52,6 +54,7 @@ interface TiDagerProsessIndexProps {
   behandlingUUID: string;
   saksnummer: string;
   arbeidsgiverOpplysningerPerId?: { [key: string]: { navn: string } };
+  vilkar: VilkårMedPerioderDto[];
 }
 
 function formatArbeidsgiverNavn(
@@ -78,6 +81,7 @@ export const TiDagerProsessIndex = ({
   behandlingUUID,
   saksnummer,
   arbeidsgiverOpplysningerPerId,
+  vilkar,
 }: TiDagerProsessIndexProps) => {
   const api = useTiDagerBackendClient();
   const hasSolvedAksjonspunkt = aksjonspunkter[0] && aksjonspunkter[0].status === aksjonspunktStatus.UTFØRT;
@@ -93,6 +97,8 @@ export const TiDagerProsessIndex = ({
     }),
   );
   const [isFormLocked, setIsFormLocked] = useState(hasSolvedAksjonspunkt);
+  const vilkår = vilkar?.[0];
+  const harJournalposter = opplysninger?.journalposter && opplysninger.journalposter.length > 0;
 
   useEffect(() => {
     if (hasSolvedAksjonspunkt) {
@@ -109,7 +115,7 @@ export const TiDagerProsessIndex = ({
   const { fields } = useFieldArray({ control: formMethods.control, name: 'vurderinger' });
 
   useEffect(() => {
-    if (opplysninger) {
+    if (opplysninger && opplysninger.journalposter) {
       const vurderinger = opplysninger.journalposter.map(jp => ({
         journalpostId: jp.journalpostId,
         harUtbetaltPliktigeDager: booleanTilJaNei(jp.harUtbetaltPliktigeDager),
@@ -147,6 +153,19 @@ export const TiDagerProsessIndex = ({
     return (
       <Box paddingInline="space-16 space-32" paddingBlock="space-8">
         <BodyShort>Kunne ikke hente opplysninger om rett fra dag én.</BodyShort>
+      </Box>
+    );
+  }
+  if (
+    vilkår != undefined &&
+    vilkår.perioder != undefined &&
+    vilkår.perioder.length > 0 &&
+    vilkår.perioder.every(p => p.vilkarStatus === vilkårStatus.OPPFYLT) &&
+    !harJournalposter
+  ) {
+    return (
+      <Box paddingInline="space-16 space-32" paddingBlock="space-8">
+        <BodyShort>10 dager har blitt dekket - ref 9-8 3.ledd</BodyShort>
       </Box>
     );
   }

--- a/packages/v2/gui/src/prosess/ti-dager/TiDagerProsess.tsx
+++ b/packages/v2/gui/src/prosess/ti-dager/TiDagerProsess.tsx
@@ -115,7 +115,7 @@ export const TiDagerProsessIndex = ({
   const { fields } = useFieldArray({ control: formMethods.control, name: 'vurderinger' });
 
   useEffect(() => {
-    if (opplysninger && opplysninger.journalposter) {
+    if (opplysninger && harJournalposter) {
       const vurderinger = opplysninger.journalposter.map(jp => ({
         journalpostId: jp.journalpostId,
         harUtbetaltPliktigeDager: booleanTilJaNei(jp.harUtbetaltPliktigeDager),
@@ -123,7 +123,7 @@ export const TiDagerProsessIndex = ({
       const begrunnelse = aksjonspunkter != undefined && aksjonspunkter[0] ? aksjonspunkter[0].begrunnelse : '';
       formMethods.reset({ vurderinger, begrunnelse });
     }
-  }, [opplysninger, formMethods, aksjonspunkter]);
+  }, [opplysninger, formMethods, aksjonspunkter, harJournalposter]);
 
   const onSubmit = async (data: TiDagerFormData) => {
     const payload = [
@@ -157,8 +157,7 @@ export const TiDagerProsessIndex = ({
     );
   }
   if (
-    vilkår != undefined &&
-    vilkår.perioder != undefined &&
+    vilkår?.perioder != undefined &&
     vilkår.perioder.length > 0 &&
     vilkår.perioder.every(p => p.vilkarStatus === vilkårStatus.OPPFYLT) &&
     !harJournalposter


### PR DESCRIPTION
### Behov / Bakgrunn
Løsningen krasjer dersom man åpner panelet Ti dager og det mangler opplysninger. 

### Løsning
Håndterer at endepunktet ikke returnerer journalposter. Viser tekster dersom ingen journalposter og vilkåret er oppfylt.

### Andre endringer

