### PR TITLE
Bruk gammelt endepunkt for eksisterende funksjonalitet

### DIFF
--- a/packages/sak-app/src/behandlingmenu/BehandlingMenuIndex.tsx
+++ b/packages/sak-app/src/behandlingmenu/BehandlingMenuIndex.tsx
@@ -9,7 +9,6 @@ import MenyEndreBehandlendeEnhetIndexV2 from '@k9-sak-web/gui/sak/meny/endre-enh
 import MenyHenleggIndexV2 from '@k9-sak-web/gui/sak/meny/henlegg-behandling/MenyHenleggIndex.js';
 import MenyMarkerBehandlingV2 from '@k9-sak-web/gui/sak/meny/marker-behandling/MenyMarkerBehandling.js';
 import MenyNyBehandlingIndexV2 from '@k9-sak-web/gui/sak/meny/ny-behandling/MenyNyBehandlingIndex.js';
-import { DELVIS_REVURDERING_ARSAKER_FALLBACK } from '@k9-sak-web/gui/sak/meny/ny-behandling/components/NyBehandlingModal.js';
 import MenySettPaVentIndexV2 from '@k9-sak-web/gui/sak/meny/sett-paa-vent/MenySettPaVentIndex.js';
 import MenyTaAvVentIndexV2 from '@k9-sak-web/gui/sak/meny/ta-av-vent/MenyTaAvVentIndex.js';
 import MenyVergeIndexV2 from '@k9-sak-web/gui/sak/meny/verge/MenyVergeIndex.js';
@@ -174,16 +173,17 @@ export const BehandlingMenuIndex = ({
 
   const fagsakPerson = restApiHooks.useGlobalStateRestApiData<FagsakPerson>(K9sakApiKeys.SAK_BRUKER);
 
-  const delvisÅrsaker = sakRettigheter.delvisRevurderingsårsaker
-    ? new Set(sakRettigheter.delvisRevurderingsårsaker.map(d => d.årsak.kode))
-    : DELVIS_REVURDERING_ARSAKER_FALLBACK;
-
   const lagNyBehandling = useCallback(async (bTypeKode: string, params: any) => {
     let lagNy = lagNyBehandlingK9Sak;
     if (bTypeKode === BehandlingType.TILBAKEKREVING_REVURDERING || bTypeKode === BehandlingType.TILBAKEKREVING) {
       lagNy = lagNyBehandlingTilbake;
     }
-    if (bTypeKode === BehandlingType.REVURDERING && typeof params.steg === 'string' && delvisÅrsaker.has(params.steg)) {
+    const erRevurderingFraStegPayload =
+      bTypeKode === BehandlingType.REVURDERING &&
+      typeof params.steg === 'string' &&
+      (Array.isArray(params.perioder) || (!!params.fom && !!params.tom));
+
+    if (erRevurderingFraStegPayload) {
       lagNy = Array.isArray(params.perioder) && params.perioder.length > 0
         ? lagRevurderingFlerePerioderFraStegK9Sak
         : lagRevurderingFraStegK9Sak;


### PR DESCRIPTION
[FAGSYSTEM-433698](https://jira.adeo.no/browse/FAGSYSTEM-433698)

### Behov / Bakgrunn

Etter utvidelsen av delvis manuell revurdering fra steg (fra kun “revurdering fra uttak” til flere steg), sluttet gammel flyt for “revurdering fra uttak” å fungere i produksjon når feature flag for ny flyt er av.

Saksbehandler fikk feilen:
`Det oppstod en valideringsfeil på felt [behandlingÅrsakType].`

Årsaken var at frontend i noen tilfeller valgte feil endepunkt ved opprettelse av revurdering:
- payload for gammel “fra uttak”-flyt inneholder `steg` + periodefelter (`fom`/`tom`) og skal sendes til revurdering-fra-steg-endepunkt,
- men routinglogikken var avhengig av kode-match i `delvisÅrsaker.has(params.steg)`,
- ved mismatch i kodeformat kunne requesten i stedet gå til “opprett ny behandling”-endepunktet, som krever `behandlingArsakType`, og dermed feilet valideringen.

### Løsning

Routingen i `BehandlingMenuIndex` er gjort robust ved å velge endepunkt basert på payload-form (hva slags flyt requesten faktisk representerer), i stedet for kodeoppslag mot `delvisÅrsaker`.

For `REVURDERING` routes request nå til revurdering-fra-steg-endepunkt når:
- `steg` er satt, og
- enten `perioder` finnes (ny delvis-flyt), eller `fom` og `tom` finnes (gammel uttak-flyt).