### PR TITLE
kompletthetsoversikt skal returnere enumverdi i stedet for enumnavn og vi tilpasser frontend

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,11 +10,12 @@ npmMinimalAgeGate: 7d
 
 npmPreapprovedPackages:
   - "@navikt/*"
-  - "react-router@7.16.0"
+  - react-router@7.16.0
 
 npmScopes:
   navikt:
     npmAlwaysAuth: true
+    npmAuthToken: ${NPM_AUTH_TOKEN}
     npmRegistryServer: "https://npm.pkg.github.com"
 
 yarnPath: .yarn/releases/yarn-4.14.1.cjs

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -10,12 +10,11 @@ npmMinimalAgeGate: 7d
 
 npmPreapprovedPackages:
   - "@navikt/*"
-  - react-router@7.16.0
+  - "react-router@7.16.0"
 
 npmScopes:
   navikt:
     npmAlwaysAuth: true
-    npmAuthToken: ${NPM_AUTH_TOKEN}
     npmRegistryServer: "https://npm.pkg.github.com"
 
 yarnPath: .yarn/releases/yarn-4.14.1.cjs

--- a/packages/v2/backend/package.json
+++ b/packages/v2/backend/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@navikt/k9-klage-typescript-client": "3.1.20260529100435",
-    "@navikt/k9-sak-typescript-client": "3.0.20260619084337",
+    "@navikt/k9-sak-typescript-client": "3.0.20260619114434",
     "@navikt/k9-tilbake-typescript-client": "1.1.20260510232128",
     "@navikt/ung-sak-typescript-client": "2.0.20260612140411",
     "@navikt/ung-tilbake-typescript-client": "3.0.20260519143823"

--- a/packages/v2/backend/package.json
+++ b/packages/v2/backend/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@navikt/k9-klage-typescript-client": "3.1.20260529100435",
-    "@navikt/k9-sak-typescript-client": "3.0.20260605142157",
+    "@navikt/k9-sak-typescript-client": "3.0.20260619084337",
     "@navikt/k9-tilbake-typescript-client": "1.1.20260510232128",
     "@navikt/ung-sak-typescript-client": "2.0.20260612140411",
     "@navikt/ung-tilbake-typescript-client": "3.0.20260519143823"

--- a/packages/v2/backend/src/k9sak/kodeverk/kompletthet/Vurdering.ts
+++ b/packages/v2/backend/src/k9sak/kodeverk/kompletthet/Vurdering.ts
@@ -6,6 +6,7 @@ import { k9_kodeverk_beregningsgrunnlag_kompletthet_Vurdering } from '@k9-sak-we
 export const Vurdering = {
   ...k9_kodeverk_beregningsgrunnlag_kompletthet_Vurdering,
   KAN_FORTSETTE: 'FORTSETT',
+  UDEFINERT: '-',
 } as const;
 
 // TODO Dette er kun midlertidig til backend fiks er rulla ut i prod. Fjern når det er gjort.

--- a/packages/v2/backend/src/k9sak/kodeverk/kompletthet/Vurdering.ts
+++ b/packages/v2/backend/src/k9sak/kodeverk/kompletthet/Vurdering.ts
@@ -1,1 +1,12 @@
-export { k9_kodeverk_beregningsgrunnlag_kompletthet_Vurdering as Vurdering } from '@k9-sak-web/backend/k9sak/generated/types.js';
+import { k9_kodeverk_beregningsgrunnlag_kompletthet_Vurdering } from '@k9-sak-web/backend/k9sak/generated/types.js';
+
+// Backend returnerer 'FORTSETT' for KAN_FORTSETTE, men den genererte typen deklarerer feilaktig 'KAN_FORTSETTE'.
+// Vi gjenbruker den genererte konstanten og overstyrer kun KAN_FORTSETTE med den faktiske verdien 'FORTSETT'.
+// TODO Dette er kun midlertidig til backend fiks er rulla ut i prod. Fjern når det er gjort.
+export const Vurdering = {
+  ...k9_kodeverk_beregningsgrunnlag_kompletthet_Vurdering,
+  KAN_FORTSETTE: 'FORTSETT',
+} as const;
+
+// TODO Dette er kun midlertidig til backend fiks er rulla ut i prod. Fjern når det er gjort.
+export type Vurdering = (typeof Vurdering)[keyof typeof Vurdering];

--- a/packages/v2/backend/src/k9sak/kontrakt/kompletthet/KompletthetsPeriode.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/kompletthet/KompletthetsPeriode.ts
@@ -2,6 +2,7 @@ import type { k9_sak_kontrakt_kompletthet_aksjonspunkt_KompletthetsPeriode } fro
 import type { Vurdering } from '@k9-sak-web/backend/k9sak/kodeverk/kompletthet/Vurdering.js';
 
 // Overstyrer den genererte vurdering-typen fordi backend bruker den faktiske verdien 'FORTSETT' for KAN_FORTSETTE.
+// TODO: Kun midlertidig, fjern når endring i Vurdering type er rulla ut til prod i backend
 export type KompletthetsPeriode = Omit<k9_sak_kontrakt_kompletthet_aksjonspunkt_KompletthetsPeriode, 'vurdering'> & {
   vurdering: Vurdering;
 };

--- a/packages/v2/backend/src/k9sak/kontrakt/kompletthet/KompletthetsPeriode.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/kompletthet/KompletthetsPeriode.ts
@@ -1,1 +1,7 @@
-export type { k9_sak_kontrakt_kompletthet_aksjonspunkt_KompletthetsPeriode as KompletthetsPeriode } from '@k9-sak-web/backend/k9sak/generated/types.js';
+import type { k9_sak_kontrakt_kompletthet_aksjonspunkt_KompletthetsPeriode } from '@k9-sak-web/backend/k9sak/generated/types.js';
+import type { Vurdering } from '@k9-sak-web/backend/k9sak/kodeverk/kompletthet/Vurdering.js';
+
+// Overstyrer den genererte vurdering-typen fordi backend bruker den faktiske verdien 'FORTSETT' for KAN_FORTSETTE.
+export type KompletthetsPeriode = Omit<k9_sak_kontrakt_kompletthet_aksjonspunkt_KompletthetsPeriode, 'vurdering'> & {
+  vurdering: Vurdering;
+};

--- a/packages/v2/backend/src/k9sak/kontrakt/kompletthet/KompletthetsTilstandPåPeriodeDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/kompletthet/KompletthetsTilstandPåPeriodeDto.ts
@@ -2,6 +2,7 @@ import type { k9_sak_kontrakt_kompletthet_KompletthetsTilstandPåPeriodeDto } fr
 import type { Vurdering } from '@k9-sak-web/backend/k9sak/kodeverk/kompletthet/Vurdering.js';
 
 // Overstyrer den genererte vurdering-typen fordi backend bruker den faktiske verdien 'FORTSETT' for KAN_FORTSETTE.
+// TODO: Kun midlertidig, fjern når endring i Vurdering type er rulla ut til prod i backend
 export type KompletthetsTilstandPåPeriodeDto = Omit<
   k9_sak_kontrakt_kompletthet_KompletthetsTilstandPåPeriodeDto,
   'vurdering'

--- a/packages/v2/backend/src/k9sak/kontrakt/kompletthet/KompletthetsTilstandPåPeriodeDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/kompletthet/KompletthetsTilstandPåPeriodeDto.ts
@@ -1,1 +1,10 @@
-export type { k9_sak_kontrakt_kompletthet_KompletthetsTilstandPåPeriodeDto as KompletthetsTilstandPåPeriodeDto } from '@k9-sak-web/backend/k9sak/generated/types.js';
+import type { k9_sak_kontrakt_kompletthet_KompletthetsTilstandPåPeriodeDto } from '@k9-sak-web/backend/k9sak/generated/types.js';
+import type { Vurdering } from '@k9-sak-web/backend/k9sak/kodeverk/kompletthet/Vurdering.js';
+
+// Overstyrer den genererte vurdering-typen fordi backend bruker den faktiske verdien 'FORTSETT' for KAN_FORTSETTE.
+export type KompletthetsTilstandPåPeriodeDto = Omit<
+  k9_sak_kontrakt_kompletthet_KompletthetsTilstandPåPeriodeDto,
+  'vurdering'
+> & {
+  vurdering?: Vurdering;
+};

--- a/packages/v2/backend/src/k9sak/kontrakt/kompletthet/KompletthetsVurderingDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/kompletthet/KompletthetsVurderingDto.ts
@@ -1,6 +1,7 @@
 import type { KompletthetsTilstandPåPeriodeDto } from '@k9-sak-web/backend/k9sak/kontrakt/kompletthet/KompletthetsTilstandPåPeriodeDto.js';
 
 // Bruker den overstyrte tilstand-typen slik at vurdering får den korrekte KAN_FORTSETTE-verdien ('FORTSETT').
+// TODO: Kun midlertidig, fjern når endring i Vurdering type er rulla ut til prod i backend
 export type KompletthetsVurderingDto = {
   tilstand: KompletthetsTilstandPåPeriodeDto[];
 };

--- a/packages/v2/backend/src/k9sak/kontrakt/kompletthet/KompletthetsVurderingDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/kompletthet/KompletthetsVurderingDto.ts
@@ -1,1 +1,6 @@
-export type { k9_sak_kontrakt_kompletthet_KompletthetsVurderingDto as KompletthetsVurderingDto } from '@k9-sak-web/backend/k9sak/generated/types.js';
+import type { KompletthetsTilstandPåPeriodeDto } from '@k9-sak-web/backend/k9sak/kontrakt/kompletthet/KompletthetsTilstandPåPeriodeDto.js';
+
+// Bruker den overstyrte tilstand-typen slik at vurdering får den korrekte KAN_FORTSETTE-verdien ('FORTSETT').
+export type KompletthetsVurderingDto = {
+  tilstand: KompletthetsTilstandPåPeriodeDto[];
+};

--- a/packages/v2/gui/src/fakta/inntektsmelding/api/K9InntektsmeldingBackendClient.ts
+++ b/packages/v2/gui/src/fakta/inntektsmelding/api/K9InntektsmeldingBackendClient.ts
@@ -34,6 +34,10 @@ export class K9InntektsmeldingBackendClient implements InntektsmeldingApi {
       return Vurdering.KAN_FORTSETTE;
     }
 
+    if (vurdering === 'UDEFINERT') {
+      return Vurdering.UDEFINERT;
+    }
+
     return vurdering as Vurdering;
   }
 

--- a/packages/v2/gui/src/fakta/inntektsmelding/api/K9InntektsmeldingBackendClient.ts
+++ b/packages/v2/gui/src/fakta/inntektsmelding/api/K9InntektsmeldingBackendClient.ts
@@ -4,6 +4,7 @@ import {
   behandlinger_settBehandlingPaVent,
 } from '@k9-sak-web/backend/k9sak/generated/sdk.js';
 import type { KompletthetsVurderingDto as KompletthetsVurdering } from '@k9-sak-web/backend/k9sak/kontrakt/kompletthet/KompletthetsVurderingDto.js';
+import { Vurdering } from '@k9-sak-web/backend/k9sak/kodeverk/kompletthet/Vurdering.js';
 import type { EtterspørInntektsmeldingRequest } from '@k9-sak-web/backend/k9sak/tjenester/behandling/inntektsmelding/EtterspørInntektsmeldingRequest.js';
 import type { SettBehandlingPaVentDto } from '@k9-sak-web/backend/k9sak/kontrakt/behandling/SettBehandlingPaVentDto.js';
 import type { InntektsmeldingApi } from './InntektsmeldingApi.ts';
@@ -14,7 +15,26 @@ export class K9InntektsmeldingBackendClient implements InntektsmeldingApi {
       query: { behandlingUuid },
     });
 
-    return response.data;
+    return {
+      ...response.data,
+      tilstand: response.data.tilstand.map(tilstand => ({
+        ...tilstand,
+        vurdering: this.mapVurdering(tilstand.vurdering),
+      })),
+    };
+  }
+
+  // Backend kan returnere feil vurderingsverdi: 'KAN_FORTSETTE'/'FORTSETTE' skal tolkes som Vurdering.KAN_FORTSETTE ('FORTSETT').
+  private mapVurdering(vurdering: string | undefined): Vurdering | undefined {
+    if (vurdering === undefined) {
+      return undefined;
+    }
+
+    if (vurdering === 'KAN_FORTSETTE') {
+      return Vurdering.KAN_FORTSETTE;
+    }
+
+    return vurdering as Vurdering;
   }
 
   async etterspørInntektsmelding({

--- a/packages/v2/gui/src/fakta/inntektsmelding/api/K9InntektsmeldingBackendClient.ts
+++ b/packages/v2/gui/src/fakta/inntektsmelding/api/K9InntektsmeldingBackendClient.ts
@@ -24,7 +24,7 @@ export class K9InntektsmeldingBackendClient implements InntektsmeldingApi {
     };
   }
 
-  // Backend kan returnere feil vurderingsverdi: 'KAN_FORTSETTE'/'FORTSETTE' skal tolkes som Vurdering.KAN_FORTSETTE ('FORTSETT').
+  // TODO Fjern så snart fiks for Vurdering enum i k9-sak er rulla ut i prod. (Mapper KAN_FORTSETTE til FORTSETT som snart skal returnerast direkte frå backend.)
   private mapVurdering(vurdering: string | undefined): Vurdering | undefined {
     if (vurdering === undefined) {
       return undefined;

--- a/packages/v2/gui/src/fakta/inntektsmelding/types.ts
+++ b/packages/v2/gui/src/fakta/inntektsmelding/types.ts
@@ -26,8 +26,6 @@ export interface TilstandMedUiState extends Tilstand {
   beslutningFieldName: `beslutning${string}`;
 }
 
-// API request/response typer
-// KompletthetsPeriode.vurdering bruker generert enum (KAN_FORTSETTE), men backend forventer FORTSETT
 export type InntektsmeldingPeriode = KompletthetsPeriode & {
   vurdering?: Vurdering;
   fortsett?: boolean;

--- a/packages/v2/gui/src/fakta/inntektsmelding/types.ts
+++ b/packages/v2/gui/src/fakta/inntektsmelding/types.ts
@@ -5,13 +5,7 @@ import type { KompletthetsPeriode } from '@k9-sak-web/backend/k9sak/kontrakt/kom
 import type { ArbeidsgiverOpplysningerDto } from '@k9-sak-web/backend/k9sak/kontrakt/arbeidsforhold/ArbeidsgiverOpplysningerDto.js';
 import type { DokumentDto } from '@k9-sak-web/backend/k9sak/kontrakt/dokument/DokumentDto.js';
 import type { BehandlingDto } from '@k9-sak-web/backend/k9sak/kontrakt/behandling/BehandlingDto.js';
-
-export const InntektsmeldingVurderingRequestKode = {
-  FORTSETT: 'FORTSETT',
-  MANGLENDE_GRUNNLAG: 'MANGLENDE_GRUNNLAG',
-  IKKE_INNTEKTSTAP: 'IKKE_INNTEKTSTAP',
-  UAVKLART: 'UAVKLART',
-} as const;
+import type { Vurdering } from '@k9-sak-web/backend/k9sak/kodeverk/kompletthet/Vurdering.js';
 
 // Feltnavn for skjema
 export const FieldName = {
@@ -22,6 +16,7 @@ export const FieldName = {
 export interface Tilstand extends Omit<KompletthetsTilstandPåPeriodeDto, 'periode'> {
   periode: Period;
   periodeOpprinneligFormat: string;
+  vurdering?: Vurdering;
 }
 
 export interface TilstandMedUiState extends Tilstand {
@@ -31,13 +26,10 @@ export interface TilstandMedUiState extends Tilstand {
   beslutningFieldName: `beslutning${string}`;
 }
 
-export type InntektsmeldingVurdering =
-  (typeof InntektsmeldingVurderingRequestKode)[keyof typeof InntektsmeldingVurderingRequestKode];
-
 // API request/response typer
 // KompletthetsPeriode.vurdering bruker generert enum (KAN_FORTSETTE), men backend forventer FORTSETT
-export type InntektsmeldingPeriode = Omit<KompletthetsPeriode, 'vurdering'> & {
-  vurdering?: InntektsmeldingVurdering;
+export type InntektsmeldingPeriode = KompletthetsPeriode & {
+  vurdering?: Vurdering;
   fortsett?: boolean;
 };
 

--- a/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingAksjonspunktForm.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingAksjonspunktForm.tsx
@@ -6,26 +6,26 @@ import { RhfForm, RhfRadioGroup, RhfTextarea } from '@navikt/ft-form-hooks';
 import type { FieldValues, UseFormReturn } from 'react-hook-form';
 import { useInntektsmeldingContext } from '../../context/InntektsmeldingContext';
 import type { InntektsmeldingRequestPayload, TilstandMedUiState } from '../../types';
-import { InntektsmeldingVurderingRequestKode } from '../../types';
+import { Vurdering } from '@k9-sak-web/backend/k9sak/kodeverk/kompletthet/Vurdering.js';
 
 type AksjonspunktKode = '9069' | '9071';
 
 const radioConfig: Record<AksjonspunktKode, Array<{ value: string; label: string }>> = {
   '9069': [
-    { value: InntektsmeldingVurderingRequestKode.FORTSETT, label: 'Ja, bruk A-inntekt for {arbeidsgivere}' },
+    { value: Vurdering.KAN_FORTSETTE, label: 'Ja, bruk A-inntekt for {arbeidsgivere}' },
     {
-      value: InntektsmeldingVurderingRequestKode.MANGLENDE_GRUNNLAG,
+      value: Vurdering.MANGLENDE_GRUNNLAG,
       label: 'Nei, send purring på min side arbeidsgiver og varsel om avslag til bruker',
     },
   ],
   '9071': [
-    { value: InntektsmeldingVurderingRequestKode.FORTSETT, label: 'Ja, bruk A-inntekt for {arbeidsgivere}' },
+    { value: Vurdering.KAN_FORTSETTE, label: 'Ja, bruk A-inntekt for {arbeidsgivere}' },
     {
-      value: InntektsmeldingVurderingRequestKode.MANGLENDE_GRUNNLAG,
+      value: Vurdering.MANGLENDE_GRUNNLAG,
       label: 'Nei, avslå på grunn av manglende opplysninger om inntekt etter §21-3',
     },
     {
-      value: InntektsmeldingVurderingRequestKode.IKKE_INNTEKTSTAP,
+      value: Vurdering.IKKE_INNTEKTSTAP,
       label: 'Nei, avslå søknaden på grunn av at ansatt ikke har tapt arbeidsinntekt §9-3',
     },
   ],
@@ -33,22 +33,22 @@ const radioConfig: Record<AksjonspunktKode, Array<{ value: string; label: string
 
 const knappetekster: Record<AksjonspunktKode, Record<string, string>> = {
   '9069': {
-    [InntektsmeldingVurderingRequestKode.FORTSETT]: 'Fortsett uten inntektsmelding',
-    [InntektsmeldingVurderingRequestKode.MANGLENDE_GRUNNLAG]: 'Send purring med varsel om avslag',
+    [Vurdering.KAN_FORTSETTE]: 'Fortsett uten inntektsmelding',
+    [Vurdering.MANGLENDE_GRUNNLAG]: 'Send purring med varsel om avslag',
   },
   '9071': {
-    [InntektsmeldingVurderingRequestKode.FORTSETT]: 'Fortsett uten inntektsmelding',
-    [InntektsmeldingVurderingRequestKode.MANGLENDE_GRUNNLAG]: 'Avslå periode',
-    [InntektsmeldingVurderingRequestKode.IKKE_INNTEKTSTAP]: 'Avslå søknad',
+    [Vurdering.KAN_FORTSETTE]: 'Fortsett uten inntektsmelding',
+    [Vurdering.MANGLENDE_GRUNNLAG]: 'Avslå periode',
+    [Vurdering.IKKE_INNTEKTSTAP]: 'Avslå søknad',
   },
 };
 
 const begrunnelseHjelpetekster: Record<string, string> = {
-  [InntektsmeldingVurderingRequestKode.FORTSETT]:
+  [Vurdering.KAN_FORTSETTE]:
     'Vi benytter opplysninger fra A-inntekt for alle arbeidsgivere vi ikke har mottatt inntektsmelding fra. Gjør en vurdering av hvorfor du benytter A-inntekt for å fastsette grunnlaget etter § 8-28.',
-  [InntektsmeldingVurderingRequestKode.MANGLENDE_GRUNNLAG]:
+  [Vurdering.MANGLENDE_GRUNNLAG]:
     'Skriv begrunnelse for hvorfor du ikke kan benytte opplysninger fra A-inntekt for å fastsette grunnlaget, og avslå saken etter folketrygdloven §§ 21-3 og 8-28.',
-  [InntektsmeldingVurderingRequestKode.IKKE_INNTEKTSTAP]:
+  [Vurdering.IKKE_INNTEKTSTAP]:
     'Skriv begrunnelse for hvorfor søker ikke har inntektstap, og avslå saken etter folketrygdloven §9-3.',
 };
 
@@ -99,8 +99,7 @@ const InntektsmeldingAksjonspunktForm = ({
   const beslutningValue = watch(beslutningFieldName);
   const beslutning = Array.isArray(beslutningValue) ? beslutningValue[0] : beslutningValue;
 
-  const skalViseBegrunnelse =
-    aksjonspunktKode !== '9069' || beslutning === InntektsmeldingVurderingRequestKode.FORTSETT;
+  const skalViseBegrunnelse = aksjonspunktKode !== '9069' || beslutning === Vurdering.KAN_FORTSETTE;
 
   // Formater arbeidsgiverliste
   const arbeidsgivereString = formatListeMedOg(
@@ -119,7 +118,7 @@ const InntektsmeldingAksjonspunktForm = ({
   const handleSubmit = async (data: FieldValues) => {
     const periode = {
       periode: tilstand.periodeOpprinneligFormat,
-      fortsett: data[beslutningFieldName] === InntektsmeldingVurderingRequestKode.FORTSETT,
+      fortsett: data[beslutningFieldName] === Vurdering.KAN_FORTSETTE,
       vurdering: data[beslutningFieldName],
       begrunnelse: skalViseBegrunnelse ? data[begrunnelseFieldName] : undefined,
     };

--- a/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
@@ -1,12 +1,12 @@
 import { finnAktivtAksjonspunkt } from '@k9-sak-web/gui/utils/aksjonspunktUtils.js';
-import { Vurdering as InntektsmeldingVurderingResponseKode } from '@k9-sak-web/backend/k9sak/kodeverk/kompletthet/Vurdering.js';
-import { Box, Button, Heading } from '@navikt/ds-react';
+import { Vurdering } from '@k9-sak-web/backend/k9sak/kodeverk/kompletthet/Vurdering.js';
+import { Box, Heading } from '@navikt/ds-react';
 import { useMemo, useState } from 'react';
 import { useForm, type FieldValues } from 'react-hook-form';
 import { useKompletthetsoversikt } from '../../api/inntektsmeldingQueries';
 import { useInntektsmeldingContext } from '../../context/InntektsmeldingContext';
-import type { Tilstand, TilstandMedUiState, InntektsmeldingVurdering } from '../../types';
-import { FieldName, InntektsmeldingVurderingRequestKode } from '../../types';
+import type { Tilstand, TilstandMedUiState } from '../../types';
+import { FieldName } from '../../types';
 import {
   finnSisteAksjonspunkt,
   finnTilstanderSomRedigeres,
@@ -17,22 +17,11 @@ import {
 import InntektsmeldingAlerts from './InntektsmeldingAlerts.js';
 import InntektsmeldingListe from './InntektsmeldingListe';
 
-// Dette er nødvendig for å mappe vurdering fra backend til det formatet som forventes i requesten, da KompletthetsPeriode.vurdering bruker en generert enum (KAN_FORTSETTE), mens backend forventer FORTSETT
-const responseToRequestVurdering: Record<string, InntektsmeldingVurdering> = {
-  [InntektsmeldingVurderingResponseKode.KAN_FORTSETTE]: InntektsmeldingVurderingRequestKode.FORTSETT,
-  [InntektsmeldingVurderingResponseKode.MANGLENDE_GRUNNLAG]: InntektsmeldingVurderingRequestKode.MANGLENDE_GRUNNLAG,
-  [InntektsmeldingVurderingResponseKode.IKKE_INNTEKTSTAP]: InntektsmeldingVurderingRequestKode.IKKE_INNTEKTSTAP,
-  [InntektsmeldingVurderingResponseKode.UAVKLART]: InntektsmeldingVurderingRequestKode.UAVKLART,
-};
-
 const buildFormDefaultValues = (tilstander: Tilstand[]): FieldValues =>
   Object.fromEntries(
     tilstander.flatMap(t => [
       [`${FieldName.BEGRUNNELSE}${t.periodeOpprinneligFormat}`, t.begrunnelse || ''],
-      [
-        `${FieldName.BESLUTNING}${t.periodeOpprinneligFormat}`,
-        (t.vurdering ? responseToRequestVurdering[t.vurdering] : null) ?? null,
-      ],
+      [`${FieldName.BESLUTNING}${t.periodeOpprinneligFormat}`, t.vurdering || undefined],
     ]),
   );
 
@@ -76,55 +65,31 @@ const InntektsmeldingContainer = () => {
   const harIngenTilstanderTilVurdering = tilstanderTilVurdering.length === 0;
 
   const harAktivtAksjonspunkt = !!aktivtAksjonspunkt;
-  const harEndretTidligereVurdering = !aktivtAksjonspunkt && sisteAksjonspunkt && formState.isDirty;
   const ingenTilstanderMangler = ingenTilstanderHarMangler(tilstanderMedUiState);
   const ferdigVurdert = harIngenTilstanderTilVurdering && ingenTilstanderMangler;
-  const kanSendeInnFlereVurderinger =
-    !readOnly && harFlereTilstanderTilVurdering && (harAktivtAksjonspunkt || harEndretTidligereVurdering);
   const kanFortsetteUtenEndring = !readOnly && harAktivtAksjonspunkt && ferdigVurdert;
-
-  const onSubmit = async (data: FieldValues) => {
-    if (!aksjonspunktKode) {
-      throw new Error('AksjonspunktKode er ikke satt');
-    }
-
-    const perioder = tilstanderTilVurdering.map(tilstand => {
-      const beslutning = data[tilstand.beslutningFieldName];
-      const skalInkludereBegrunnelse =
-        aksjonspunktKode !== '9069' || beslutning === InntektsmeldingVurderingRequestKode.FORTSETT;
-
-      return {
-        periode: tilstand.periodeOpprinneligFormat,
-        fortsett: beslutning === InntektsmeldingVurderingRequestKode.FORTSETT,
-        vurdering: beslutning,
-        begrunnelse: skalInkludereBegrunnelse ? data[tilstand.begrunnelseFieldName] : undefined,
-      };
-    });
-
-    await onFinished({
-      '@type': aksjonspunktKode,
-      kode: aksjonspunktKode,
-      perioder,
-    });
-  };
 
   const onSubmitUtenEndring = async () => {
     if (!aksjonspunktKode) {
       throw new Error('AksjonspunktKode er ikke satt');
     }
 
+    const tilstanderMedVurdering = tilstanderMedUiState.filter(
+      (tilstand): tilstand is TilstandMedUiState & { vurdering: Vurdering } => tilstand.vurdering != null,
+    );
+    if (tilstanderMedVurdering.length !== tilstanderMedUiState.length) {
+      throw new Error('Alle tilstander må ha en vurdering for å kunne fortsette uten endring');
+    }
+
     await onFinished({
       '@type': aksjonspunktKode,
       kode: aksjonspunktKode,
-      perioder: tilstanderMedUiState.map(tilstand => {
-        const vurdering = tilstand.vurdering ? responseToRequestVurdering[tilstand.vurdering] : undefined;
-        return {
-          periode: tilstand.periodeOpprinneligFormat,
-          fortsett: vurdering === InntektsmeldingVurderingRequestKode.FORTSETT,
-          vurdering,
-          begrunnelse: tilstand.begrunnelse || undefined,
-        };
-      }),
+      perioder: tilstanderMedVurdering.map(tilstand => ({
+        periode: tilstand.periodeOpprinneligFormat,
+        fortsett: tilstand.vurdering === Vurdering.KAN_FORTSETTE,
+        vurdering: tilstand.vurdering,
+        begrunnelse: tilstand.begrunnelse || undefined,
+      })),
     });
   };
 
@@ -153,15 +118,6 @@ const InntektsmeldingContainer = () => {
           harFlereTilstanderTilVurdering={harFlereTilstanderTilVurdering}
         />
       </Box>
-      {kanSendeInnFlereVurderinger && (
-        <Box marginBlock="space-24 space-0">
-          <form onSubmit={handleSubmit(onSubmit)}>
-            <Button variant="primary" size="small" loading={formState.isSubmitting} disabled={formState.isSubmitting}>
-              Send inn
-            </Button>
-          </form>
-        </Box>
-      )}
     </div>
   );
 };

--- a/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
@@ -12,7 +12,6 @@ import {
   finnTilstanderSomRedigeres,
   finnTilstanderSomVurderes,
   ingenTilstanderHarMangler,
-  responseToRequestVurdering,
   transformKompletthetsdata,
 } from '../../util/utils';
 import InntektsmeldingAlerts from './InntektsmeldingAlerts.js';
@@ -66,7 +65,7 @@ const InntektsmeldingContainer = () => {
 
   const alleTilstanderHarVurdering = tilstanderMedUiState
     .filter(t => t.tilVurdering)
-    .map(t => (t.vurdering ? responseToRequestVurdering[t.vurdering] : undefined))
+    .map(t => t.vurdering)
     .every(vurdering => vurdering !== undefined);
 
   const harAktivtAksjonspunkt = !!aktivtAksjonspunkt;
@@ -108,7 +107,7 @@ const InntektsmeldingContainer = () => {
     const mappetVurdering = tilstanderMedUiState
       .filter(tilstand => tilstand.tilVurdering)
       .map(tilstand => {
-        const vurdering = tilstand.vurdering ? responseToRequestVurdering[tilstand.vurdering] : undefined;
+        const { vurdering } = tilstand;
 
         if (!vurdering) {
           // Hvis dette er tilfellet, så er det en feil i logikken for når "send inn uten endring" rendres

--- a/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
@@ -12,6 +12,7 @@ import {
   finnTilstanderSomRedigeres,
   finnTilstanderSomVurderes,
   ingenTilstanderHarMangler,
+  responseToRequestVurdering,
   transformKompletthetsdata,
 } from '../../util/utils';
 import InntektsmeldingAlerts from './InntektsmeldingAlerts.js';
@@ -62,12 +63,16 @@ const InntektsmeldingContainer = () => {
     ...finnTilstanderSomRedigeres(tilstanderMedUiState),
   ];
   const harFlereTilstanderTilVurdering = tilstanderTilVurdering.length > 1;
-  const harIngenTilstanderTilVurdering = tilstanderTilVurdering.length === 0;
+
+  const alleTilstanderHarVurdering = tilstanderMedUiState
+    .filter(t => t.tilVurdering)
+    .map(t => (t.vurdering ? responseToRequestVurdering[t.vurdering] : undefined))
+    .every(vurdering => vurdering !== undefined);
 
   const harAktivtAksjonspunkt = !!aktivtAksjonspunkt;
   const harEndretTidligereVurdering = !aktivtAksjonspunkt && sisteAksjonspunkt && formState.isDirty;
   const ingenTilstanderMangler = ingenTilstanderHarMangler(tilstanderMedUiState);
-  const ferdigVurdert = harIngenTilstanderTilVurdering && ingenTilstanderMangler;
+  const ferdigVurdert = alleTilstanderHarVurdering && ingenTilstanderMangler;
   const kanSendeInnFlereVurderinger =
     !readOnly && harFlereTilstanderTilVurdering && (harAktivtAksjonspunkt || harEndretTidligereVurdering);
   const kanFortsetteUtenEndring = !readOnly && harAktivtAksjonspunkt && ferdigVurdert;
@@ -100,17 +105,27 @@ const InntektsmeldingContainer = () => {
     if (!aksjonspunktKode) {
       throw new Error('AksjonspunktKode er ikke satt');
     }
+    const mappetVurdering = tilstanderMedUiState
+      .filter(tilstand => tilstand.tilVurdering)
+      .map(tilstand => {
+        const vurdering = tilstand.vurdering ? responseToRequestVurdering[tilstand.vurdering] : undefined;
+
+        if (!vurdering) {
+          // Hvis dette er tilfellet, så er det en feil i logikken for når "send inn uten endring" rendres
+          throw new Error(`Vurdering mangler for periode ${tilstand.periode.prettifyPeriod()}`);
+        }
+
+        return {
+          periode: tilstand.periodeOpprinneligFormat,
+          fortsett: vurdering === Vurdering.KAN_FORTSETTE,
+          vurdering,
+          begrunnelse: tilstand.begrunnelse || undefined,
+        };
+      });
     await onFinished({
       '@type': aksjonspunktKode,
       kode: aksjonspunktKode,
-      perioder: tilstanderMedUiState
-        .filter((tilstand): tilstand is TilstandMedUiState & { vurdering: Vurdering } => tilstand.vurdering != null)
-        .map(tilstand => ({
-          periode: tilstand.periodeOpprinneligFormat,
-          fortsett: tilstand.vurdering === Vurdering.KAN_FORTSETTE,
-          vurdering: tilstand.vurdering,
-          begrunnelse: tilstand.begrunnelse || undefined,
-        })),
+      perioder: mappetVurdering,
     });
   };
 

--- a/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
@@ -17,8 +17,6 @@ import {
 import InntektsmeldingAlerts from './InntektsmeldingAlerts.js';
 import InntektsmeldingListe from './InntektsmeldingListe';
 
-// Dette er nødvendig for å mappe vurdering fra backend til det formatet som forventes i requesten, da KompletthetsPeriode.vurdering bruker en generert enum (KAN_FORTSETTE), mens backend forventer FORTSETT
-
 const buildFormDefaultValues = (tilstander: Tilstand[]): FieldValues =>
   Object.fromEntries(
     tilstander.flatMap(t => [

--- a/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingContainer.tsx
@@ -1,6 +1,6 @@
 import { finnAktivtAksjonspunkt } from '@k9-sak-web/gui/utils/aksjonspunktUtils.js';
 import { Vurdering } from '@k9-sak-web/backend/k9sak/kodeverk/kompletthet/Vurdering.js';
-import { Box, Heading } from '@navikt/ds-react';
+import { Box, Button, Heading } from '@navikt/ds-react';
 import { useMemo, useState } from 'react';
 import { useForm, type FieldValues } from 'react-hook-form';
 import { useKompletthetsoversikt } from '../../api/inntektsmeldingQueries';
@@ -16,6 +16,8 @@ import {
 } from '../../util/utils';
 import InntektsmeldingAlerts from './InntektsmeldingAlerts.js';
 import InntektsmeldingListe from './InntektsmeldingListe';
+
+// Dette er nødvendig for å mappe vurdering fra backend til det formatet som forventes i requesten, da KompletthetsPeriode.vurdering bruker en generert enum (KAN_FORTSETTE), mens backend forventer FORTSETT
 
 const buildFormDefaultValues = (tilstander: Tilstand[]): FieldValues =>
   Object.fromEntries(
@@ -65,31 +67,52 @@ const InntektsmeldingContainer = () => {
   const harIngenTilstanderTilVurdering = tilstanderTilVurdering.length === 0;
 
   const harAktivtAksjonspunkt = !!aktivtAksjonspunkt;
+  const harEndretTidligereVurdering = !aktivtAksjonspunkt && sisteAksjonspunkt && formState.isDirty;
   const ingenTilstanderMangler = ingenTilstanderHarMangler(tilstanderMedUiState);
   const ferdigVurdert = harIngenTilstanderTilVurdering && ingenTilstanderMangler;
+  const kanSendeInnFlereVurderinger =
+    !readOnly && harFlereTilstanderTilVurdering && (harAktivtAksjonspunkt || harEndretTidligereVurdering);
   const kanFortsetteUtenEndring = !readOnly && harAktivtAksjonspunkt && ferdigVurdert;
+
+  const onSubmit = async (data: FieldValues) => {
+    if (!aksjonspunktKode) {
+      throw new Error('AksjonspunktKode er ikke satt');
+    }
+
+    const perioder = tilstanderTilVurdering.map(tilstand => {
+      const beslutning = data[tilstand.beslutningFieldName];
+      const skalInkludereBegrunnelse = aksjonspunktKode !== '9069' || beslutning === Vurdering.KAN_FORTSETTE;
+
+      return {
+        periode: tilstand.periodeOpprinneligFormat,
+        fortsett: beslutning === Vurdering.KAN_FORTSETTE,
+        vurdering: beslutning,
+        begrunnelse: skalInkludereBegrunnelse ? data[tilstand.begrunnelseFieldName] : undefined,
+      };
+    });
+
+    await onFinished({
+      '@type': aksjonspunktKode,
+      kode: aksjonspunktKode,
+      perioder,
+    });
+  };
 
   const onSubmitUtenEndring = async () => {
     if (!aksjonspunktKode) {
       throw new Error('AksjonspunktKode er ikke satt');
     }
-
-    const tilstanderMedVurdering = tilstanderMedUiState.filter(
-      (tilstand): tilstand is TilstandMedUiState & { vurdering: Vurdering } => tilstand.vurdering != null,
-    );
-    if (tilstanderMedVurdering.length !== tilstanderMedUiState.length) {
-      throw new Error('Alle tilstander må ha en vurdering for å kunne fortsette uten endring');
-    }
-
     await onFinished({
       '@type': aksjonspunktKode,
       kode: aksjonspunktKode,
-      perioder: tilstanderMedVurdering.map(tilstand => ({
-        periode: tilstand.periodeOpprinneligFormat,
-        fortsett: tilstand.vurdering === Vurdering.KAN_FORTSETTE,
-        vurdering: tilstand.vurdering,
-        begrunnelse: tilstand.begrunnelse || undefined,
-      })),
+      perioder: tilstanderMedUiState
+        .filter((tilstand): tilstand is TilstandMedUiState & { vurdering: Vurdering } => tilstand.vurdering != null)
+        .map(tilstand => ({
+          periode: tilstand.periodeOpprinneligFormat,
+          fortsett: tilstand.vurdering === Vurdering.KAN_FORTSETTE,
+          vurdering: tilstand.vurdering,
+          begrunnelse: tilstand.begrunnelse || undefined,
+        })),
     });
   };
 
@@ -118,6 +141,15 @@ const InntektsmeldingContainer = () => {
           harFlereTilstanderTilVurdering={harFlereTilstanderTilVurdering}
         />
       </Box>
+      {kanSendeInnFlereVurderinger && (
+        <Box marginBlock="space-24 space-0">
+          <form onSubmit={handleSubmit(onSubmit)}>
+            <Button variant="primary" size="small" loading={formState.isSubmitting} disabled={formState.isSubmitting}>
+              Send inn
+            </Button>
+          </form>
+        </Box>
+      )}
     </div>
   );
 };

--- a/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingFerdigvisning.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingFerdigvisning.tsx
@@ -3,19 +3,18 @@ import { VurdertAv } from '@k9-sak-web/gui/shared/vurdert-av/VurdertAv.js';
 import { PencilIcon } from '@navikt/aksel-icons';
 import { Alert, BodyShort, Button } from '@navikt/ds-react';
 import type { TilstandMedUiState } from '../../types';
-import { InntektsmeldingVurderingRequestKode } from '../../types';
-import { Vurdering as InntektsmeldingVurderingResponseKode } from '@k9-sak-web/backend/k9sak/kodeverk/kompletthet/Vurdering.js';
+import { Vurdering } from '@k9-sak-web/backend/k9sak/kodeverk/kompletthet/Vurdering.js';
 
 const vurderingConfig: Record<string, { variant: 'info' | 'error'; melding: string }> = {
-  [InntektsmeldingVurderingResponseKode.KAN_FORTSETTE]: {
+  [Vurdering.KAN_FORTSETTE]: {
     variant: 'info',
     melding: 'Fortsett uten inntektsmelding.',
   },
-  [InntektsmeldingVurderingRequestKode.MANGLENDE_GRUNNLAG]: {
+  [Vurdering.MANGLENDE_GRUNNLAG]: {
     variant: 'error',
     melding: 'Søknaden avslås på grunn av manglende opplysninger om inntekt',
   },
-  [InntektsmeldingVurderingRequestKode.IKKE_INNTEKTSTAP]: {
+  [Vurdering.IKKE_INNTEKTSTAP]: {
     variant: 'error',
     melding: 'Søknaden avslås fordi søker ikke har dokumentert tapt arbeidsinntekt',
   },

--- a/packages/v2/gui/src/fakta/inntektsmelding/util/utils.ts
+++ b/packages/v2/gui/src/fakta/inntektsmelding/util/utils.ts
@@ -10,12 +10,13 @@ import { type Tilstand, type TilstandMedUiState } from '../types';
 export const transformKompletthetsdata = (response: KompletthetsVurdering): Tilstand[] =>
   response.tilstand.map(({ periode, status, begrunnelse, tilVurdering, vurdering, vurdertAv, vurdertTidspunkt }) => {
     const [fom = '', tom = ''] = periode.split('/');
+    const mappetVurdering = vurdering === InntektsmeldingVurderingResponseKode.UDEFINERT ? undefined : vurdering;
     return {
       periode: new Period(fom, tom),
       status,
       begrunnelse,
       tilVurdering,
-      vurdering,
+      vurdering: mappetVurdering,
       periodeOpprinneligFormat: periode,
       vurdertAv,
       vurdertTidspunkt,

--- a/packages/v2/gui/src/fakta/inntektsmelding/util/utils.ts
+++ b/packages/v2/gui/src/fakta/inntektsmelding/util/utils.ts
@@ -6,29 +6,17 @@ import { Period } from '@k9-sak-web/gui/utils/Period.js';
 import { initializeDate } from '@k9-sak-web/lib/dateUtils/initializeDate.js';
 import { type Tilstand, type TilstandMedUiState } from '../types';
 
-// Backend sender i dag enumnavn i responsen for kompletthetsvurdering
-// vi går over til å bruke enumverdi, og må støtte begge i en liten overgangsperiode
-export const responseToRequestVurdering: Record<string, InntektsmeldingVurderingResponseKode | undefined> = {
-  [InntektsmeldingVurderingResponseKode.KAN_FORTSETTE]: InntektsmeldingVurderingResponseKode.KAN_FORTSETTE,
-  [InntektsmeldingVurderingResponseKode.MANGLENDE_GRUNNLAG]: InntektsmeldingVurderingResponseKode.MANGLENDE_GRUNNLAG,
-  [InntektsmeldingVurderingResponseKode.IKKE_INNTEKTSTAP]: InntektsmeldingVurderingResponseKode.IKKE_INNTEKTSTAP,
-  [InntektsmeldingVurderingResponseKode.UAVKLART]: InntektsmeldingVurderingResponseKode.UAVKLART,
-  [InntektsmeldingVurderingResponseKode.UDEFINERT]: undefined,
-  KAN_FORTSETTE: InntektsmeldingVurderingResponseKode.KAN_FORTSETTE,
-  UDEFINERT: undefined,
-};
 /** Transforms backend response to domain model with Period objects */
 export const transformKompletthetsdata = (response: KompletthetsVurdering): Tilstand[] =>
   response.tilstand.map(({ periode, status, begrunnelse, tilVurdering, vurdering, vurdertAv, vurdertTidspunkt }) => {
     const [fom = '', tom = ''] = periode.split('/');
 
-    const mappetVurdering = vurdering ? responseToRequestVurdering[vurdering] : undefined;
     return {
       periode: new Period(fom, tom),
       status,
       begrunnelse,
       tilVurdering,
-      vurdering: mappetVurdering,
+      vurdering: vurdering && vurdering !== InntektsmeldingVurderingResponseKode.UDEFINERT ? vurdering : undefined,
       periodeOpprinneligFormat: periode,
       vurdertAv,
       vurdertTidspunkt,

--- a/packages/v2/gui/src/fakta/inntektsmelding/util/utils.ts
+++ b/packages/v2/gui/src/fakta/inntektsmelding/util/utils.ts
@@ -1,7 +1,7 @@
 import type { AksjonspunktDto } from '@k9-sak-web/backend/k9sak/kontrakt/aksjonspunkt/AksjonspunktDto.js';
 import type { KompletthetsVurderingDto as KompletthetsVurdering } from '@k9-sak-web/backend/k9sak/kontrakt/kompletthet/KompletthetsVurderingDto.js';
 import { Status as InntektsmeldingStatus } from '@k9-sak-web/backend/k9sak/kontrakt/kompletthet/Status.js';
-import { Vurdering as InntektsmeldingVurderingResponseKode } from '@k9-sak-web/backend/k9sak/kodeverk/kompletthet/Vurdering.js';
+import { Vurdering } from '@k9-sak-web/backend/k9sak/kodeverk/kompletthet/Vurdering.js';
 import { Period } from '@k9-sak-web/gui/utils/Period.js';
 import { initializeDate } from '@k9-sak-web/lib/dateUtils/initializeDate.js';
 import { type Tilstand, type TilstandMedUiState } from '../types';
@@ -16,7 +16,7 @@ export const transformKompletthetsdata = (response: KompletthetsVurdering): Tils
       status,
       begrunnelse,
       tilVurdering,
-      vurdering: vurdering && vurdering !== InntektsmeldingVurderingResponseKode.UDEFINERT ? vurdering : undefined,
+      vurdering: vurdering && vurdering !== Vurdering.UDEFINERT ? vurdering : undefined,
       periodeOpprinneligFormat: periode,
       vurdertAv,
       vurdertTidspunkt,
@@ -32,7 +32,7 @@ export const skalVurderes = (tilstand: TilstandMedUiState): boolean =>
   (tilstand?.tilVurdering &&
     tilstand?.status.some(status => status.status === InntektsmeldingStatus.MANGLER) &&
     tilstand?.vurdering == null) ||
-  tilstand?.vurdering === InntektsmeldingVurderingResponseKode.UDEFINERT;
+  tilstand?.vurdering === Vurdering.UDEFINERT;
 
 export const ikkePaakrevd = (tilstand: TilstandMedUiState): boolean =>
   tilstand?.status.some(status => status.status === InntektsmeldingStatus.IKKE_PÅKREVD);

--- a/packages/v2/gui/src/fakta/inntektsmelding/util/utils.ts
+++ b/packages/v2/gui/src/fakta/inntektsmelding/util/utils.ts
@@ -8,7 +8,7 @@ import { type Tilstand, type TilstandMedUiState } from '../types';
 
 // Backend sender i dag enumnavn i responsen for kompletthetsvurdering
 // vi går over til å bruke enumverdi, og må støtte begge i en liten overgangsperiode
-const responseToRequestVurdering: Record<string, InntektsmeldingVurderingResponseKode | undefined> = {
+export const responseToRequestVurdering: Record<string, InntektsmeldingVurderingResponseKode | undefined> = {
   [InntektsmeldingVurderingResponseKode.KAN_FORTSETTE]: InntektsmeldingVurderingResponseKode.KAN_FORTSETTE,
   [InntektsmeldingVurderingResponseKode.MANGLENDE_GRUNNLAG]: InntektsmeldingVurderingResponseKode.MANGLENDE_GRUNNLAG,
   [InntektsmeldingVurderingResponseKode.IKKE_INNTEKTSTAP]: InntektsmeldingVurderingResponseKode.IKKE_INNTEKTSTAP,

--- a/packages/v2/gui/src/fakta/inntektsmelding/util/utils.ts
+++ b/packages/v2/gui/src/fakta/inntektsmelding/util/utils.ts
@@ -6,11 +6,23 @@ import { Period } from '@k9-sak-web/gui/utils/Period.js';
 import { initializeDate } from '@k9-sak-web/lib/dateUtils/initializeDate.js';
 import { type Tilstand, type TilstandMedUiState } from '../types';
 
+// Backend sender i dag enumnavn i responsen for kompletthetsvurdering
+// vi går over til å bruke enumverdi, og må støtte begge i en liten overgangsperiode
+const responseToRequestVurdering: Record<string, InntektsmeldingVurderingResponseKode | undefined> = {
+  [InntektsmeldingVurderingResponseKode.KAN_FORTSETTE]: InntektsmeldingVurderingResponseKode.KAN_FORTSETTE,
+  [InntektsmeldingVurderingResponseKode.MANGLENDE_GRUNNLAG]: InntektsmeldingVurderingResponseKode.MANGLENDE_GRUNNLAG,
+  [InntektsmeldingVurderingResponseKode.IKKE_INNTEKTSTAP]: InntektsmeldingVurderingResponseKode.IKKE_INNTEKTSTAP,
+  [InntektsmeldingVurderingResponseKode.UAVKLART]: InntektsmeldingVurderingResponseKode.UAVKLART,
+  [InntektsmeldingVurderingResponseKode.UDEFINERT]: undefined,
+  KAN_FORTSETTE: InntektsmeldingVurderingResponseKode.KAN_FORTSETTE,
+  UDEFINERT: undefined,
+};
 /** Transforms backend response to domain model with Period objects */
 export const transformKompletthetsdata = (response: KompletthetsVurdering): Tilstand[] =>
   response.tilstand.map(({ periode, status, begrunnelse, tilVurdering, vurdering, vurdertAv, vurdertTidspunkt }) => {
     const [fom = '', tom = ''] = periode.split('/');
-    const mappetVurdering = vurdering === InntektsmeldingVurderingResponseKode.UDEFINERT ? undefined : vurdering;
+
+    const mappetVurdering = vurdering ? responseToRequestVurdering[vurdering] : undefined;
     return {
       periode: new Period(fom, tom),
       status,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,7 +2046,7 @@ __metadata:
   resolution: "@k9-sak-web/backend@workspace:packages/v2/backend"
   dependencies:
     "@navikt/k9-klage-typescript-client": "npm:3.1.20260529100435"
-    "@navikt/k9-sak-typescript-client": "npm:3.0.20260619084337"
+    "@navikt/k9-sak-typescript-client": "npm:3.0.20260619114434"
     "@navikt/k9-tilbake-typescript-client": "npm:1.1.20260510232128"
     "@navikt/ung-sak-typescript-client": "npm:2.0.20260612140411"
     "@navikt/ung-tilbake-typescript-client": "npm:3.0.20260519143823"
@@ -3365,10 +3365,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/k9-sak-typescript-client@npm:3.0.20260619084337":
-  version: 3.0.20260619084337
-  resolution: "@navikt/k9-sak-typescript-client@npm:3.0.20260619084337::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-sak-typescript-client%2F3.0.20260619084337%2F910ffc4822aa178f06e75b9aa746913ae2be223e"
-  checksum: 10/be2988b2df256d1f903a6f7aad0b4e7b247a50f1490ae5d7fee80998307c77cd94206d8283ba088cdf449234bdebc2d1685b0142afca5d23cce3d1a77511cfc3
+"@navikt/k9-sak-typescript-client@npm:3.0.20260619114434":
+  version: 3.0.20260619114434
+  resolution: "@navikt/k9-sak-typescript-client@npm:3.0.20260619114434::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-sak-typescript-client%2F3.0.20260619114434%2F0f6f3967cf5c1c9db3115b7a75340a37390b473b"
+  checksum: 10/4df7433564c45f10f12b3ac03391623526f8f4de9d433ff6761f49f755f1b4a5c06a569119ff5d4a0a501a6b4eb99eafae8238b99bbb226b822939fe63f6768f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,7 +2046,7 @@ __metadata:
   resolution: "@k9-sak-web/backend@workspace:packages/v2/backend"
   dependencies:
     "@navikt/k9-klage-typescript-client": "npm:3.1.20260529100435"
-    "@navikt/k9-sak-typescript-client": "npm:3.0.20260605142157"
+    "@navikt/k9-sak-typescript-client": "npm:3.0.20260619084337"
     "@navikt/k9-tilbake-typescript-client": "npm:1.1.20260510232128"
     "@navikt/ung-sak-typescript-client": "npm:2.0.20260612140411"
     "@navikt/ung-tilbake-typescript-client": "npm:3.0.20260519143823"
@@ -3365,10 +3365,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/k9-sak-typescript-client@npm:3.0.20260605142157":
-  version: 3.0.20260605142157
-  resolution: "@navikt/k9-sak-typescript-client@npm:3.0.20260605142157::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-sak-typescript-client%2F3.0.20260605142157%2Fbdb825eecaa516eedf3336fd2d21923214dd6123"
-  checksum: 10/4dd76f1a0d37608b07da840d9d2408de36e2bd78562dc762694c87bec3160846575ea73bf5d88a3c5be1b123963895485bedd8e4cd06acb2d09f45a82d1fb0cc
+"@navikt/k9-sak-typescript-client@npm:3.0.20260619084337":
+  version: 3.0.20260619084337
+  resolution: "@navikt/k9-sak-typescript-client@npm:3.0.20260619084337::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-sak-typescript-client%2F3.0.20260619084337%2F910ffc4822aa178f06e75b9aa746913ae2be223e"
+  checksum: 10/be2988b2df256d1f903a6f7aad0b4e7b247a50f1490ae5d7fee80998307c77cd94206d8283ba088cdf449234bdebc2d1685b0142afca5d23cce3d1a77511cfc3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Behov / Bakgrunn
https://github.com/navikt/k9-sak/pull/13051 fører til at man får enumverdi i stedet for enumnavn i dtoen som returnerer tilstand. I en overgangsperiode må da støtte begge

### Løsning
Tilpasse frontend

### Andre endringer

