### PR TITLE
chore: justerer minimumsalder på pakker for yarn og dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,7 +10,7 @@ updates:
     schedule:
       interval: daily
     cooldown:
-      default-days: 7
+      default-days: 3
     open-pull-requests-limit: 30
     registries:
       - npm-github
@@ -44,7 +44,7 @@ updates:
     schedule:
       interval: daily
     cooldown:
-      default-days: 7
+      default-days: 3
     registries:
       - npm-github
     groups:

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -6,7 +6,7 @@ enableScripts: false
 
 nodeLinker: node-modules
 
-npmMinimalAgeGate: 7d
+npmMinimalAgeGate: 3d
 
 npmPreapprovedPackages:
   - "@navikt/*"


### PR DESCRIPTION
### Behov / Bakgrunn
Ønsker å redusere minimumsalderen en pakke må ha før den kan oppdateres.

### Løsning
Justerer fra 7 til 3 dager i henhold til Security Playbook.

### Andre endringer

