### PR TITLE
Nattevåk og beredskap skal ikke kunne redigeres uten aksjonspunkt

### DIFF
--- a/packages/behandling-opplaeringspenger/src/components/EtablertTilsyn.tsx
+++ b/packages/behandling-opplaeringspenger/src/components/EtablertTilsyn.tsx
@@ -21,13 +21,12 @@ export default ({ aksjonspunkter, behandling, readOnly, submitCallback }) => {
 
   const harUløstAksjonspunktForBeredskap = beredskapAksjonspunkt?.status.kode === aksjonspunktStatus.OPPRETTET;
   const harUløstAksjonspunktForNattevåk = nattevåkAksjonspunkt?.status.kode === aksjonspunktStatus.OPPRETTET;
-  const harAksjonspunkt = !!beredskapAksjonspunktkode || !!nattevåkAksjonspunktkode;
 
   return (
     <EtablertTilsynContainer
       data={{
         httpErrorHandler: httpErrorHandlerCaller,
-        readOnly: readOnly || !harAksjonspunkt,
+        readOnly,
         endpoints: findEndpointsFromRels(behandling.links, [
           { rel: 'opplaeringspenger-sykt-barn-tilsyn', desiredName: 'tilsyn' },
           { rel: 'sykdom-vurdering-oversikt-ktp', desiredName: 'sykdom' },

--- a/packages/behandling-pleiepenger/src/components/EtablertTilsyn.tsx
+++ b/packages/behandling-pleiepenger/src/components/EtablertTilsyn.tsx
@@ -22,13 +22,12 @@ export default ({ aksjonspunkter, behandling, readOnly, submitCallback }) => {
 
   const harUløstAksjonspunktForBeredskap = beredskapAksjonspunkt?.status.kode === aksjonspunktStatus.OPPRETTET;
   const harUløstAksjonspunktForNattevåk = nattevåkAksjonspunkt?.status.kode === aksjonspunktStatus.OPPRETTET;
-  const harAksjonspunkt = !!beredskapAksjonspunktkode || !!nattevåkAksjonspunktkode;
 
   return (
     <EtablertTilsynContainer
       data={{
         httpErrorHandler: httpErrorHandlerCaller,
-        readOnly: readOnly || !harAksjonspunkt,
+        readOnly,
         endpoints: findEndpointsFromRels(behandling.links, [
           { rel: 'pleiepenger-sykt-barn-tilsyn', desiredName: 'tilsyn' },
           { rel: 'sykdom-vurdering-oversikt-ktp', desiredName: 'sykdom' },

--- a/packages/fakta-etablert-tilsyn/src/ui/EtablertTilsyn.stories.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/EtablertTilsyn.stories.tsx
@@ -120,6 +120,156 @@ EtablertTilsyn.parameters = {
   },
 };
 
+export const UtenAksjonspunkter: Story = {
+  args: {
+    data: {
+      readOnly: false,
+      endpoints: {
+        tilsyn: `${mockUrlPrepend}/mock/tilsyn`,
+        sykdom: `${mockUrlPrepend}/mock/sykdom`,
+        sykdomInnleggelse: `${mockUrlPrepend}/mock/sykdomInnleggelse`,
+      },
+      httpErrorHandler: () => {},
+      lagreBeredskapvurdering: fn(),
+      lagreNattevåkvurdering: fn(),
+      harAksjonspunktForBeredskap: false,
+      harAksjonspunktForNattevåk: false,
+    },
+  },
+  parameters: {
+    msw: {
+      handlers,
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('skal ikke vise submit-knapp for beredskap uten aksjonspunkt', async () => {
+      await userEvent.click(canvas.getByRole('tab', { name: 'Beredskap' }));
+      await waitFor(async () => {
+        await expect(
+          canvas.getByRole('textbox', {
+            name: 'Gjør en vurdering av om det er behov for beredskap etter § 9-11, tredje ledd.',
+          }),
+        ).toBeDisabled();
+      });
+      await expect(canvas.queryByText('Bekreft og fortsett')).not.toBeInTheDocument();
+    });
+
+    await step('skal ikke vise submit-knapp for nattevåk uten aksjonspunkt', async () => {
+      await userEvent.click(canvas.getByRole('tab', { name: 'Nattevåk' }));
+      await waitFor(async () => {
+        await expect(
+          canvas.getByRole('textbox', {
+            name: 'Gjør en vurdering av om det er behov for nattevåk etter § 9-11, tredje ledd.',
+          }),
+        ).toBeDisabled();
+      });
+      await expect(canvas.queryByText('Bekreft og fortsett')).not.toBeInTheDocument();
+    });
+  },
+};
+
+export const BareNattevåkAksjonspunkt: Story = {
+  args: {
+    data: {
+      readOnly: false,
+      endpoints: {
+        tilsyn: `${mockUrlPrepend}/mock/tilsyn`,
+        sykdom: `${mockUrlPrepend}/mock/sykdom`,
+        sykdomInnleggelse: `${mockUrlPrepend}/mock/sykdomInnleggelse`,
+      },
+      httpErrorHandler: () => {},
+      lagreBeredskapvurdering: fn(),
+      lagreNattevåkvurdering: fn(),
+      harAksjonspunktForBeredskap: false,
+      harAksjonspunktForNattevåk: true,
+    },
+  },
+  parameters: {
+    msw: {
+      handlers,
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('skal ikke vise submit-knapp for beredskap uten aksjonspunkt', async () => {
+      await userEvent.click(canvas.getByRole('tab', { name: 'Beredskap' }));
+      await waitFor(async () => {
+        await expect(
+          canvas.getByRole('textbox', {
+            name: 'Gjør en vurdering av om det er behov for beredskap etter § 9-11, tredje ledd.',
+          }),
+        ).toBeDisabled();
+      });
+      await expect(canvas.queryByText('Bekreft og fortsett')).not.toBeInTheDocument();
+    });
+
+    await step('skal vise submit-knapp for nattevåk med aksjonspunkt', async () => {
+      await userEvent.click(canvas.getByRole('tab', { name: 'Nattevåk' }));
+      await waitFor(async () => {
+        await expect(
+          canvas.getByRole('textbox', {
+            name: 'Gjør en vurdering av om det er behov for nattevåk etter § 9-11, tredje ledd.',
+          }),
+        ).not.toBeDisabled();
+      });
+      await expect(canvas.getByText('Bekreft og fortsett')).toBeInTheDocument();
+    });
+  },
+};
+
+export const BareBeredskapAksjonspunkt: Story = {
+  args: {
+    data: {
+      readOnly: false,
+      endpoints: {
+        tilsyn: `${mockUrlPrepend}/mock/tilsyn`,
+        sykdom: `${mockUrlPrepend}/mock/sykdom`,
+        sykdomInnleggelse: `${mockUrlPrepend}/mock/sykdomInnleggelse`,
+      },
+      httpErrorHandler: () => {},
+      lagreBeredskapvurdering: fn(),
+      lagreNattevåkvurdering: fn(),
+      harAksjonspunktForBeredskap: true,
+      harAksjonspunktForNattevåk: false,
+    },
+  },
+  parameters: {
+    msw: {
+      handlers,
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('skal vise submit-knapp for beredskap med aksjonspunkt', async () => {
+      await userEvent.click(canvas.getByRole('tab', { name: 'Beredskap' }));
+      await waitFor(async () => {
+        await expect(
+          canvas.getByRole('textbox', {
+            name: 'Gjør en vurdering av om det er behov for beredskap etter § 9-11, tredje ledd.',
+          }),
+        ).not.toBeDisabled();
+      });
+      await expect(canvas.getByText('Bekreft og fortsett')).toBeInTheDocument();
+    });
+
+    await step('skal ikke vise submit-knapp for nattevåk uten aksjonspunkt', async () => {
+      await userEvent.click(canvas.getByRole('tab', { name: 'Nattevåk' }));
+      await waitFor(async () => {
+        await expect(
+          canvas.getByRole('textbox', {
+            name: 'Gjør en vurdering av om det er behov for nattevåk etter § 9-11, tredje ledd.',
+          }),
+        ).toBeDisabled();
+      });
+      await expect(canvas.queryByText('Bekreft og fortsett')).not.toBeInTheDocument();
+    });
+  },
+};
+
 export const BeredskapFerdigVurdert: Story = {
   args: {
     data: {

--- a/packages/fakta-etablert-tilsyn/src/ui/components/beredskap/beredskapsperiode-vurderingsdetaljer/BeredskapsperiodeVurderingsdetaljer.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/beredskap/beredskapsperiode-vurderingsdetaljer/BeredskapsperiodeVurderingsdetaljer.tsx
@@ -22,7 +22,7 @@ const BeredskapsperiodeVurderingsdetaljer = ({
   onEditClick,
   beskrivelser,
 }: BeredskapsperiodeVurderingsdetaljerProps): JSX.Element => {
-  const { readOnly = false } = useContext(ContainerContext) || {};
+  const { readOnly = false, harAksjonspunktForBeredskap = false } = useContext(ContainerContext) || {};
   const { opprettetAv, opprettetTidspunkt } = beredskapsperiode;
   return (
     <DetailView
@@ -34,7 +34,7 @@ const BeredskapsperiodeVurderingsdetaljer = ({
               Rediger vurdering
             </Button>
           )}
-          readOnly={readOnly}
+          readOnly={readOnly || !harAksjonspunktForBeredskap}
         />
       )}
     >

--- a/packages/fakta-etablert-tilsyn/src/ui/components/beredskap/vurdering-av-beredskapsperioder-form/VurderingAvBeredskapsperioderForm.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/beredskap/vurdering-av-beredskapsperioder-form/VurderingAvBeredskapsperioderForm.tsx
@@ -54,7 +54,12 @@ const VurderingAvBeredskapsperioderForm = ({
   onCancelClick,
   beskrivelser,
 }: VurderingAvBeredskapsperioderFormProps): JSX.Element => {
-  const { lagreBeredskapvurdering, readOnly } = React.useContext(ContainerContext) || {};
+  const {
+    lagreBeredskapvurdering,
+    readOnly,
+    harAksjonspunktForBeredskap = false,
+  } = React.useContext(ContainerContext) || {};
+  const disabled = readOnly || !harAksjonspunktForBeredskap;
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const defaultBehovForBeredeskap = () => {
     if (beredskapsperiode.resultat === Vurderingsresultat.OPPFYLT) {
@@ -136,7 +141,7 @@ const VurderingAvBeredskapsperioderForm = ({
           onAvbryt={onCancelClick}
           cancelButtonDisabled={isSubmitting}
           submitButtonDisabled={isSubmitting}
-          shouldShowSubmitButton={!readOnly}
+          shouldShowSubmitButton={!disabled}
           smallButtons
         >
           <Box marginBlock="space-24 space-0">
@@ -147,7 +152,7 @@ const VurderingAvBeredskapsperioderForm = ({
               label="Gjør en vurdering av om det er behov for beredskap etter § 9-11, tredje ledd."
               name={FieldName.BEGRUNNELSE}
               validators={{ required }}
-              disabled={readOnly}
+              disabled={disabled}
             />
           </Box>
           <Box marginBlock="space-32 space-0">
@@ -160,7 +165,7 @@ const VurderingAvBeredskapsperioderForm = ({
               ]}
               name={FieldName.HAR_BEHOV_FOR_BEREDSKAP}
               validators={{ required }}
-              disabled={readOnly}
+              disabled={disabled}
             />
           </Box>
           {erDetBehovForBeredskap === RadioOptions.JA_DELER && (
@@ -170,7 +175,7 @@ const VurderingAvBeredskapsperioderForm = ({
                 legend="I hvilke perioder er det behov for beredskap?"
                 fromDatepickerProps={{ label: 'Fra', ariaLabel: 'Fra' }}
                 toDatepickerProps={{ label: 'Til', ariaLabel: 'Til' }}
-                disabled={readOnly}
+                disabled={disabled}
                 defaultValues={[new Period(beredskapsperiode.periode.fom, beredskapsperiode.periode.tom)]}
                 renderContentAfterElement={(index, numberOfItems, fieldArrayMethods) =>
                   numberOfItems > 1 ? (

--- a/packages/fakta-etablert-tilsyn/src/ui/components/nattevåk/nattevåksperiode-vurderingsdetaljer/NattevåksperiodeVurderingsdetaljer.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/nattevåk/nattevåksperiode-vurderingsdetaljer/NattevåksperiodeVurderingsdetaljer.tsx
@@ -22,7 +22,7 @@ const NattevåksperiodeVurderingsdetaljer = ({
   onEditClick,
   beskrivelser,
 }: NattevåksperiodeVurderingsdetaljerProps) => {
-  const { readOnly = false } = useContext(ContainerContext) || {};
+  const { readOnly = false, harAksjonspunktForNattevåk = false } = useContext(ContainerContext) || {};
   const { opprettetAv, opprettetTidspunkt } = nattevåksperiode;
   return (
     <DetailView
@@ -34,7 +34,7 @@ const NattevåksperiodeVurderingsdetaljer = ({
               Rediger vurdering
             </Button>
           )}
-          readOnly={readOnly}
+          readOnly={readOnly || !harAksjonspunktForNattevåk}
         />
       )}
     >

--- a/packages/fakta-etablert-tilsyn/src/ui/components/nattevåk/vurdering-av-nattevåksperioder-form/VurderingAvNattevåksperioderForm.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/nattevåk/vurdering-av-nattevåksperioder-form/VurderingAvNattevåksperioderForm.tsx
@@ -53,7 +53,12 @@ const VurderingAvNattevåksperioderForm = ({
   onCancelClick,
   beskrivelser,
 }: VurderingAvNattevåksperioderFormProps): JSX.Element => {
-  const { lagreNattevåkvurdering, readOnly } = React.useContext(ContainerContext) || {};
+  const {
+    lagreNattevåkvurdering,
+    readOnly,
+    harAksjonspunktForNattevåk = false,
+  } = React.useContext(ContainerContext) || {};
+  const disabled = readOnly || !harAksjonspunktForNattevåk;
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const defaultBehovForNattevåk = () => {
     if (nattevåksperiode.resultat === Vurderingsresultat.OPPFYLT) {
@@ -129,7 +134,7 @@ const VurderingAvNattevåksperioderForm = ({
           onAvbryt={onCancelClick}
           cancelButtonDisabled={isSubmitting}
           submitButtonDisabled={isSubmitting}
-          shouldShowSubmitButton={!readOnly}
+          shouldShowSubmitButton={!disabled}
           smallButtons
         >
           <Box marginBlock="space-24 space-0">
@@ -139,7 +144,7 @@ const VurderingAvNattevåksperioderForm = ({
             <TextAreaRHF
               label="Gjør en vurdering av om det er behov for nattevåk etter § 9-11, tredje ledd."
               name={FieldName.BEGRUNNELSE}
-              disabled={readOnly}
+              disabled={disabled}
             />
           </Box>
           <Box marginBlock="space-32 space-0">
@@ -151,7 +156,7 @@ const VurderingAvNattevåksperioderForm = ({
                 { value: RadioOptions.NEI, label: 'Nei' },
               ]}
               name={FieldName.HAR_BEHOV_FOR_NATTEVÅK}
-              disabled={readOnly}
+              disabled={disabled}
             />
           </Box>
           {erDetBehovForNattevåk === RadioOptions.JA_DELER && (
@@ -162,7 +167,7 @@ const VurderingAvNattevåksperioderForm = ({
                 fromDatepickerProps={{ label: 'Fra', ariaLabel: 'Fra' }}
                 toDatepickerProps={{ label: 'Til', ariaLabel: 'Til' }}
                 defaultValues={[new Period(nattevåksperiode.periode.fom, nattevåksperiode.periode.tom)]}
-                disabled={readOnly}
+                disabled={disabled}
                 renderContentAfterElement={(index, numberOfItems, fieldArrayMethods) =>
                   numberOfItems > 1 ? (
                     <DeleteButton


### PR DESCRIPTION
### Behov / Bakgrunn
I dag sjekker vi om man har enten aksjonsjonspunktet for nattevåk eller beredskap, og da får man lov til å redigere begge to i GUI. Det er feil, de skal sjekkes hver for seg. Når man submitter uten aksjonspunkt får man feil mot backend. 

### Løsning
Fjerner aksjonspunktene fra readOnly-variabelen og flytter de nedover i komponentene

### Kontekst
Rotårsaken er at saksbehandler ønsker å redigere perioder fra tidligere behandling, men der må backend endres til å opprette aksjonspunktet når det er perioder finnes perioder fra tidligere behandlinger, selv om det ikke er noen nye perioder. Så viser vi fortsett-knapp i frontend, som allerede er implementert. Er opprettet JIRA egen på dette