### PR TITLE
Fix/tsff 2747 breaking backend changes

### DIFF
--- a/packages/behandling-pleiepenger/src/prosess/api/K9SakProsessApi.ts
+++ b/packages/behandling-pleiepenger/src/prosess/api/K9SakProsessApi.ts
@@ -1,5 +1,5 @@
+import type { BeregningsgrunnlagDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagDto.js';
 import {
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagDto,
   k9_oppdrag_kontrakt_simulering_v1_SimuleringDto,
   type k9_sak_kontrakt_aksjonspunkt_AksjonspunktDto,
   k9_sak_kontrakt_arbeidsforhold_ArbeidsgiverOversiktDto,
@@ -32,9 +32,7 @@ export interface K9SakProsessApi {
   getBeregningreferanserTilVurdering(
     behandlingUuid: string,
   ): Promise<k9_sak_kontrakt_beregningsgrunnlag_BeregningsgrunnlagKoblingDto[]>;
-  getAlleBeregningsgrunnlag(
-    behandlingUuid: string,
-  ): Promise<folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagDto[]>;
+  getAlleBeregningsgrunnlag(behandlingUuid: string): Promise<BeregningsgrunnlagDto[]>;
   getBehandling(behandlingUuid: string): Promise<k9_sak_kontrakt_behandling_BehandlingDto>;
   getSimuleringResultat(behandlingUuid: string): Promise<k9_oppdrag_kontrakt_simulering_v1_SimuleringDto>;
   getTilbakekrevingValg(behandlingUuid: string): Promise<k9_sak_kontrakt_økonomi_tilbakekreving_TilbakekrevingValgDto>;

--- a/packages/prosess-vedtak/src/components/VedtakForm.tsx
+++ b/packages/prosess-vedtak/src/components/VedtakForm.tsx
@@ -20,7 +20,6 @@ import {
 } from '@fpsak-frontend/utils/src/formidlingUtils';
 import {
   k9_sak_kontrakt_aksjonspunkt_AksjonspunktDto as AksjonspunktDto,
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_frisinn_AvslagsårsakPrPeriodeDto as AvslagsårsakPrPeriodeDto,
   k9_sak_kontrakt_behandling_BehandlingÅrsakDto as BehandlingÅrsakDto,
   k9_sak_kontrakt_vedtak_DokumentMedUstrukturerteDataDto as DokumentMedUstrukturerteDataDto,
   k9_sak_kontrakt_ytelser_OverlappendeYtelseDto as OverlappendeYtelseDto,
@@ -30,6 +29,7 @@ import {
   k9_sak_kontrakt_arbeidsforhold_ArbeidsgiverOversiktDto,
   k9_sak_kontrakt_behandling_BehandlingDto,
 } from '@k9-sak-web/backend/k9sak/generated/types.js';
+import type { AvslagsårsakPrPeriodeDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/AvslagsårsakPrPeriodeDto.js';
 import { FagsakYtelsesType, fagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
 import { VedtakFormContext } from '@k9-sak-web/behandling-felles/src/components/ProsessStegContainer';
 import { useKodeverkContext } from '@k9-sak-web/gui/kodeverk/index.js';

--- a/packages/prosess-vedtak/src/components/VedtakHelper.spec.tsx
+++ b/packages/prosess-vedtak/src/components/VedtakHelper.spec.tsx
@@ -1,11 +1,11 @@
 import behandlingType from '@fpsak-frontend/kodeverk/src/behandlingType';
 import { k9_klage_kodeverk_behandling_BehandlingResultatType as klageBehandlingsresultat } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import { fagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
+import type { AvslagsårsakPrPeriodeDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/AvslagsårsakPrPeriodeDto.js';
+import { Avslagsårsak as AvslagsårsakPrPeriodeDtoAvslagsårsak } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/Avslagsårsak.js';
+import type { BeregningsgrunnlagPeriodeDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagPeriodeDto.js';
 import {
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_frisinn_AvslagsårsakPrPeriodeDto as AvslagsårsakPrPeriodeDto,
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_frisinn_Avslagsårsak as AvslagsårsakPrPeriodeDtoAvslagsårsak,
   k9_kodeverk_behandling_BehandlingResultatType as BehandlingDtoBehandlingResultatType,
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagPeriodeDto as BeregningsgrunnlagPeriodeDto,
   k9_kodeverk_økonomi_tilbakekreving_TilbakekrevingVidereBehandling as TilbakekrevingValgDtoVidereBehandling,
 } from '@k9-sak-web/backend/k9sak/generated/types.js';
 import {

--- a/packages/prosess-vedtak/src/components/VedtakHelper.tsx
+++ b/packages/prosess-vedtak/src/components/VedtakHelper.tsx
@@ -3,11 +3,11 @@ import {
   k9_klage_kodeverk_behandling_BehandlingType as BehandlingType,
 } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import {
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_frisinn_AvslagsårsakPrPeriodeDto as AvslagsårsakPrPeriodeDto,
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagPeriodeDto as BeregningsgrunnlagPeriodeDto,
   k9_sak_kontrakt_økonomi_tilbakekreving_TilbakekrevingValgDto as TilbakekrevingValgDto,
   k9_kodeverk_økonomi_tilbakekreving_TilbakekrevingVidereBehandling as TilbakekrevingVidereBehandling,
 } from '@k9-sak-web/backend/k9sak/generated/types.js';
+import type { AvslagsårsakPrPeriodeDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/AvslagsårsakPrPeriodeDto.js';
+import type { BeregningsgrunnlagPeriodeDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagPeriodeDto.js';
 import { FagsakYtelsesType, fagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
 import { erFagytelseTypeUtvidetRett } from '@k9-sak-web/gui/utils/utvidetRettHjelpfunksjoner.js';
 import { TIDENES_ENDE } from '@k9-sak-web/lib/dateUtils/dateUtils.js';

--- a/packages/prosess-vedtak/src/components/revurdering/RevurderingPaneler.tsx
+++ b/packages/prosess-vedtak/src/components/revurdering/RevurderingPaneler.tsx
@@ -3,10 +3,10 @@ import { useIntl } from 'react-intl';
 
 import { isAvslag, isInnvilget, isOpphor } from '@fpsak-frontend/kodeverk/src/behandlingResultatType';
 import {
-  type folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_frisinn_AvslagsårsakPrPeriodeDto as AvslagsårsakPrPeriodeDto,
   type k9_sak_kontrakt_økonomi_tilbakekreving_TilbakekrevingValgDto as TilbakekrevingValgDto,
   type k9_sak_kontrakt_vilkår_VilkårMedPerioderDto as VilkårMedPerioderDto,
 } from '@k9-sak-web/backend/k9sak/generated/types.js';
+import type { AvslagsårsakPrPeriodeDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/AvslagsårsakPrPeriodeDto.js';
 import { fagsakYtelsesType, FagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
 import { useKodeverkContext } from '@k9-sak-web/gui/kodeverk/index.js';
 import { HGrid } from '@navikt/ds-react';

--- a/packages/prosess-vedtak/src/components/revurdering/VedtakInnvilgetRevurderingPanel.tsx
+++ b/packages/prosess-vedtak/src/components/revurdering/VedtakInnvilgetRevurderingPanel.tsx
@@ -1,10 +1,10 @@
 import avslagsarsakCodes from '@fpsak-frontend/kodeverk/src/avslagsarsakCodes';
 import { VerticalSpacer } from '@fpsak-frontend/shared-components';
 import {
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_frisinn_AvslagsårsakPrPeriodeDto as AvslagsårsakPrPeriodeDto,
   k9_sak_kontrakt_behandling_BehandlingsresultatDto as BehandlingsresultatDto,
   k9_sak_kontrakt_økonomi_tilbakekreving_TilbakekrevingValgDto as TilbakekrevingValgDto,
 } from '@k9-sak-web/backend/k9sak/generated/types.js';
+import type { AvslagsårsakPrPeriodeDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/AvslagsårsakPrPeriodeDto.js';
 import { useKodeverkContext } from '@k9-sak-web/gui/kodeverk/index.js';
 import { DDMMYYYY_DATE_FORMAT } from '@k9-sak-web/lib/dateUtils/formats.js';
 import { KodeverkNavnFraKodeType } from '@k9-sak-web/lib/kodeverk/types.js';

--- a/packages/prosess-vedtak/src/types/Beregningsgrunnlag.ts
+++ b/packages/prosess-vedtak/src/types/Beregningsgrunnlag.ts
@@ -1,8 +1,6 @@
-import {
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_frisinn_AvslagsårsakPrPeriodeDto as AvslagsårsakPrPeriodeDto,
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagDto as BeregningsgrunnlagDto,
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_YtelsespesifiktGrunnlagDto as YtelsespesifiktGrunnlagDto,
-} from '@k9-sak-web/backend/k9sak/generated/types.js';
+import type { AvslagsårsakPrPeriodeDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/AvslagsårsakPrPeriodeDto.js';
+import type { BeregningsgrunnlagDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagDto.js';
+import type { YtelsespesifiktGrunnlagDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/YtelsespesifiktGrunnlagDto.js';
 
 export type Beregningsgrunnlag = BeregningsgrunnlagDto & {
   ytelsesspesifiktGrunnlag?: YtelsespesifiktGrunnlagDto & {

--- a/packages/v2/backend/package.json
+++ b/packages/v2/backend/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "@navikt/k9-klage-typescript-client": "3.1.20260529100435",
-    "@navikt/k9-sak-typescript-client": "3.0.20260619114434",
+    "@navikt/k9-sak-typescript-client": "3.0.20260619204931",
     "@navikt/k9-tilbake-typescript-client": "1.1.20260510232128",
     "@navikt/ung-sak-typescript-client": "2.0.20260612140411",
     "@navikt/ung-tilbake-typescript-client": "3.0.20260519143823"

--- a/packages/v2/backend/src/k9sak/kodeverk/AktivitetStatus.ts
+++ b/packages/v2/backend/src/k9sak/kodeverk/AktivitetStatus.ts
@@ -1,0 +1,1 @@
+export { folketrygdloven_kalkulus_kodeverk_AktivitetStatus as AktivitetStatus } from '../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kodeverk/ArbeidsforholdHandlingType.ts
+++ b/packages/v2/backend/src/k9sak/kodeverk/ArbeidsforholdHandlingType.ts
@@ -1,0 +1,1 @@
+export { folketrygdloven_kalkulus_kodeverk_ArbeidsforholdHandlingType as ArbeidsforholdHandlingType } from '../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kodeverk/FaktaOmBeregningTilfelle.ts
+++ b/packages/v2/backend/src/k9sak/kodeverk/FaktaOmBeregningTilfelle.ts
@@ -1,0 +1,1 @@
+export { folketrygdloven_kalkulus_kodeverk_FaktaOmBeregningTilfelle as FaktaOmBeregningTilfelle } from '../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kodeverk/LønnsendringScenario.ts
+++ b/packages/v2/backend/src/k9sak/kodeverk/LønnsendringScenario.ts
@@ -1,0 +1,1 @@
+export { folketrygdloven_kalkulus_kodeverk_LønnsendringScenario as LønnsendringScenario } from '../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kodeverk/VirksomhetType.ts
+++ b/packages/v2/backend/src/k9sak/kodeverk/VirksomhetType.ts
@@ -1,0 +1,1 @@
+export { folketrygdloven_kalkulus_kodeverk_VirksomhetType as VirksomhetType } from '../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/Avslagsårsak.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/Avslagsårsak.ts
@@ -1,1 +1,1 @@
-export { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_frisinn_Avslagsårsak as Avslagsårsak } from '../../generated/types.js';
+export { folketrygdloven_kalkulus_response_beregningsgrunnlag_gui_frisinn_Avslagsårsak as Avslagsårsak } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/Avslagsårsak.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/Avslagsårsak.ts
@@ -1,0 +1,1 @@
+export { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_frisinn_Avslagsårsak as Avslagsårsak } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/AvslagsårsakPrPeriodeDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/AvslagsårsakPrPeriodeDto.ts
@@ -1,0 +1,1 @@
+export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_frisinn_AvslagsårsakPrPeriodeDto as AvslagsårsakPrPeriodeDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/AvslagsårsakPrPeriodeDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/AvslagsårsakPrPeriodeDto.ts
@@ -1,1 +1,1 @@
-export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_frisinn_AvslagsårsakPrPeriodeDto as AvslagsårsakPrPeriodeDto } from '../../generated/types.js';
+export type { folketrygdloven_kalkulus_response_beregningsgrunnlag_gui_frisinn_AvslagsårsakPrPeriodeDto as AvslagsårsakPrPeriodeDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagArbeidsforholdDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagArbeidsforholdDto.ts
@@ -1,0 +1,1 @@
+export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagArbeidsforholdDto as BeregningsgrunnlagArbeidsforholdDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagArbeidsforholdDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagArbeidsforholdDto.ts
@@ -1,1 +1,1 @@
-export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagArbeidsforholdDto as BeregningsgrunnlagArbeidsforholdDto } from '../../generated/types.js';
+export type { folketrygdloven_kalkulus_response_beregningsgrunnlag_gui_BeregningsgrunnlagArbeidsforholdDto as BeregningsgrunnlagArbeidsforholdDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagDto.ts
@@ -1,1 +1,1 @@
-export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagDto as BeregningsgrunnlagDto } from '../../generated/types.js';
+export type { folketrygdloven_kalkulus_response_beregningsgrunnlag_gui_BeregningsgrunnlagDto as BeregningsgrunnlagDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagDto.ts
@@ -1,0 +1,1 @@
+export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagDto as BeregningsgrunnlagDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagPeriodeDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagPeriodeDto.ts
@@ -1,0 +1,1 @@
+export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagPeriodeDto as BeregningsgrunnlagPeriodeDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagPeriodeDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagPeriodeDto.ts
@@ -1,1 +1,1 @@
-export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagPeriodeDto as BeregningsgrunnlagPeriodeDto } from '../../generated/types.js';
+export type { folketrygdloven_kalkulus_response_beregningsgrunnlag_gui_BeregningsgrunnlagPeriodeDto as BeregningsgrunnlagPeriodeDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagPrStatusOgAndelDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagPrStatusOgAndelDto.ts
@@ -1,0 +1,1 @@
+export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagPrStatusOgAndelDto as BeregningsgrunnlagPrStatusOgAndelDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagPrStatusOgAndelDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagPrStatusOgAndelDto.ts
@@ -1,1 +1,1 @@
-export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagPrStatusOgAndelDto as BeregningsgrunnlagPrStatusOgAndelDto } from '../../generated/types.js';
+export type { folketrygdloven_kalkulus_response_beregningsgrunnlag_gui_BeregningsgrunnlagPrStatusOgAndelDto as BeregningsgrunnlagPrStatusOgAndelDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/EgenNæringDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/EgenNæringDto.ts
@@ -1,1 +1,1 @@
-export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_EgenNæringDto as EgenNæringDto } from '../../generated/types.js';
+export type { folketrygdloven_kalkulus_response_beregningsgrunnlag_gui_EgenNæringDto as EgenNæringDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/EgenNæringDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/EgenNæringDto.ts
@@ -1,0 +1,1 @@
+export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_EgenNæringDto as EgenNæringDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/FaktaOmBeregningDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/FaktaOmBeregningDto.ts
@@ -1,1 +1,1 @@
-export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_FaktaOmBeregningDto as FaktaOmBeregningDto } from '../../generated/types.js';
+export type { folketrygdloven_kalkulus_response_beregningsgrunnlag_gui_FaktaOmBeregningDto as FaktaOmBeregningDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/FaktaOmBeregningDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/FaktaOmBeregningDto.ts
@@ -1,0 +1,1 @@
+export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_FaktaOmBeregningDto as FaktaOmBeregningDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/FordelingDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/FordelingDto.ts
@@ -1,1 +1,1 @@
-export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_FordelingDto as FordelingDto } from '../../generated/types.js';
+export type { folketrygdloven_kalkulus_response_beregningsgrunnlag_gui_FordelingDto as FordelingDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/FordelingDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/FordelingDto.ts
@@ -1,0 +1,1 @@
+export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_FordelingDto as FordelingDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/InntektsgrunnlagDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/InntektsgrunnlagDto.ts
@@ -1,1 +1,1 @@
-export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_inntektsgrunnlag_InntektsgrunnlagDto as InntektsgrunnlagDto } from '../../generated/types.js';
+export type { folketrygdloven_kalkulus_response_beregningsgrunnlag_gui_inntektsgrunnlag_InntektsgrunnlagDto as InntektsgrunnlagDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/InntektsgrunnlagDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/InntektsgrunnlagDto.ts
@@ -1,0 +1,1 @@
+export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_inntektsgrunnlag_InntektsgrunnlagDto as InntektsgrunnlagDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/PgiDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/PgiDto.ts
@@ -1,0 +1,1 @@
+export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_PgiDto as PgiDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/PgiDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/PgiDto.ts
@@ -1,1 +1,1 @@
-export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_PgiDto as PgiDto } from '../../generated/types.js';
+export type { folketrygdloven_kalkulus_response_beregningsgrunnlag_gui_PgiDto as PgiDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/RefusjonTilVurderingDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/RefusjonTilVurderingDto.ts
@@ -1,1 +1,1 @@
-export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_refusjon_RefusjonTilVurderingDto as RefusjonTilVurderingDto } from '../../generated/types.js';
+export type { folketrygdloven_kalkulus_response_beregningsgrunnlag_gui_refusjon_RefusjonTilVurderingDto as RefusjonTilVurderingDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/RefusjonTilVurderingDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/RefusjonTilVurderingDto.ts
@@ -1,0 +1,1 @@
+export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_refusjon_RefusjonTilVurderingDto as RefusjonTilVurderingDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/YtelsespesifiktGrunnlagDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/YtelsespesifiktGrunnlagDto.ts
@@ -1,1 +1,1 @@
-export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_YtelsespesifiktGrunnlagDto as YtelsespesifiktGrunnlagDto } from '../../generated/types.js';
+export type { folketrygdloven_kalkulus_response_beregningsgrunnlag_gui_YtelsespesifiktGrunnlagDto as YtelsespesifiktGrunnlagDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/YtelsespesifiktGrunnlagDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/beregningsgrunnlag/YtelsespesifiktGrunnlagDto.ts
@@ -1,0 +1,1 @@
+export type { folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_YtelsespesifiktGrunnlagDto as YtelsespesifiktGrunnlagDto } from '../../generated/types.js';

--- a/packages/v2/gui/src/ft-adapt/mapBeregningsgrunnlag.spec.ts
+++ b/packages/v2/gui/src/ft-adapt/mapBeregningsgrunnlag.spec.ts
@@ -1,4 +1,4 @@
-import { folketrygdloven_kalkulus_kodeverk_LønnsendringScenario } from '@k9-sak-web/backend/k9sak/generated/types.js';
+import { LønnsendringScenario } from '@k9-sak-web/backend/k9sak/kodeverk/LønnsendringScenario.js';
 import { describe, expect, it } from 'vitest';
 import { mapBeregningsgrunnlagTilFP } from './mapBeregningsgrunnlag.js';
 
@@ -111,7 +111,7 @@ describe('mapBeregningsgrunnlagTilFP – faktaOmBeregning', () => {
           lønnsendringSaksopplysning: [
             {
               sisteLønnsendringsdato: '2024-01-01',
-              lønnsendringscenario: folketrygdloven_kalkulus_kodeverk_LønnsendringScenario.FULL_MÅNEDSINNTEKT_EN_MND,
+              lønnsendringscenario: LønnsendringScenario.FULL_MÅNEDSINNTEKT_EN_MND,
               arbeidsforhold: { andelsnr: undefined, arbeidsgiverIdent: undefined },
             },
           ],

--- a/packages/v2/gui/src/ft-adapt/mapBeregningsgrunnlag.ts
+++ b/packages/v2/gui/src/ft-adapt/mapBeregningsgrunnlag.ts
@@ -1,16 +1,14 @@
-import type {
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagArbeidsforholdDto as BeregningsgrunnlagArbeidsforholdDto,
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagDto as BeregningsgrunnlagDto,
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagPeriodeDto as BeregningsgrunnlagPeriodeDto,
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagPrStatusOgAndelDto as BeregningsgrunnlagPrStatusOgAndelDto,
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_EgenNæringDto as EgenNæringDto,
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_FaktaOmBeregningDto as FaktaOmBeregningDto,
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_FordelingDto as FordelingDto,
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_inntektsgrunnlag_InntektsgrunnlagDto as InntektsgrunnlagDto,
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_PgiDto as PgiDto,
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_refusjon_RefusjonTilVurderingDto as RefusjonTilVurderingDto,
-} from '@k9-sak-web/backend/k9sak/generated/types.js';
-import { folketrygdloven_kalkulus_kodeverk_VirksomhetType as VirksomhetType } from '@k9-sak-web/backend/k9sak/generated/types.js';
+import type { BeregningsgrunnlagArbeidsforholdDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagArbeidsforholdDto.js';
+import type { BeregningsgrunnlagDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagDto.js';
+import type { BeregningsgrunnlagPeriodeDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagPeriodeDto.js';
+import type { BeregningsgrunnlagPrStatusOgAndelDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagPrStatusOgAndelDto.js';
+import type { EgenNæringDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/EgenNæringDto.js';
+import type { FaktaOmBeregningDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/FaktaOmBeregningDto.js';
+import type { FordelingDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/FordelingDto.js';
+import type { InntektsgrunnlagDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/InntektsgrunnlagDto.js';
+import type { PgiDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/PgiDto.js';
+import type { RefusjonTilVurderingDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/RefusjonTilVurderingDto.js';
+import { VirksomhetType } from '@k9-sak-web/backend/k9sak/kodeverk/VirksomhetType.js';
 import type {
   Beregningsgrunnlag as FPBeregningsgrunnlag,
   BeregningsgrunnlagAndel as FPBeregningsgrunnlagAndel,

--- a/packages/v2/gui/src/kodeverk/oppslag/K9SakKodeverkoppslag.spec.ts
+++ b/packages/v2/gui/src/kodeverk/oppslag/K9SakKodeverkoppslag.spec.ts
@@ -1,6 +1,6 @@
 import { oppslagKodeverkSomObjektK9Sak } from '../mocks/oppslagKodeverkSomObjektK9Sak.js';
+import { AktivitetStatus as AndelForFaktaOmBeregningDtoAktivitetStatus } from '@k9-sak-web/backend/k9sak/kodeverk/AktivitetStatus.js';
 import {
-  folketrygdloven_kalkulus_kodeverk_AktivitetStatus as AndelForFaktaOmBeregningDtoAktivitetStatus,
   type k9_sak_web_app_tjenester_kodeverk_dto_KodeverdiSomObjektK9_kodeverk_arbeidsforhold_AktivitetStatus as AktivitetStatus,
   k9_kodeverk_behandling_aksjonspunkt_Venteårsak as Venteårsak,
 } from '@k9-sak-web/backend/k9sak/generated/types.js';

--- a/packages/v2/gui/src/sak/totrinnskontroll/VurderFaktaBeregningTotrinnText.ts
+++ b/packages/v2/gui/src/sak/totrinnskontroll/VurderFaktaBeregningTotrinnText.ts
@@ -1,4 +1,4 @@
-import { folketrygdloven_kalkulus_kodeverk_FaktaOmBeregningTilfelle as FaktaOmBeregningTilfelle } from '@k9-sak-web/backend/k9sak/generated/types.js';
+import { FaktaOmBeregningTilfelle } from '@k9-sak-web/backend/k9sak/kodeverk/FaktaOmBeregningTilfelle.js';
 
 const vurderFaktaOmBeregningTotrinnText: Record<string, string> = {
   [FaktaOmBeregningTilfelle.VURDER_TIDSBEGRENSET_ARBEIDSFORHOLD]: 'Det er vurdert om arbeidsforhold er tidsbegrenset.',

--- a/packages/v2/gui/src/sak/totrinnskontroll/components/aksjonspunktTekster/aksjonspunktTekstUtleder.spec.tsx
+++ b/packages/v2/gui/src/sak/totrinnskontroll/components/aksjonspunktTekster/aksjonspunktTekstUtleder.spec.tsx
@@ -1,9 +1,9 @@
 import { k9_klage_kodeverk_behandling_aksjonspunkt_AksjonspunktDefinisjon as KlageAksjonspunktDtoDefinisjon } from '@k9-sak-web/backend/k9klage/generated/types.js';
 import { Klagevurdering } from '@k9-sak-web/backend/k9klage/kodeverk/Klagevurdering.js';
 import { KlagevurderingOmgjør } from '@k9-sak-web/backend/k9klage/kodeverk/KlagevurderingOmgjør.js';
+import { FaktaOmBeregningTilfelle as FaktaOmBeregningTilfeller } from '@k9-sak-web/backend/k9sak/kodeverk/FaktaOmBeregningTilfelle.js';
 import {
   k9_kodeverk_behandling_BehandlingStatus as BehandlingStatus,
-  folketrygdloven_kalkulus_kodeverk_FaktaOmBeregningTilfelle as FaktaOmBeregningTilfeller,
   k9_kodeverk_arbeidsforhold_ArbeidsforholdHandlingType as ArbeidsforholdHandlingType,
 } from '@k9-sak-web/backend/k9sak/generated/types.js';
 import { render, screen } from '@testing-library/react';

--- a/packages/v2/gui/src/sak/totrinnskontroll/components/aksjonspunktTekster/aksjonspunktTekstUtleder.tsx
+++ b/packages/v2/gui/src/sak/totrinnskontroll/components/aksjonspunktTekster/aksjonspunktTekstUtleder.tsx
@@ -8,8 +8,8 @@ import { AksjonspunktDefinisjon } from '@k9-sak-web/backend/combined/kodeverk/be
 import { Label } from '@navikt/ds-react';
 
 import type { KlagebehandlingDto } from '@k9-sak-web/backend/combined/kontrakt/klage/KlagebehandlingDto.js';
+import { ArbeidsforholdHandlingType as HandlingType } from '@k9-sak-web/backend/k9sak/kodeverk/ArbeidsforholdHandlingType.js';
 import {
-  folketrygdloven_kalkulus_kodeverk_ArbeidsforholdHandlingType as HandlingType,
   k9_kodeverk_behandling_BehandlingStatus as BehandlingStatus,
   type k9_sak_kontrakt_vedtak_TotrinnsArbeidsforholdDto as TotrinnsArbeidsforholdDto,
   type k9_sak_kontrakt_vedtak_TotrinnsBeregningDto as TotrinnsBeregningDto,

--- a/packages/v2/gui/src/storybook/mocks/FakeK9SakProsessApi.ts
+++ b/packages/v2/gui/src/storybook/mocks/FakeK9SakProsessApi.ts
@@ -1,5 +1,5 @@
+import type { BeregningsgrunnlagDto } from '@k9-sak-web/backend/k9sak/kontrakt/beregningsgrunnlag/BeregningsgrunnlagDto.js';
 import type {
-  folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagDto,
   k9_oppdrag_kontrakt_simulering_v1_SimuleringDto,
   k9_sak_kontrakt_aksjonspunkt_AksjonspunktDto,
   k9_sak_kontrakt_arbeidsforhold_ArbeidsgiverOversiktDto,
@@ -27,7 +27,7 @@ interface FakeK9SakProsessApiOptions {
   personopplysninger?: k9_sak_kontrakt_person_PersonopplysningDto;
   arbeidsgiverOpplysninger?: k9_sak_kontrakt_arbeidsforhold_ArbeidsgiverOversiktDto;
   beregningreferanser?: k9_sak_kontrakt_beregningsgrunnlag_BeregningsgrunnlagKoblingDto[];
-  beregningsgrunnlag?: folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagDto[];
+  beregningsgrunnlag?: BeregningsgrunnlagDto[];
   behandling?: k9_sak_kontrakt_behandling_BehandlingDto;
   tilbakekrevingValg?: k9_sak_kontrakt_økonomi_tilbakekreving_TilbakekrevingValgDto;
   medlemskap?: k9_sak_kontrakt_medlem_MedlemV2Dto;
@@ -81,9 +81,7 @@ export class FakeK9SakProsessApi {
     return this.options.beregningreferanser ?? [];
   }
 
-  async getAlleBeregningsgrunnlag(): Promise<
-    folketrygdloven_kalkulus_response_v1_beregningsgrunnlag_gui_BeregningsgrunnlagDto[]
-  > {
+  async getAlleBeregningsgrunnlag(): Promise<BeregningsgrunnlagDto[]> {
     return this.options.beregningsgrunnlag ?? [];
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2046,7 +2046,7 @@ __metadata:
   resolution: "@k9-sak-web/backend@workspace:packages/v2/backend"
   dependencies:
     "@navikt/k9-klage-typescript-client": "npm:3.1.20260529100435"
-    "@navikt/k9-sak-typescript-client": "npm:3.0.20260619114434"
+    "@navikt/k9-sak-typescript-client": "npm:3.0.20260619204931"
     "@navikt/k9-tilbake-typescript-client": "npm:1.1.20260510232128"
     "@navikt/ung-sak-typescript-client": "npm:2.0.20260612140411"
     "@navikt/ung-tilbake-typescript-client": "npm:3.0.20260519143823"
@@ -3365,10 +3365,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/k9-sak-typescript-client@npm:3.0.20260619114434":
-  version: 3.0.20260619114434
-  resolution: "@navikt/k9-sak-typescript-client@npm:3.0.20260619114434::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-sak-typescript-client%2F3.0.20260619114434%2F0f6f3967cf5c1c9db3115b7a75340a37390b473b"
-  checksum: 10/4df7433564c45f10f12b3ac03391623526f8f4de9d433ff6761f49f755f1b4a5c06a569119ff5d4a0a501a6b4eb99eafae8238b99bbb226b822939fe63f6768f
+"@navikt/k9-sak-typescript-client@npm:3.0.20260619204931":
+  version: 3.0.20260619204931
+  resolution: "@navikt/k9-sak-typescript-client@npm:3.0.20260619204931::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fk9-sak-typescript-client%2F3.0.20260619204931%2F33538264802788d3e257bc7ffbfc464c60b7badf"
+  checksum: 10/b60e61215e6f50ad17fc3c140aad5e4eae62005a033adbad1bfafd7c77b4376f52ba09175e2cfa1bf7ddac8cced82bcbd2d708dc86f9b2e69c47704614b84d0d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Behov / Bakgrunn

Pakkenamn på nokre typer i k9-sak openapi spec vart endra.

Ref https://github.com/navikt/k9-sak/pull/13056

### Løsning

1. Lager re-eksport av typer som fekk endra namn, tek dei i bruk.
2. Oppdaterer k9-sak-typescript-client og oppdaterer import i re-eksporterte typer slik at dei blir korrekt etter endring i pakkenamn.

Dette er kun ei type-refaktorering, ingen faktisk endring i definisjon eller runtime oppførsel.

