### PR TITLE
Fix: Visningsfeil i nøkkeltall

### DIFF
--- a/loosely-type-checked-files.json
+++ b/loosely-type-checked-files.json
@@ -211,7 +211,6 @@
   "packages/modal-sett-pa-vent/src/components/SettPaVentModal.tsx",
   "packages/prosess-aarskvantum-oms/src/components/AksjonspunktForm9014.tsx",
   "packages/prosess-aarskvantum-oms/src/components/AktivitetTabell.tsx",
-  "packages/prosess-aarskvantum-oms/src/components/nokkeltall/DagerNavKanUtbetale.tsx",
   "packages/prosess-aarskvantum-oms/src/components/nokkeltall/NokkeltallContainer.tsx",
   "packages/prosess-aarskvantum-oms/src/components/nokkeltall/Restdager.tsx",
   "packages/prosess-aarskvantum-oms/src/components/nokkeltall/durationUtils.ts",

--- a/packages/prosess-aarskvantum-oms/src/components/nokkeltall/DagerNavKanUtbetale.tsx
+++ b/packages/prosess-aarskvantum-oms/src/components/nokkeltall/DagerNavKanUtbetale.tsx
@@ -44,7 +44,7 @@ const DagerNavKanUtbetale = ({
           overskrifttekstId: 'Nøkkeltall.AntallDagerFraværRapportertSomNyoppstartet',
           infotekstContent: <FormattedMessage id="Nøkkeltall.AntallDagerFraværRapportertSomNyoppstartet.InfoText" />,
         },
-      ]}
+      ].filter(v => !!v)}
       viserDetaljer={viserDetaljer}
       visDetaljer={visDetaljer}
       className={styles.dagerNavKanUtbetale}


### PR DESCRIPTION
### Behov / Bakgrunn
Dersom feature toggle for nye nøkkeltall er av vil man få en 'false' i detaljer-arrayet. Ettersom det ikke finnes noen sjekker på om verdiene er definert når de mappes til visning, vil nok alle spans fylles med "undefined" når man destrukturerer det man forventer er et objekt, men egentlig er false

Oppdaget via formatjs-feilmelding i sentry.
```
Error: [@formatjs/intl] An `id` must be provided to format a message. You can either:
1. Configure your build toolchain with [babel-plugin-formatjs](https://formatjs.github.io/docs/tooling/babel-plugin)
or [@formatjs/ts-transformer](https://formatjs.github.io/docs/tooling/ts-transformer) OR
2. Configure your `eslint` config to include [eslint-plugin-formatjs](https://formatjs.github.io/docs/tooling/linter#enforce-id)
to autofix this issue
```

### Løsning
Filtrerer ut falsy verdier av arrayet

### Andre endringer

