### PR TITLE
Tilgangsfeil skal ikke dupliseres

### DIFF
--- a/packages/v2/gui/src/app/feilmeldinger/ForbiddenPage.tsx
+++ b/packages/v2/gui/src/app/feilmeldinger/ForbiddenPage.tsx
@@ -51,7 +51,7 @@ const ForbiddenPage = ({ ikkeTilgangÅrsaker }: ForbiddenPageProps) => {
   return (
     <BigError title="Du har ikke tilgang til denne saken">
       <VStack gap="space-32" className="mt-4">
-        {unikeÅrsaker && unikeÅrsaker.length > 0 ? (
+        {unikeÅrsaker.length > 0 ? (
           <>
             <List>
               {filtrerteÅrsaker.map(årsak => (

--- a/packages/v2/gui/src/app/feilmeldinger/ForbiddenPage.tsx
+++ b/packages/v2/gui/src/app/feilmeldinger/ForbiddenPage.tsx
@@ -44,10 +44,13 @@ const ForbiddenPage = ({ ikkeTilgangÅrsaker }: ForbiddenPageProps) => {
   const filtrerteÅrsaker = ikkeTilgangÅrsaker
     ? ikkeTilgangÅrsaker.filter(årsak => årsakerViØnskerÅVise.includes(årsak))
     : [];
+
+  const unikeÅrsaker = Array.from(new Set(filtrerteÅrsaker));
+
   return (
     <BigError title="Du har ikke tilgang til denne saken">
       <VStack gap="space-32" className="mt-4">
-        {filtrerteÅrsaker && filtrerteÅrsaker.length > 0 ? (
+        {unikeÅrsaker && unikeÅrsaker.length > 0 ? (
           <>
             <List>
               {filtrerteÅrsaker.map(årsak => (

--- a/packages/v2/gui/src/app/feilmeldinger/ForbiddenPage.tsx
+++ b/packages/v2/gui/src/app/feilmeldinger/ForbiddenPage.tsx
@@ -45,6 +45,7 @@ const ForbiddenPage = ({ ikkeTilgangÅrsaker }: ForbiddenPageProps) => {
     ? ikkeTilgangÅrsaker.filter(årsak => årsakerViØnskerÅVise.includes(årsak))
     : [];
 
+  // Fjern duplikater i tilfelle samme årsak oppgis flere ganger
   const unikeÅrsaker = Array.from(new Set(filtrerteÅrsaker));
 
   return (

--- a/packages/v2/gui/src/app/feilmeldinger/ForbiddenPage.tsx
+++ b/packages/v2/gui/src/app/feilmeldinger/ForbiddenPage.tsx
@@ -54,7 +54,7 @@ const ForbiddenPage = ({ ikkeTilgangÅrsaker }: ForbiddenPageProps) => {
         {unikeÅrsaker && unikeÅrsaker.length > 0 ? (
           <>
             <List>
-              {filtrerteÅrsaker.map(årsak => (
+              {unikeÅrsaker.map(årsak => (
                 <List.Item key={årsak}>{årsak_tekst[årsak] ?? årsak}</List.Item>
               ))}
             </List>


### PR DESCRIPTION
### Behov / Bakgrunn
Flere kall gi 403 samtidig og gi samme tilgangsfeil. Disse blir da duplisert i visningen

### Løsning
Viser bare èn av hver feilmelding

