### PR TITLE
chore: aksel-pakkene kan oppdateres samtidig som andre pakker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -25,16 +25,12 @@ updates:
           - 'react'
           - 'react-dom'
           - '@types/react'
-          - '@navikt*'
+          - '@navikt/ft-*'
       react:
         patterns:
           - 'react'
           - 'react-dom'
           - '@types/react'
-      designsystem:
-        patterns:
-          - '@navikt/aksel-icons'
-          - '@navikt/ds-*'
       ft-frontend:
         patterns:
           - '@navikt/ft-*'


### PR DESCRIPTION
### Behov / Bakgrunn
Trenger ikke egen gruppe i dependabot for Aksel-pakkene mer da disse ikke trenger å være helt i sync med ft-repoet.

### Løsning
Fjerner gruppering i dependabot.

### Andre endringer

