### PR TITLE
Reduser mellomrom mellom historikkinnslag linjer.

### DIFF
--- a/packages/v2/gui/src/sak/historikk/innslag/InnslagBoble.tsx
+++ b/packages/v2/gui/src/sak/historikk/innslag/InnslagBoble.tsx
@@ -80,11 +80,13 @@ export const InnslagBoble = ({ innslag, behandlingLocation }: InnslagBobleProps)
           {bådeTittelOgSkjermlenke ? `: ` : null}
           {innslag.tittel != null ? innslag.tittel : null}
         </Tittel>
-        {innslag.linjer.map((linje, idx) => (
-          <div key={idx} hidden={doCutOff && !expanded && idx > antallLinjerSomAlltidVises - 1}>
-            <InnslagLinje linje={linje} behandlingLocation={behandlingLocation} />
-          </div>
-        ))}
+        <VStack gap="space-0">
+          {innslag.linjer.map((linje, idx) => (
+            <div key={idx} hidden={doCutOff && !expanded && idx > antallLinjerSomAlltidVises - 1}>
+              <InnslagLinje linje={linje} behandlingLocation={behandlingLocation} />
+            </div>
+          ))}
+        </VStack>
 
         {innslag.dokumenter != null ? (
           <VStack gap="space-4">


### PR DESCRIPTION
### Behov / Bakgrunn
Vart litt masse mellomrom mellom tekstlinjer som høyre i hop.

### Løsning

Fjerner gap mellom tekstlinjer, beheld lineheight frå InnslagLinje


