### PR TITLE
fix: skal vise vanlig opptjeningspanel dersom man har AP

### DIFF
--- a/packages/behandling-pleiepenger/src/prosess/inngangsvilkårFortsetterPaneler/OpptjeningProsessStegInitPanel.tsx
+++ b/packages/behandling-pleiepenger/src/prosess/inngangsvilkårFortsetterPaneler/OpptjeningProsessStegInitPanel.tsx
@@ -72,7 +72,7 @@ export function OpptjeningProsessStegInitPanel(props: Props) {
     kode => kode === AksjonspunktDefinisjon.OVERSTYRING_AV_OPPTJENINGSVILKÅRET,
   );
 
-  if (erAlleVilkårVurdert) {
+  if (erAlleVilkårVurdert && !isAksjonspunktOpen) {
     return (
       <VilkarresultatMedOverstyringProsessIndex
         aksjonspunkter={[]}


### PR DESCRIPTION
### Behov / Bakgrunn
Viser feil panel ved åpent aksjonspunkt i prosessmeny v2

### Løsning
Viser vanlig panel dersom man har åpent aksjonspunkt.

### Andre endringer

