### PR TITLE
feat: Forbedrer styling i dokumentnavigasjon

### DIFF
--- a/packages/fakta-medisinsk-vilkår/src/ui/components/dokumentnavigasjon/Dokumentnavigasjon.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/dokumentnavigasjon/Dokumentnavigasjon.tsx
@@ -7,14 +7,13 @@ import {
   PersonFillIcon,
   PersonIcon,
 } from '@navikt/aksel-icons';
-import { Bleed, BodyShort, Box, Button, Heading, HStack, Pagination, Table, Tooltip } from '@navikt/ds-react';
+import { BodyShort, Box, Button, HStack, Pagination, Table, Tooltip } from '@navikt/ds-react';
 import React, { type JSX } from 'react';
 import { Dokument, dokumentLabel, Dokumenttype } from '../../../types/Dokument';
 import Dokumentfilter from '../dokumentfilter/Dokumentfilter';
 import styles from './dokumentnavigasjon.module.css';
 
 interface DokumentnavigasjonProps {
-  tittel: string;
   dokumenter: Dokument[];
   onDokumentValgt: (dokument: Dokument) => void;
   valgtDokument: Dokument | null;
@@ -71,7 +70,6 @@ const getDatert = (dokument: Dokument) => {
 };
 
 const Dokumentnavigasjon = ({
-  tittel,
   dokumenter,
   onDokumentValgt,
   valgtDokument,
@@ -102,114 +100,101 @@ const Dokumentnavigasjon = ({
   const alleRelevanteDokumentTyper = [...new Set(dokumenter.map(dokument => dokument.type))];
 
   return (
-    <Box className={styles.dokumentnavigasjon}>
-      <Box
-        maxWidth="456px"
-        borderColor="neutral-subtle"
-        borderRadius="8"
-        borderWidth="1"
-        paddingBlock="space-16 space-0"
-        paddingInline="space-16"
-        style={{ alignSelf: 'start' }}
-      >
-        <Heading size="small" level="2">
-          {tittel}
-        </Heading>
-        <Bleed marginInline="space-16">
-          <Table size="medium">
-            <Table.Header>
-              <Table.Row>
-                <Table.HeaderCell textSize="small" scope="col" className={styles.statusCell}>
-                  Status
-                </Table.HeaderCell>
-                {!displayFilterOption && (
-                  <Table.HeaderCell textSize="small" scope="col">
-                    Type
-                  </Table.HeaderCell>
-                )}
-                {displayFilterOption && (
-                  <Table.HeaderCell textSize="small" scope="col">
-                    <Dokumentfilter
-                      className=""
-                      text="Type"
-                      filters={dokumenttypeFilter}
-                      onFilterChange={updateDokumenttypeFilter}
-                      alleRelevanteDokumentTyper={alleRelevanteDokumentTyper}
-                    />
-                  </Table.HeaderCell>
-                )}
+    <>
+      <Box paddingBlock="space-0">
+        <Table size="medium" className={styles.table}>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell textSize="small" scope="col" className={styles.statusCell}>
+                Status
+              </Table.HeaderCell>
+              {!displayFilterOption && (
                 <Table.HeaderCell textSize="small" scope="col">
-                  Datert
+                  Type
                 </Table.HeaderCell>
-                <Table.HeaderCell textSize="small" scope="col" colSpan={3}>
-                  Part
-                </Table.HeaderCell>
-              </Table.Row>
-            </Table.Header>
-            <Table.Body>
-              {dokumenterSomVises.length === 0 && (
-                <Table.Row>
-                  <Table.DataCell colSpan={4}>
-                    <BodyShort size="small">Ingen dokumenter å vise</BodyShort>
-                  </Table.DataCell>
-                </Table.Row>
               )}
-              {dokumenterSomVises.map(dokument => (
-                <Table.Row
-                  key={dokument.id}
-                  onRowClick={() => onDokumentValgt(dokument)}
-                  selected={dokument === valgtDokument}
-                  className={`${styles.selectableRow} ${dokument === valgtDokument ? styles.selectedRow : styles.row}`}
-                >
-                  <Table.DataCell>
-                    <HStack align="center" justify="center">
-                      <StatusIcon dokument={dokument} />
-                    </HStack>
-                  </Table.DataCell>
-                  <Table.DataCell>
-                    <BodyShort size="small">{getDokumenttype(dokument)}</BodyShort>
-                  </Table.DataCell>
-                  <Table.DataCell>
-                    <BodyShort size="small">{getDatert(dokument)}</BodyShort>
-                  </Table.DataCell>
-                  <Table.DataCell>
-                    <HStack align="center">
-                      <PartIcon annenPartErKilde={dokument.annenPartErKilde} />
-                    </HStack>
-                  </Table.DataCell>
-                  <Table.DataCell>
-                    <HStack gap="space-8" align="center">
-                      {dokument.duplikater?.length > 0 && (
-                        <FilesFillIcon
-                          title="Det finnes ett eller flere duplikater av dette dokumentet"
-                          fontSize="1.5rem"
-                        />
-                      )}
-                    </HStack>
-                  </Table.DataCell>
-                  <Table.DataCell>
-                    <HStack align="center" justify="end">
-                      <Button
-                        type="button"
-                        variant="tertiary"
-                        size="small"
-                        onClick={() => onDokumentValgt(dokument)}
-                        icon={<ChevronRightIcon title="Åpne" fontSize="1.5rem" />}
+              {displayFilterOption && (
+                <Table.HeaderCell textSize="small" scope="col">
+                  <Dokumentfilter
+                    className=""
+                    text="Type"
+                    filters={dokumenttypeFilter}
+                    onFilterChange={updateDokumenttypeFilter}
+                    alleRelevanteDokumentTyper={alleRelevanteDokumentTyper}
+                  />
+                </Table.HeaderCell>
+              )}
+              <Table.HeaderCell textSize="small" scope="col">
+                Datert
+              </Table.HeaderCell>
+              <Table.HeaderCell textSize="small" scope="col" colSpan={3}>
+                Part
+              </Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {dokumenterSomVises.length === 0 && (
+              <Table.Row>
+                <Table.DataCell colSpan={4}>
+                  <BodyShort size="small">Ingen dokumenter å vise</BodyShort>
+                </Table.DataCell>
+              </Table.Row>
+            )}
+            {dokumenterSomVises.map(dokument => (
+              <Table.Row
+                key={dokument.id}
+                onRowClick={() => onDokumentValgt(dokument)}
+                selected={dokument === valgtDokument}
+                className={`${styles.selectableRow} ${dokument === valgtDokument ? styles.selectedRow : styles.row}`}
+              >
+                <Table.DataCell>
+                  <HStack align="center" justify="center">
+                    <StatusIcon dokument={dokument} />
+                  </HStack>
+                </Table.DataCell>
+                <Table.DataCell>
+                  <BodyShort size="small">{getDokumenttype(dokument)}</BodyShort>
+                </Table.DataCell>
+                <Table.DataCell>
+                  <BodyShort size="small">{getDatert(dokument)}</BodyShort>
+                </Table.DataCell>
+                <Table.DataCell>
+                  <HStack align="center">
+                    <PartIcon annenPartErKilde={dokument.annenPartErKilde} />
+                  </HStack>
+                </Table.DataCell>
+                <Table.DataCell>
+                  <HStack gap="space-8" align="center">
+                    {dokument.duplikater?.length > 0 && (
+                      <FilesFillIcon
+                        title="Det finnes ett eller flere duplikater av dette dokumentet"
+                        fontSize="1.5rem"
                       />
-                    </HStack>
-                  </Table.DataCell>
-                </Table.Row>
-              ))}
-            </Table.Body>
-          </Table>
-        </Bleed>
-        {usePagination && antallSider > 1 && (
-          <Box paddingBlock="space-16">
-            <Pagination size="small" page={aktivSide} onPageChange={setAktivSide} count={antallSider} />
-          </Box>
-        )}
+                    )}
+                  </HStack>
+                </Table.DataCell>
+                <Table.DataCell>
+                  <HStack align="center" justify="end">
+                    <Button
+                      type="button"
+                      variant="tertiary"
+                      size="small"
+                      onClick={() => onDokumentValgt(dokument)}
+                      icon={<ChevronRightIcon title="Åpne" fontSize="1.5rem" />}
+                    />
+                  </HStack>
+                </Table.DataCell>
+              </Table.Row>
+            ))}
+          </Table.Body>
+        </Table>
       </Box>
-    </Box>
+      {usePagination && antallSider > 1 && (
+        <Box paddingBlock="space-16">
+          <Pagination size="small" page={aktivSide} onPageChange={setAktivSide} count={antallSider} />
+        </Box>
+      )}
+    </>
   );
 };
 

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/dokumentnavigasjon/dokumentnavigasjon.module.css
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/dokumentnavigasjon/dokumentnavigasjon.module.css
@@ -1,7 +1,3 @@
-.dokumentnavigasjon {
-  min-width: 28.5rem;
-}
-
 .statusCell {
   width: 2rem;
   padding-left: 0.875rem;
@@ -12,20 +8,11 @@
 }
 
 .selectedRow {
-  border-left: 5px solid var(--ax-text-accent-decoration);
+  /* stylelint-disable-next-line custom-property-pattern */
+  background-color: var(--ax-bg-accent-moderateA);
 }
 
-.row {
-  border-left: 5px solid transparent;
-}
-
-.dokumentnavigasjon :global(.aksel-expansioncard__content) {
-  overflow: visible;
-  padding-inline: 0;
-  padding-block: 0;
-}
-
-.dokumentnavigasjon :global(.aksel-expansioncard__content-inner) {
-  padding: 0;
-  overflow: visible;
+.table {
+  border-radius: 8px;
+  overflow: hidden;
 }

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/strukturering-av-dokumentasjon/StruktureringAvDokumentasjon.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/strukturering-av-dokumentasjon/StruktureringAvDokumentasjon.tsx
@@ -6,7 +6,7 @@ import React, { type JSX, useMemo } from 'react';
 import FeatureTogglesContext from '@k9-sak-web/gui/featuretoggles/FeatureTogglesContext.js';
 import { NavigationWithDetailView } from '@k9-sak-web/gui/shared/navigation-with-detail-view/NavigationWithDetailView.js';
 import { PageContainer } from '@k9-sak-web/gui/shared/pageContainer/PageContainer.js';
-import { Box } from '@navikt/ds-react';
+import { Bleed, Box, ExpansionCard, Heading } from '@navikt/ds-react';
 import Dokument from '../../../types/Dokument';
 import Dokumentoversikt from '../../../types/Dokumentoversikt';
 import { DokumentoversiktResponse } from '../../../types/DokumentoversiktResponse';
@@ -27,6 +27,7 @@ import Innleggelsesperiodeoversikt from '../innleggelsesperiodeoversikt/Innlegge
 import SignertSeksjon from '../signert-seksjon/SignertSeksjon';
 import ActionType from './actionTypes';
 import dokumentReducer from './reducer';
+import styles from './struktureringAvDokumentasjon.module.css';
 
 interface StruktureringAvDokumentasjonProps {
   navigerTilNesteSteg: () => void;
@@ -157,21 +158,42 @@ const StruktureringAvDokumentasjon = ({
             noBorder
             navigationSection={() => (
               <>
-                <Dokumentnavigasjon
-                  tittel="Dokumenter til behandling"
-                  dokumenter={dokumentoversikt.ustrukturerteDokumenter}
-                  onDokumentValgt={velgDokument}
-                  valgtDokument={valgtDokument}
-                />
-                <Box marginBlock="space-24 space-0">
-                  <Dokumentnavigasjon
-                    tittel="Andre dokumenter"
-                    dokumenter={dokumentoversikt.strukturerteDokumenter}
-                    onDokumentValgt={velgDokument}
-                    valgtDokument={valgtDokument}
-                    displayFilterOption
-                    usePagination
-                  />
+                <Box minWidth="456px">
+                  <Box
+                    borderColor="neutral"
+                    borderRadius="12"
+                    borderWidth="1"
+                    paddingBlock="space-16 space-0"
+                    paddingInline="space-16"
+                    style={{ alignSelf: 'start' }}
+                  >
+                    <Heading size="small" level="2">
+                      Dokumenter til behandling
+                    </Heading>
+                    <Bleed marginInline="space-16">
+                      <Dokumentnavigasjon
+                        dokumenter={dokumentoversikt.ustrukturerteDokumenter}
+                        onDokumentValgt={velgDokument}
+                        valgtDokument={valgtDokument}
+                      />
+                    </Bleed>
+                  </Box>
+                </Box>
+                <Box marginBlock="space-24 space-0" minWidth="456px" className={styles.ekspanderbarDokumentnavigasjon}>
+                  <ExpansionCard aria-label="Andre dokumenter" size="small" defaultOpen={false}>
+                    <ExpansionCard.Header>
+                      <ExpansionCard.Title size="small">Andre dokumenter</ExpansionCard.Title>
+                    </ExpansionCard.Header>
+                    <ExpansionCard.Content>
+                      <Dokumentnavigasjon
+                        dokumenter={dokumentoversikt.strukturerteDokumenter}
+                        onDokumentValgt={velgDokument}
+                        valgtDokument={valgtDokument}
+                        displayFilterOption
+                        usePagination
+                      />
+                    </ExpansionCard.Content>
+                  </ExpansionCard>
                 </Box>
               </>
             )}

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/strukturering-av-dokumentasjon/struktureringAvDokumentasjon.module.css
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/strukturering-av-dokumentasjon/struktureringAvDokumentasjon.module.css
@@ -1,0 +1,10 @@
+.ekspanderbarDokumentnavigasjon :global(.aksel-expansioncard__content) {
+  overflow: visible;
+  padding-inline: 0;
+  padding-block: 0;
+}
+
+.ekspanderbarDokumentnavigasjon :global(.aksel-expansioncard__content-inner) {
+  padding: 0;
+  overflow: visible;
+}


### PR DESCRIPTION
### Behov / Bakgrunn
Ønsker å endre på styling i Dokumentnavigasjon.
Dokumenter til behandling skal alltid være åpen.
Andre dokumenter skal være lukket ved default.

### Løsning
Justerer styling og komponenter.

### Andre endringer
<img width="495" height="442" alt="Skjermbilde 2026-06-12 kl  14 26 05" src="https://github.com/user-attachments/assets/cafe243b-1d01-405f-9490-11d96ecda847" />


