### PR TITLE
Fix: legger på liten padding til venstre for tekst

### DIFF
--- a/packages/fakta-medisinsk-vilkår/src/ui/components/dokumentnavigasjon/Dokumentnavigasjon.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/dokumentnavigasjon/Dokumentnavigasjon.tsx
@@ -136,7 +136,9 @@ const Dokumentnavigasjon = ({
             {dokumenterSomVises.length === 0 && (
               <Table.Row>
                 <Table.DataCell colSpan={4}>
-                  <BodyShort size="small">Ingen dokumenter å vise</BodyShort>
+                  <BodyShort size="small" className={styles.noDocuments}>
+                    Ingen dokumenter å vise
+                  </BodyShort>
                 </Table.DataCell>
               </Table.Row>
             )}

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/dokumentnavigasjon/dokumentnavigasjon.module.css
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/dokumentnavigasjon/dokumentnavigasjon.module.css
@@ -16,3 +16,7 @@
   border-radius: 8px;
   overflow: hidden;
 }
+
+.noDocuments {
+  padding-left: 0.5rem;
+}


### PR DESCRIPTION
### Behov / Bakgrunn
Mangler litt padding på venstre side av tekst som vises i dokumentnavigasjon i Sykdomsteget.

### Løsning
Legger på padding.

### Andre endringer

