### PR TITLE
chore: justerer pattern for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,8 @@ updates:
           - 'patch'
           - 'minor'
         exclude-patterns:
-          - 'react*'
+          - 'react'
+          - 'react-dom'
           - '@types/react'
           - '@navikt*'
       react:


### PR DESCRIPTION
### Behov / Bakgrunn
Pakker som react-intl og react-hook-form kan oppdateres sammen med andre pakker nå.

### Løsning
Justerer exclude-patterns bort fra alt som starter med react i navnet. 

### Andre endringer

