### PR TITLE
Tsff 2645 utvidelse av innleggelse for pils

### DIFF
--- a/packages/behandling-pleiepenger-sluttfase/src/panelDefinisjoner/prosessStegPaneler/UttakProsessStegPanelDef.tsx
+++ b/packages/behandling-pleiepenger-sluttfase/src/panelDefinisjoner/prosessStegPaneler/UttakProsessStegPanelDef.tsx
@@ -56,6 +56,7 @@ class PanelDef extends ProsessStegPanelDef {
   getData = ({ uttak }) => ({
     uttak,
     kvoteInfo: uttak?.uttaksplan?.kvoteInfo,
+    uttaksperioder: uttak?.uttaksplan?.perioder,
     relevanteAksjonspunkter: this.getAksjonspunktKoder(),
   });
 }

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/innleggelsesperiodeFormModal/InnleggelsesperiodeFormModal.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/innleggelsesperiodeFormModal/InnleggelsesperiodeFormModal.tsx
@@ -93,14 +93,22 @@ const InnleggelsesperiodeFormModal = ({
                 fromDatepickerProps={{
                   hideLabel: true,
                   label: 'Fra',
-                  ...(søknadsperiode?.fom && { fromDate: new Date(søknadsperiode.fom) }),
-                  ...(søknadsperiode?.tom && { toDate: new Date(søknadsperiode.tom) }),
+                  ...(søknadsperiode && {
+                    limitations: {
+                      minDate: søknadsperiode.fom,
+                      maxDate: søknadsperiode.tom,
+                    },
+                  }),
                 }}
                 toDatepickerProps={{
                   hideLabel: true,
                   label: 'Til',
-                  ...(søknadsperiode?.fom && { fromDate: new Date(søknadsperiode.fom) }),
-                  ...(søknadsperiode?.tom && { toDate: new Date(søknadsperiode.tom) }),
+                  ...(søknadsperiode && {
+                    limitations: {
+                      minDate: søknadsperiode.fom,
+                      maxDate: søknadsperiode.tom,
+                    },
+                  }),
                 }}
                 afterOnChange={async () => {
                   const initialiserteInnleggelsesperioder = getValues().innleggelsesperioder.map(

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/innleggelsesperiodeFormModal/InnleggelsesperiodeFormModal.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/innleggelsesperiodeFormModal/InnleggelsesperiodeFormModal.tsx
@@ -27,6 +27,7 @@ interface InnleggelsesperiodeFormModal {
   isLoading: boolean;
   endringerPåvirkerAndreBehandlinger: (innleggelsesperioder: Period[]) => Promise<InnleggelsesperiodeDryRunResponse>;
   pleietrengendePart: Personopplysninger['pleietrengendePart'];
+  søknadsperiode?: Period;
 }
 
 const InnleggelsesperiodeFormModal = ({
@@ -36,6 +37,7 @@ const InnleggelsesperiodeFormModal = ({
   isLoading,
   endringerPåvirkerAndreBehandlinger,
   pleietrengendePart,
+  søknadsperiode,
 }: InnleggelsesperiodeFormModal): JSX.Element => {
   const formMethods = useForm({
     defaultValues: {
@@ -91,10 +93,14 @@ const InnleggelsesperiodeFormModal = ({
                 fromDatepickerProps={{
                   hideLabel: true,
                   label: 'Fra',
+                  ...(søknadsperiode?.fom && { fromDate: new Date(søknadsperiode.fom) }),
+                  ...(søknadsperiode?.tom && { toDate: new Date(søknadsperiode.tom) }),
                 }}
                 toDatepickerProps={{
                   hideLabel: true,
                   label: 'Til',
+                  ...(søknadsperiode?.fom && { fromDate: new Date(søknadsperiode.fom) }),
+                  ...(søknadsperiode?.tom && { toDate: new Date(søknadsperiode.tom) }),
                 }}
                 afterOnChange={async () => {
                   const initialiserteInnleggelsesperioder = getValues().innleggelsesperioder.map(
@@ -149,6 +155,17 @@ const InnleggelsesperiodeFormModal = ({
                       if (fødselsdato && dayjs(fom).isBefore(fødselsdato)) {
                         return 'Fra-dato kan ikke være før fødselsdato';
                       }
+                    }
+                    return null;
+                  },
+                  innenforSøknadsperiode: (periodValue: Period) => {
+                    if (!søknadsperiode) return null;
+                    const { fom, tom } = periodValue;
+                    if (fom && dayjs(fom).isBefore(søknadsperiode.fom)) {
+                      return 'Fra-dato må være innenfor søknadsperioden';
+                    }
+                    if (tom && dayjs(tom).isAfter(søknadsperiode.tom)) {
+                      return 'Til-dato må være innenfor søknadsperioden';
                     }
                     return null;
                   },

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/innleggelsesperiodeoversikt/Innleggelsesperiodeoversikt.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/innleggelsesperiodeoversikt/Innleggelsesperiodeoversikt.tsx
@@ -7,6 +7,7 @@ import { postInnleggelsesperioder, postInnleggelsesperioderDryRun } from '../../
 import LinkRel from '../../../constants/LinkRel';
 import { InnleggelsesperiodeResponse } from '../../../types/InnleggelsesperiodeResponse';
 import { findLinkByRel } from '../../../util/linkUtils';
+import { finnMaksavgrensningerForPerioder } from '../../../util/periodUtils';
 import ContainerContext from '../../context/ContainerContext';
 import AddButton from '../add-button/AddButton';
 import InnleggelsesperiodeFormModal, { FieldName } from '../innleggelsesperiodeFormModal/InnleggelsesperiodeFormModal';
@@ -24,6 +25,7 @@ const Innleggelsesperiodeoversikt = ({
   const refetchBehandlingVedSykdomsendring = useRefetchBehandlingVedSykdomsendring();
 
   const [modalIsOpen, setModalIsOpen] = React.useState(false);
+  const [søknadsperiode, setSøknadsperiode] = React.useState<Period | undefined>(undefined);
   const [innleggelsesperioderResponse, setInnleggelsesperioderResponse] = React.useState<InnleggelsesperiodeResponse>({
     perioder: [],
     links: [],
@@ -100,6 +102,23 @@ const Innleggelsesperiodeoversikt = ({
       .catch(() => {
         setHentInnleggelsesperioderFeilet(true);
       });
+
+    const vurderingsoversiktEndpoint = endpoints.vurderingsoversiktLivetsSluttfase;
+    if (vurderingsoversiktEndpoint) {
+      httpUtils
+        .get(vurderingsoversiktEndpoint, httpErrorHandler, { signal: controller.signal })
+        .then((response: { perioderSomKanVurderes?: { fom: string; tom: string }[] }) => {
+          const vurderingsperioder = response?.perioderSomKanVurderes;
+          if (isMounted && vurderingsperioder && vurderingsperioder.length > 0) {
+            const perioder = vurderingsperioder.map(({ fom, tom }) => new Period(fom, tom));
+            setSøknadsperiode(finnMaksavgrensningerForPerioder(perioder));
+          }
+        })
+        .catch(() => {
+          setHentInnleggelsesperioderFeilet(true);
+        });
+    }
+
     return () => {
       isMounted = false;
       controller.abort();
@@ -160,6 +179,7 @@ const Innleggelsesperiodeoversikt = ({
           onSubmit={lagreInnleggelsesperioder}
           isLoading={isLoading}
           pleietrengendePart={pleietrengendePart}
+          søknadsperiode={søknadsperiode}
           endringerPåvirkerAndreBehandlinger={nyeInnleggelsesperioder => {
             const { href, requestPayload } = findLinkByRel(
               LinkRel.ENDRE_INNLEGGELSESPERIODER,

--- a/packages/v2/gui/src/prosess/uttak/constants/UttaksperiodeInfoÅrsakerTekst.ts
+++ b/packages/v2/gui/src/prosess/uttak/constants/UttaksperiodeInfoÅrsakerTekst.ts
@@ -74,3 +74,10 @@ export const IkkeOppfylteÅrsakerMedTekst: UttaksperiodeInfoÅrsakerTekstType[] 
     tekst: 'Årsak for avslag: Søker har mottatt pleiepenger i 60 dager.',
   },
 ];
+
+export const SluttfaseÅrsakerMedTekst: UttaksperiodeInfoÅrsakerTekstType[] = [
+  {
+    årsak: UttaksperiodeInfoÅrsaker.UTENOM_PLEIEBEHOV,
+    tekst: 'Årsak for avslag: Pleietrengende er innlagt.',
+  },
+];

--- a/packages/v2/gui/src/prosess/uttak/uttak-detaljer/UttakDetaljer.tsx
+++ b/packages/v2/gui/src/prosess/uttak/uttak-detaljer/UttakDetaljer.tsx
@@ -15,6 +15,7 @@ import { Alert, Box, Heading, HelpText, HGrid, HStack, Tag } from '@navikt/ds-re
 import {
   BarnetsDødsfallÅrsakerMedTekst,
   IkkeOppfylteÅrsakerMedTekst,
+  SluttfaseÅrsakerMedTekst,
 } from '../constants/UttaksperiodeInfoÅrsakerTekst';
 import { FremhevingTag } from './FremhevingTag';
 import GraderingMotArbeidstidDetaljer from './GraderingMotArbeidstidDetaljer';
@@ -24,13 +25,8 @@ import { useUttakContext } from '../context/UttakContext';
 import type { UttaksperiodeBeriket } from '../types/UttaksperiodeBeriket';
 import styles from './uttakDetaljer.module.css';
 
-const getÅrsaksetiketter = (årsaker: UttaksperiodeInfoÅrsakerType[]) => {
-  const funnedeÅrsaker = IkkeOppfylteÅrsakerMedTekst.filter(årsak => årsaker.includes(årsak.årsak));
-  return funnedeÅrsaker.map(årsak => (
-    <Tag data-color="danger" variant="outline" key={årsak.årsak} className={styles.uttakDetaljer}>
-      {årsak.tekst}
-    </Tag>
-  ));
+const getIkkeOppfylteÅrsaksetiketter = (årsaker: UttaksperiodeInfoÅrsakerType[]) => {
+  return getÅrsaksetiketter(årsaker, IkkeOppfylteÅrsakerMedTekst);
 };
 
 const getTekstVedBarnetsDødsfall = (årsaker: UttaksperiodeInfoÅrsakerType[]) => {
@@ -40,6 +36,25 @@ const getTekstVedBarnetsDødsfall = (årsaker: UttaksperiodeInfoÅrsakerType[]) 
       {årsak.tekst}
     </div>
   ));
+};
+
+const getSluttfaseÅrsaksetiketter = (årsaker: UttaksperiodeInfoÅrsakerType[], ytelse: FagsakYtelsesType) => {
+  return ytelse === fagsakYtelsesType.PLEIEPENGER_NÆRSTÅENDE
+    ? getÅrsaksetiketter(årsaker, SluttfaseÅrsakerMedTekst)
+    : null;
+};
+
+const getÅrsaksetiketter = (
+  årsaker: UttaksperiodeInfoÅrsakerType[],
+  årsakerMedTekst: { årsak: UttaksperiodeInfoÅrsakerType; tekst: string }[],
+) => {
+  return årsakerMedTekst
+    .filter(årsak => årsaker.includes(årsak.årsak))
+    .map(årsak => (
+      <Tag data-color="danger" variant="outline" key={årsak.årsak} className={styles.uttakDetaljer}>
+        {årsak.tekst}
+      </Tag>
+    ));
 };
 
 const utenlandsoppholdTekst = (utenlandsopphold: Utenlandsopphold, kodeverkNavnFraKode: KodeverkNavnFraKodeType) => {
@@ -138,7 +153,8 @@ const UttakDetaljer = ({ uttak, manueltOverstyrt }: UttakDetaljerProps): JSX.Ele
 
   return (
     <>
-      {getÅrsaksetiketter(årsaker || [])}
+      {getIkkeOppfylteÅrsaksetiketter(årsaker || [])}
+      {getSluttfaseÅrsaksetiketter(årsaker || [], fagsakYtelseType)}
       {getTekstVedBarnetsDødsfall(årsaker || [])}
       {utenlandsoppholdInfo(utfall, utenlandsopphold, kodeverkNavnFraKode)}
       {manueltOverstyrt && (


### PR DESCRIPTION
### Behov / Bakgrunn
For PILS:
Det skal ikke være mulig å legge til innleggelsesperioder utenom datoene for søknadsperioden, løste det ved å hente inn søknadsperioden fra endepunktet for vurderILivetsSluttfase. Blir det riktig eller lagres søknadsperioden globalt?
Prosesstegbaren for uttak skal vise delvis innvilgelse. La til uttaksperioder, og da ble prosesstegbaren riktig for delvis innleggelse.
Det skal komme opp en avslagsårsak i uttak når det er innleggelse. La til en avlagstekst på årsak UTENOM_PLEIEBEHOV.

https://nav.atlassian.net/browse/TSFF-2645

### Løsning


### Andre endringer

