### PR TITLE
TSFF-2732: Vis infoboks om å fortsette dersom alle vurderinger er gjort

### DIFF
--- a/packages/v2/gui/src/fakta/inntektsmelding/stories/Inntektsmelding.stories.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/stories/Inntektsmelding.stories.tsx
@@ -1,5 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
-import { expect, userEvent, waitFor, within } from 'storybook/test';
+import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import inntektsmeldingPropsMock, {
   aksjonspunkt9071FerdigProps,
   aksjonspunkt9071Props,
@@ -204,9 +204,9 @@ export const FerdigVisning9071: Story = {
 };
 
 export const AlleInntektsmeldingerMottatt: Story = {
-  args: createProps(alleErMottatt.behandlingUuid, aksjonspunkt9071Props),
+  args: createProps(alleErMottatt.behandlingUuid, { ...aksjonspunkt9071Props, submitCallback: fn() }),
   decorators: [withFakeInntektsmeldingApi(alleErMottatt.behandlingUuid, alleErMottatt.vurdering)],
-  play: async ({ canvasElement, step }) => {
+  play: async ({ canvasElement, step, args }) => {
     const canvas = within(canvasElement);
     const user = userEvent.setup();
 
@@ -217,8 +217,23 @@ export const AlleInntektsmeldingerMottatt: Story = {
     await step(
       'Hvis det tidligere er blitt gjort en vurdering og behandlingen har hoppet tilbake må man kunne løse aksjonspunktet',
       async () => {
-        const sendInnButton = await canvas.findByRole('button', { name: /Send inn/i });
+        const sendInnButton = await canvas.findByRole('button', { name: /Fortsett uten endring/i });
         await user.click(sendInnButton);
+        await waitFor(() =>
+          expect(args.submitCallback).toHaveBeenCalledWith([
+            expect.objectContaining({
+              '@type': '9071',
+              kode: '9071',
+              perioder: [
+                expect.objectContaining({
+                  periode: '2022-08-01/2022-08-04',
+                  fortsett: false,
+                  vurdering: 'UDEFINERT',
+                }),
+              ],
+            }),
+          ]),
+        );
       },
     );
   },

--- a/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingAksjonspunktForm.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingAksjonspunktForm.tsx
@@ -1,7 +1,6 @@
 import AksjonspunktBox from '@k9-sak-web/gui/shared/aksjonspunktBox/AksjonspunktBox.js';
 import { Lovreferanse } from '@k9-sak-web/gui/shared/lovreferanse/Lovreferanse.js';
 import type { AksjonspunktDto } from '@k9-sak-web/backend/k9sak/kontrakt/aksjonspunkt/AksjonspunktDto.js';
-import { Status as InntektsmeldingStatus } from '@k9-sak-web/backend/k9sak/kontrakt/kompletthet/Status.js';
 import { Alert, Box, Button, Heading, Radio } from '@navikt/ds-react';
 import { RhfForm, RhfRadioGroup, RhfTextarea } from '@navikt/ft-form-hooks';
 import type { FieldValues, UseFormReturn } from 'react-hook-form';
@@ -104,9 +103,8 @@ const InntektsmeldingAksjonspunktForm = ({
     aksjonspunktKode !== '9069' || beslutning === InntektsmeldingVurderingRequestKode.FORTSETT;
 
   // Formater arbeidsgiverliste
-  const arbeidsgivereMedMangler = tilstand.status.filter(s => s.status === InntektsmeldingStatus.MANGLER);
   const arbeidsgivereString = formatListeMedOg(
-    arbeidsgivereMedMangler.map(
+    tilstand.status.map(
       ({ arbeidsgiver: ag }) =>
         `${arbeidsforhold[ag.arbeidsgiver]?.navn ?? ag.arbeidsgiver} (${ag.arbeidsforhold ?? 'ukjent'})`,
     ),

--- a/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingAlerts.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingAlerts.tsx
@@ -1,0 +1,105 @@
+import { Accordion, Alert, Bleed, BodyLong, Box, Button, Heading } from '@navikt/ds-react';
+
+const ManglendeInntektsmeldingAlert = () => (
+  <Box marginBlock="space-0 space-24">
+    <Alert variant="warning" size="small">
+      <Heading spacing size="xsmall" level="3">
+        Vurder om du kan fortsette behandlingen uten inntektsmelding.
+      </Heading>
+      <BodyLong>
+        Inntektsmelding mangler for en eller flere arbeidsgivere, eller for ett eller flere arbeidsforhold hos samme
+        arbeidsgiver.
+      </BodyLong>
+    </Alert>
+  </Box>
+);
+
+interface FerdigVurdertAlertProps {
+  isSubmitting: boolean;
+  onSubmit: () => void;
+}
+
+const FerdigVurdertAlert = ({ isSubmitting, onSubmit }: FerdigVurdertAlertProps) => (
+  <Box marginBlock="space-0 space-24">
+    <Alert variant="info" size="small">
+      Inntektsmelding er ferdig vurdert og du kan gå videre i behandlingen.
+      <Box marginBlock="space-8 space-0">
+        <form onSubmit={onSubmit}>
+          <Button variant="primary" size="small" loading={isSubmitting} disabled={isSubmitting}>
+            Fortsett uten endring
+          </Button>
+        </form>
+      </Box>
+    </Alert>
+  </Box>
+);
+
+const InntektsmeldingVeiledningAlert = () => (
+  <Box marginBlock="space-0 space-24">
+    <Alert variant="info" size="small">
+      <Accordion>
+        <Accordion.Item>
+          <Bleed marginBlock="space-12">
+            <Accordion.Header className="before:hidden after:hidden">
+              <Heading className="!mb-0 font-normal" spacing size="xsmall" level="3">
+                Når kan du gå videre uten inntektsmelding?
+              </Heading>
+            </Accordion.Header>
+          </Bleed>
+          <Accordion.Content>
+            Vurder om du kan gå videre uten alle inntektsmeldinger hvis:
+            <ul className="m-0 pl-6">
+              <li>Det er rapportert fast og regelmessig lønn de siste 3 månedene før skjæringstidspunktet.</li>
+              <li>
+                Det ikke er rapportert lønn hos arbeidsforholdet de siste 3 månedene før skjæringstidspunktet.
+                Beregningsgrunnlaget for denne arbeidsgiveren vil settes til 0,-.
+              </li>
+              <li>
+                Måneden for skjæringstidspunktet er innrapportert til A-ordningen. Hvis det er innrapportert lavere lønn
+                enn foregående måneder kan det tyde på at arbeidsgiver ikke lenger utbetaler lønn. Det er dermed lavere
+                risiko for at arbeidsgiver vil kreve refusjon.
+              </li>
+            </ul>
+            <Box marginBlock="space-24 space-0">
+              Du bør ikke gå videre uten inntektsmelding hvis:
+              <ul className="m-0 pl-6">
+                <li>
+                  Det er arbeidsforhold og frilansoppdrag i samme organisasjon (sjekk i Aa-registeret). I disse
+                  tilfellene trenger vi inntektsmelding for å skille hva som er arbeidsinntekt og frilansinntekt i samme
+                  organisasjon.
+                </li>
+                <li>
+                  Måneden for skjæringstidspunktet er innrapportert til A-ordningen, og det er utbetalt full lønn. Dette
+                  tyder på at arbeidsgiver forskutterer lønn og vil kreve refusjon. I disse tilfellene bør vi ikke
+                  utbetale til bruker, men vente på inntektsmelding.
+                </li>
+              </ul>
+            </Box>
+          </Accordion.Content>
+        </Accordion.Item>
+      </Accordion>
+    </Alert>
+  </Box>
+);
+
+export interface InntektsmeldingAlertsProps {
+  ferdigVurdert: boolean;
+  kanFortsetteUtenEndring: boolean;
+  isSubmitting: boolean;
+  onSubmit: () => void;
+}
+
+const InntektsmeldingAlerts = ({
+  ferdigVurdert,
+  kanFortsetteUtenEndring,
+  isSubmitting,
+  onSubmit,
+}: InntektsmeldingAlertsProps) => (
+  <>
+    {kanFortsetteUtenEndring && <FerdigVurdertAlert isSubmitting={isSubmitting} onSubmit={onSubmit} />}
+    {!ferdigVurdert && <ManglendeInntektsmeldingAlert />}
+    <InntektsmeldingVeiledningAlert />
+  </>
+);
+
+export default InntektsmeldingAlerts;

--- a/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
@@ -21,7 +21,12 @@ const buildFormDefaultValues = (tilstander: Tilstand[]): FieldValues =>
   Object.fromEntries(
     tilstander.flatMap(t => [
       [`${FieldName.BEGRUNNELSE}${t.periodeOpprinneligFormat}`, t.begrunnelse || ''],
-      [`${FieldName.BESLUTNING}${t.periodeOpprinneligFormat}`, t.vurdering ?? null],
+      [
+        `${FieldName.BESLUTNING}${t.periodeOpprinneligFormat}`,
+        t.vurdering === InntektsmeldingVurderingResponseKode.KAN_FORTSETTE
+          ? InntektsmeldingVurderingRequestKode.FORTSETT
+          : (t.vurdering ?? null),
+      ],
     ]),
   );
 

--- a/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
@@ -1,6 +1,6 @@
 import { finnAktivtAksjonspunkt } from '@k9-sak-web/gui/utils/aksjonspunktUtils.js';
 import { Vurdering as InntektsmeldingVurderingResponseKode } from '@k9-sak-web/backend/k9sak/kodeverk/kompletthet/Vurdering.js';
-import { Accordion, Alert, Bleed, BodyLong, Box, Button, Heading } from '@navikt/ds-react';
+import { Box, Button, Heading } from '@navikt/ds-react';
 import { useMemo, useState } from 'react';
 import { useForm, type FieldValues } from 'react-hook-form';
 import { useKompletthetsoversikt } from '../../api/inntektsmeldingQueries';
@@ -14,109 +14,8 @@ import {
   ingenTilstanderHarMangler,
   transformKompletthetsdata,
 } from '../../util/utils';
+import InntektsmeldingAlerts from './InntektsmeldingAlerts.js';
 import InntektsmeldingListe from './InntektsmeldingListe';
-
-interface InntektsmeldingAlertsProps {
-  ferdigVurdert: boolean;
-  kanFortsetteUtenEndring: boolean;
-  isSubmitting: boolean;
-  onSubmit: () => void;
-}
-
-const ManglendeInntektsmeldingAlert = () => (
-  <Box marginBlock="space-0 space-24">
-    <Alert variant="warning" size="small">
-      <Heading spacing size="xsmall" level="3">
-        Vurder om du kan fortsette behandlingen uten inntektsmelding.
-      </Heading>
-      <BodyLong>
-        Inntektsmelding mangler for en eller flere arbeidsgivere, eller for ett eller flere arbeidsforhold hos samme
-        arbeidsgiver.
-      </BodyLong>
-    </Alert>
-  </Box>
-);
-
-interface FerdigVurdertAlertProps {
-  isSubmitting: boolean;
-  onSubmit: () => void;
-}
-
-const FerdigVurdertAlert = ({ isSubmitting, onSubmit }: FerdigVurdertAlertProps) => (
-  <Box marginBlock="space-0 space-24">
-    <Alert variant="info" size="small">
-      Inntektsmelding er ferdig vurdert og du kan gå videre i behandlingen.
-      <Box marginBlock="space-8 space-0">
-        <form onSubmit={onSubmit}>
-          <Button variant="primary" size="small" loading={isSubmitting} disabled={isSubmitting}>
-            Fortsett uten endring
-          </Button>
-        </form>
-      </Box>
-    </Alert>
-  </Box>
-);
-
-const InntektsmeldingVeiledningAlert = () => (
-  <Box marginBlock="space-0 space-24">
-    <Alert variant="info" size="small">
-      <Accordion>
-        <Accordion.Item>
-          <Bleed marginBlock="space-12">
-            <Accordion.Header className="before:hidden after:hidden">
-              <Heading className="!mb-0 font-normal" spacing size="xsmall" level="3">
-                Når kan du gå videre uten inntektsmelding?
-              </Heading>
-            </Accordion.Header>
-          </Bleed>
-          <Accordion.Content>
-            Vurder om du kan gå videre uten alle inntektsmeldinger hvis:
-            <ul className="m-0 pl-6">
-              <li>Det er rapportert fast og regelmessig lønn de siste 3 månedene før skjæringstidspunktet.</li>
-              <li>
-                Det ikke er rapportert lønn hos arbeidsforholdet de siste 3 månedene før skjæringstidspunktet.
-                Beregningsgrunnlaget for denne arbeidsgiveren vil settes til 0,-.
-              </li>
-              <li>
-                Måneden for skjæringstidspunktet er innrapportert til A-ordningen. Hvis det er innrapportert lavere lønn
-                enn foregående måneder kan det tyde på at arbeidsgiver ikke lenger utbetaler lønn. Det er dermed lavere
-                risiko for at arbeidsgiver vil kreve refusjon.
-              </li>
-            </ul>
-            <Box marginBlock="space-24 space-0">
-              Du bør ikke gå videre uten inntektsmelding hvis:
-              <ul className="m-0 pl-6">
-                <li>
-                  Det er arbeidsforhold og frilansoppdrag i samme organisasjon (sjekk i Aa-registeret). I disse
-                  tilfellene trenger vi inntektsmelding for å skille hva som er arbeidsinntekt og frilansinntekt i samme
-                  organisasjon.
-                </li>
-                <li>
-                  Måneden for skjæringstidspunktet er innrapportert til A-ordningen, og det er utbetalt full lønn. Dette
-                  tyder på at arbeidsgiver forskutterer lønn og vil kreve refusjon. I disse tilfellene bør vi ikke
-                  utbetale til bruker, men vente på inntektsmelding.
-                </li>
-              </ul>
-            </Box>
-          </Accordion.Content>
-        </Accordion.Item>
-      </Accordion>
-    </Alert>
-  </Box>
-);
-
-const InntektsmeldingAlerts = ({
-  ferdigVurdert,
-  kanFortsetteUtenEndring,
-  isSubmitting,
-  onSubmit,
-}: InntektsmeldingAlertsProps) => (
-  <>
-    {kanFortsetteUtenEndring && <FerdigVurdertAlert isSubmitting={isSubmitting} onSubmit={onSubmit} />}
-    {!ferdigVurdert && <ManglendeInntektsmeldingAlert />}
-    <InntektsmeldingVeiledningAlert />
-  </>
-);
 
 const buildFormDefaultValues = (tilstander: Tilstand[]): FieldValues =>
   Object.fromEntries(

--- a/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
@@ -18,83 +18,103 @@ import InntektsmeldingListe from './InntektsmeldingListe';
 
 interface InntektsmeldingAlertsProps {
   ferdigVurdert: boolean;
+  kanFortsetteUtenEndring: boolean;
   isSubmitting: boolean;
   onSubmit: () => void;
 }
 
-const InntektsmeldingAlerts = ({ ferdigVurdert, isSubmitting, onSubmit }: InntektsmeldingAlertsProps) => (
-  <>
-    {!ferdigVurdert ? (
-      <Box marginBlock="space-0 space-24">
-        <Alert variant="warning" size="small">
-          <Heading spacing size="xsmall" level="3">
-            Vurder om du kan fortsette behandlingen uten inntektsmelding.
-          </Heading>
-          <BodyLong>
-            Inntektsmelding mangler for en eller flere arbeidsgivere, eller for ett eller flere arbeidsforhold hos samme
-            arbeidsgiver.
-          </BodyLong>
-        </Alert>
+const ManglendeInntektsmeldingAlert = () => (
+  <Box marginBlock="space-0 space-24">
+    <Alert variant="warning" size="small">
+      <Heading spacing size="xsmall" level="3">
+        Vurder om du kan fortsette behandlingen uten inntektsmelding.
+      </Heading>
+      <BodyLong>
+        Inntektsmelding mangler for en eller flere arbeidsgivere, eller for ett eller flere arbeidsforhold hos samme
+        arbeidsgiver.
+      </BodyLong>
+    </Alert>
+  </Box>
+);
+
+interface FerdigVurdertAlertProps {
+  isSubmitting: boolean;
+  onSubmit: () => void;
+}
+
+const FerdigVurdertAlert = ({ isSubmitting, onSubmit }: FerdigVurdertAlertProps) => (
+  <Box marginBlock="space-0 space-24">
+    <Alert variant="info" size="small">
+      Inntektsmelding er ferdig vurdert og du kan gå videre i behandlingen.
+      <Box marginBlock="space-8 space-0">
+        <form onSubmit={onSubmit}>
+          <Button variant="primary" size="small" loading={isSubmitting} disabled={isSubmitting}>
+            Fortsett uten endring
+          </Button>
+        </form>
       </Box>
-    ) : (
-      <Box marginBlock="space-0 space-24">
-        <Alert variant="info" size="small">
-          Inntektsmelding er ferdig vurdert og du kan gå videre i behandlingen.
-          <Box marginBlock="space-8 space-0">
-            <form onSubmit={onSubmit}>
-              <Button variant="primary" size="small" loading={isSubmitting} disabled={isSubmitting}>
-                Fortsett uten endring
-              </Button>
-            </form>
-          </Box>
-        </Alert>
-      </Box>
-    )}
-    <Box marginBlock="space-0 space-24">
-      <Alert variant="info" size="small">
-        <Accordion>
-          <Accordion.Item>
-            <Bleed marginBlock="space-12">
-              <Accordion.Header className="before:hidden after:hidden">
-                <Heading className="!mb-0 font-normal" spacing size="xsmall" level="3">
-                  Når kan du gå videre uten inntektsmelding?
-                </Heading>
-              </Accordion.Header>
-            </Bleed>
-            <Accordion.Content>
-              Vurder om du kan gå videre uten alle inntektsmeldinger hvis:
+    </Alert>
+  </Box>
+);
+
+const InntektsmeldingVeiledningAlert = () => (
+  <Box marginBlock="space-0 space-24">
+    <Alert variant="info" size="small">
+      <Accordion>
+        <Accordion.Item>
+          <Bleed marginBlock="space-12">
+            <Accordion.Header className="before:hidden after:hidden">
+              <Heading className="!mb-0 font-normal" spacing size="xsmall" level="3">
+                Når kan du gå videre uten inntektsmelding?
+              </Heading>
+            </Accordion.Header>
+          </Bleed>
+          <Accordion.Content>
+            Vurder om du kan gå videre uten alle inntektsmeldinger hvis:
+            <ul className="m-0 pl-6">
+              <li>Det er rapportert fast og regelmessig lønn de siste 3 månedene før skjæringstidspunktet.</li>
+              <li>
+                Det ikke er rapportert lønn hos arbeidsforholdet de siste 3 månedene før skjæringstidspunktet.
+                Beregningsgrunnlaget for denne arbeidsgiveren vil settes til 0,-.
+              </li>
+              <li>
+                Måneden for skjæringstidspunktet er innrapportert til A-ordningen. Hvis det er innrapportert lavere lønn
+                enn foregående måneder kan det tyde på at arbeidsgiver ikke lenger utbetaler lønn. Det er dermed lavere
+                risiko for at arbeidsgiver vil kreve refusjon.
+              </li>
+            </ul>
+            <Box marginBlock="space-24 space-0">
+              Du bør ikke gå videre uten inntektsmelding hvis:
               <ul className="m-0 pl-6">
-                <li>Det er rapportert fast og regelmessig lønn de siste 3 månedene før skjæringstidspunktet.</li>
                 <li>
-                  Det ikke er rapportert lønn hos arbeidsforholdet de siste 3 månedene før skjæringstidspunktet.
-                  Beregningsgrunnlaget for denne arbeidsgiveren vil settes til 0,-.
+                  Det er arbeidsforhold og frilansoppdrag i samme organisasjon (sjekk i Aa-registeret). I disse
+                  tilfellene trenger vi inntektsmelding for å skille hva som er arbeidsinntekt og frilansinntekt i samme
+                  organisasjon.
                 </li>
                 <li>
-                  Måneden for skjæringstidspunktet er innrapportert til A-ordningen. Hvis det er innrapportert lavere
-                  lønn enn foregående måneder kan det tyde på at arbeidsgiver ikke lenger utbetaler lønn. Det er dermed
-                  lavere risiko for at arbeidsgiver vil kreve refusjon.
+                  Måneden for skjæringstidspunktet er innrapportert til A-ordningen, og det er utbetalt full lønn. Dette
+                  tyder på at arbeidsgiver forskutterer lønn og vil kreve refusjon. I disse tilfellene bør vi ikke
+                  utbetale til bruker, men vente på inntektsmelding.
                 </li>
               </ul>
-              <Box marginBlock="space-24 space-0">
-                Du bør ikke gå videre uten inntektsmelding hvis:
-                <ul className="m-0 pl-6">
-                  <li>
-                    Det er arbeidsforhold og frilansoppdrag i samme organisasjon (sjekk i Aa-registeret). I disse
-                    tilfellene trenger vi inntektsmelding for å skille hva som er arbeidsinntekt og frilansinntekt i
-                    samme organisasjon.
-                  </li>
-                  <li>
-                    Måneden for skjæringstidspunktet er innrapportert til A-ordningen, og det er utbetalt full lønn.
-                    Dette tyder på at arbeidsgiver forskutterer lønn og vil kreve refusjon. I disse tilfellene bør vi
-                    ikke utbetale til bruker, men vente på inntektsmelding.
-                  </li>
-                </ul>
-              </Box>
-            </Accordion.Content>
-          </Accordion.Item>
-        </Accordion>
-      </Alert>
-    </Box>
+            </Box>
+          </Accordion.Content>
+        </Accordion.Item>
+      </Accordion>
+    </Alert>
+  </Box>
+);
+
+const InntektsmeldingAlerts = ({
+  ferdigVurdert,
+  kanFortsetteUtenEndring,
+  isSubmitting,
+  onSubmit,
+}: InntektsmeldingAlertsProps) => (
+  <>
+    {kanFortsetteUtenEndring && <FerdigVurdertAlert isSubmitting={isSubmitting} onSubmit={onSubmit} />}
+    {!ferdigVurdert && <ManglendeInntektsmeldingAlert />}
+    <InntektsmeldingVeiledningAlert />
   </>
 );
 
@@ -148,10 +168,10 @@ const InntektsmeldingContainer = () => {
   const harAktivtAksjonspunkt = !!aktivtAksjonspunkt;
   const harEndretTidligereVurdering = !aktivtAksjonspunkt && sisteAksjonspunkt && formState.isDirty;
   const ingenTilstanderMangler = ingenTilstanderHarMangler(tilstanderMedUiState);
+  const ferdigVurdert = harIngenTilstanderTilVurdering && ingenTilstanderMangler;
   const kanSendeInnFlereVurderinger =
     !readOnly && harFlereTilstanderTilVurdering && (harAktivtAksjonspunkt || harEndretTidligereVurdering);
-  const kanFortsetteUtenEndring =
-    !readOnly && harAktivtAksjonspunkt && harIngenTilstanderTilVurdering && ingenTilstanderMangler;
+  const kanFortsetteUtenEndring = !readOnly && harAktivtAksjonspunkt && ferdigVurdert;
 
   const onSubmit = async (data: FieldValues) => {
     if (!aksjonspunktKode) {
@@ -205,7 +225,8 @@ const InntektsmeldingContainer = () => {
       </Heading>
       {harAktivtAksjonspunkt && (
         <InntektsmeldingAlerts
-          ferdigVurdert={kanFortsetteUtenEndring}
+          ferdigVurdert={ferdigVurdert}
+          kanFortsetteUtenEndring={kanFortsetteUtenEndring}
           isSubmitting={formState.isSubmitting}
           onSubmit={handleSubmit(onSubmitUtenEndring)}
         />

--- a/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
@@ -1,4 +1,5 @@
 import { finnAktivtAksjonspunkt } from '@k9-sak-web/gui/utils/aksjonspunktUtils.js';
+import { Vurdering as InntektsmeldingVurderingResponseKode } from '@k9-sak-web/backend/k9sak/kodeverk/kompletthet/Vurdering.js';
 import { Accordion, Alert, Bleed, BodyLong, Box, Button, Heading } from '@navikt/ds-react';
 import { useMemo, useState } from 'react';
 import { useForm, type FieldValues } from 'react-hook-form';
@@ -15,19 +16,40 @@ import {
 } from '../../util/utils';
 import InntektsmeldingListe from './InntektsmeldingListe';
 
-const InntektsmeldingManglerInfo = () => (
+interface InntektsmeldingAlertsProps {
+  ferdigVurdert: boolean;
+  isSubmitting: boolean;
+  onSubmit: () => void;
+}
+
+const InntektsmeldingAlerts = ({ ferdigVurdert, isSubmitting, onSubmit }: InntektsmeldingAlertsProps) => (
   <>
-    <Box marginBlock="space-0 space-24">
-      <Alert variant="warning" size="small">
-        <Heading spacing size="xsmall" level="3">
-          Vurder om du kan fortsette behandlingen uten inntektsmelding.
-        </Heading>
-        <BodyLong>
-          Inntektsmelding mangler for en eller flere arbeidsgivere, eller for ett eller flere arbeidsforhold hos samme
-          arbeidsgiver.
-        </BodyLong>
-      </Alert>
-    </Box>
+    {!ferdigVurdert ? (
+      <Box marginBlock="space-0 space-24">
+        <Alert variant="warning" size="small">
+          <Heading spacing size="xsmall" level="3">
+            Vurder om du kan fortsette behandlingen uten inntektsmelding.
+          </Heading>
+          <BodyLong>
+            Inntektsmelding mangler for en eller flere arbeidsgivere, eller for ett eller flere arbeidsforhold hos samme
+            arbeidsgiver.
+          </BodyLong>
+        </Alert>
+      </Box>
+    ) : (
+      <Box marginBlock="space-0 space-24">
+        <Alert variant="info" size="small">
+          Inntektsmelding er ferdig vurdert og du kan gå videre i behandlingen.
+          <Box marginBlock="space-8 space-0">
+            <form onSubmit={onSubmit}>
+              <Button variant="primary" size="small" loading={isSubmitting} disabled={isSubmitting}>
+                Fortsett uten endring
+              </Button>
+            </form>
+          </Box>
+        </Alert>
+      </Box>
+    )}
     <Box marginBlock="space-0 space-24">
       <Alert variant="info" size="small">
         <Accordion>
@@ -121,11 +143,15 @@ const InntektsmeldingContainer = () => {
     ...finnTilstanderSomRedigeres(tilstanderMedUiState),
   ];
   const harFlereTilstanderTilVurdering = tilstanderTilVurdering.length > 1;
+  const harIngenTilstanderTilVurdering = tilstanderTilVurdering.length === 0;
 
   const harAktivtAksjonspunkt = !!aktivtAksjonspunkt;
   const harEndretTidligereVurdering = !aktivtAksjonspunkt && sisteAksjonspunkt && formState.isDirty;
-  const kanVurderes = harFlereTilstanderTilVurdering || ingenTilstanderHarMangler(tilstanderMedUiState);
-  const kanSendeInn = !readOnly && kanVurderes && (harAktivtAksjonspunkt || harEndretTidligereVurdering);
+  const ingenTilstanderMangler = ingenTilstanderHarMangler(tilstanderMedUiState);
+  const kanSendeInnFlereVurderinger =
+    !readOnly && harFlereTilstanderTilVurdering && (harAktivtAksjonspunkt || harEndretTidligereVurdering);
+  const kanFortsetteUtenEndring =
+    !readOnly && harAktivtAksjonspunkt && harIngenTilstanderTilVurdering && ingenTilstanderMangler;
 
   const onSubmit = async (data: FieldValues) => {
     if (!aksjonspunktKode) {
@@ -152,6 +178,23 @@ const InntektsmeldingContainer = () => {
     });
   };
 
+  const onSubmitUtenEndring = async () => {
+    if (!aksjonspunktKode) {
+      throw new Error('AksjonspunktKode er ikke satt');
+    }
+
+    await onFinished({
+      '@type': aksjonspunktKode,
+      kode: aksjonspunktKode,
+      perioder: tilstanderMedUiState.map(tilstand => ({
+        periode: tilstand.periodeOpprinneligFormat,
+        fortsett: tilstand.vurdering === InntektsmeldingVurderingResponseKode.KAN_FORTSETTE,
+        vurdering: tilstand.vurdering ?? InntektsmeldingVurderingResponseKode.UDEFINERT,
+        begrunnelse: tilstand.begrunnelse || undefined,
+      })),
+    });
+  };
+
   return (
     <div>
       <Heading size="small" level="1">
@@ -160,7 +203,13 @@ const InntektsmeldingContainer = () => {
       <Heading size="xsmall" level="2" className="my-[0.625rem] mt-5">
         Opplysninger til beregning
       </Heading>
-      {harAktivtAksjonspunkt && <InntektsmeldingManglerInfo />}
+      {harAktivtAksjonspunkt && (
+        <InntektsmeldingAlerts
+          ferdigVurdert={kanFortsetteUtenEndring}
+          isSubmitting={formState.isSubmitting}
+          onSubmit={handleSubmit(onSubmitUtenEndring)}
+        />
+      )}
       <Box>
         <InntektsmeldingListe
           tilstander={tilstanderMedUiState}
@@ -170,7 +219,7 @@ const InntektsmeldingContainer = () => {
           harFlereTilstanderTilVurdering={harFlereTilstanderTilVurdering}
         />
       </Box>
-      {kanSendeInn && (
+      {kanSendeInnFlereVurderinger && (
         <Box marginBlock="space-24 space-0">
           <form onSubmit={handleSubmit(onSubmit)}>
             <Button variant="primary" size="small" loading={formState.isSubmitting} disabled={formState.isSubmitting}>

--- a/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
@@ -21,7 +21,7 @@ const buildFormDefaultValues = (tilstander: Tilstand[]): FieldValues =>
   Object.fromEntries(
     tilstander.flatMap(t => [
       [`${FieldName.BEGRUNNELSE}${t.periodeOpprinneligFormat}`, t.begrunnelse || ''],
-      [`${FieldName.BESLUTNING}${t.periodeOpprinneligFormat}`, null],
+      [`${FieldName.BESLUTNING}${t.periodeOpprinneligFormat}`, t.vurdering ?? null],
     ]),
   );
 


### PR DESCRIPTION
### Behov / Bakgrunn
Aksjonspunktet er åpent, men alt er vurdert ved tilbakerulling eller revurdering. Bruker i dag "Send inn"-knapp, men den fungerer ikke siden den ikke fører til innsending av perioder når det kun er èn enkelt periode som må vurderes. 

Den vanlige visningen er også at vi har denne funksjonaliteten i en info-alert, så gjør det likt som andre steder

### Løsning
Lager en fortsett-alert med knapp for å fortsette uten å gjøre nye vurderinger

### Andre greier
- Fiks populering av tidligere løste perioder
- Fiks visning av arbeidsgivernavn i radio
