### PR TITLE
Fix/errorhandling adjust badrequest

### DIFF
--- a/packages/v2/gui/src/app/errorhandling/ui/ErrorAlert.stories.tsx
+++ b/packages/v2/gui/src/app/errorhandling/ui/ErrorAlert.stories.tsx
@@ -74,11 +74,31 @@ export const DefaultStory: Story = {
       </>
     ),
     fixAction: {
-      label: 'Fix action label',
       info: <BodyLong>Fix info. (More text about how to resolve problem)</BodyLong>,
-      icon: <RocketIcon />,
-      callback: action('Fix problem'),
+      button: {
+        label: 'Fix action label',
+        icon: <RocketIcon />,
+        callback: action('Fix problem'),
+      },
     },
+  },
+};
+
+/** Viser ErrorAlert med fixAction som berre har info (ingen knapp) */
+export const UtenFikseknapp: Story = {
+  args: {
+    title: 'Innsendt forespørsel var ugyldig',
+    error: new AppError({ message: 'Lorem ipsum error' }),
+    errorInfo: <BodyLong>Et eller flere av feltene er enten fylt inn feil eller mangler utfylling.</BodyLong>,
+    fixAction: {
+      info: <BodyLong>Se over feltene og prøv på nytt. Meld feil i porten hvis du ikke får løst det.</BodyLong>,
+    },
+  },
+  play: async ({ canvas }) => {
+    await expect(canvas.getByText('Innsendt forespørsel var ugyldig')).toBeInTheDocument();
+    // Ingen fikseknapp skal visast, men "Meld feil i porten" skal framleis finnast
+    await expect(canvas.queryByRole('button', { name: 'Fix action label' })).not.toBeInTheDocument();
+    await expect(canvas.getByRole('button', { name: 'Meld feil i porten' })).toBeInTheDocument();
   },
 };
 

--- a/packages/v2/gui/src/app/errorhandling/ui/ErrorFixAction.tsx
+++ b/packages/v2/gui/src/app/errorhandling/ui/ErrorFixAction.tsx
@@ -1,64 +1,83 @@
-import type { ReactNode } from "react";
-import { ArrowCirclepathIcon, ArrowCirclepathReverseIcon, ArrowsCirclepathIcon } from "@navikt/aksel-icons";
-import { BodyLong } from "@navikt/ds-react";
+import type { ReactNode } from 'react';
+import { ArrowCirclepathIcon, ArrowCirclepathReverseIcon, ArrowsCirclepathIcon } from '@navikt/aksel-icons';
+import { BodyLong } from '@navikt/ds-react';
 
-export type ErrorFixAction = Readonly<
+export type ErrorFixButton = Readonly<
   {
     // Tekst på "fikseknapp" i wizard
     label: string;
     // Ikon på "fikseknapp" i wizard
     icon: ReactNode;
-    // Tekst til bruker, om kva som kan gjerast for å fikse problem, evt melde det. Ikkje putt avansert markup her.
-    info: ReactNode;
   } & (
-  | {
-  callback: () => void; // Onclick på "fikseknapp" kaller denne
-  href?: never;
-}
-  | {
-  callback?: never;
-  href: string; // Klikk på "fikseknapp" (link) navigerer til denne.
-}
+    | {
+        callback: () => void; // Onclick på "fikseknapp" kaller denne
+        href?: never;
+      }
+    | {
+        callback?: never;
+        href: string; // Klikk på "fikseknapp" (link) navigerer til denne.
+      }
   )
 >;
+
+export type ErrorFixAction = Readonly<{
+  // Tekst til bruker, om kva som kan gjerast for å fikse problem, evt melde det. Ikkje putt avansert markup her.
+  info: ReactNode;
+  // Valgfri knapp. Viss ikkje sett, visast ingen "fikseknapp" i feilvisninga.
+  button?: ErrorFixButton;
+}>;
 
 // Genererer fixAction verdi for standard Prøv på nytt knapp i Error
 export const retryAction = (callback: () => void): ErrorFixAction => {
   return {
-    label: 'Prøv på nytt',
-    icon: <ArrowsCirclepathIcon />,
-    info: <BodyLong>Prøv på nytt for å få feilfri visning. Meld feil i porten hvis du ikke får løst den selv.</BodyLong>,
-    callback,
+    info: (
+      <BodyLong>Prøv på nytt for å få feilfri visning. Meld feil i porten hvis du ikke får løst den selv.</BodyLong>
+    ),
+    button: {
+      label: 'Prøv på nytt',
+      icon: <ArrowsCirclepathIcon />,
+      callback,
+    },
   };
 };
 
 export const reloadAction: ErrorFixAction = {
-  label: 'Last siden på nytt',
-  icon: <ArrowCirclepathIcon />,
-  info: <>
-    <BodyLong>Prøv å laste siden på nytt.</BodyLong>
-    <BodyLong> Meld feil i porten hvis den ikke løser seg etter hvert.</BodyLong>
-    </>,
-  callback: () => window.location.reload(),
+  info: (
+    <>
+      <BodyLong>Prøv å laste siden på nytt.</BodyLong>
+      <BodyLong> Meld feil i porten hvis den ikke løser seg etter hvert.</BodyLong>
+    </>
+  ),
+  button: {
+    label: 'Last siden på nytt',
+    icon: <ArrowCirclepathIcon />,
+    callback: () => window.location.reload(),
+  },
 };
 
 export const reloadActionWithFormResetWarning: ErrorFixAction = {
-  label: 'Last siden på nytt',
-  icon: <ArrowCirclepathIcon />,
-  info: <>
-    <BodyLong>Prøv å laste siden på nytt.</BodyLong>
-    <BodyLong>
-    Obs! Hvis du trykker på "Last siden på nytt", forsvinner teksten du har skrevet inn i feltene. Du kan kopiere teksten
-  før du laster inn på nytt.
-    </BodyLong>
-    <BodyLong>Meld feilen i Porten hvis du ikke får løst den selv.</BodyLong>
-    </>,
-  callback: () => window.location.reload(),
+  info: (
+    <>
+      <BodyLong>Prøv å laste siden på nytt.</BodyLong>
+      <BodyLong>
+        Obs! Hvis du trykker på "Last siden på nytt", forsvinner teksten du har skrevet inn i feltene. Du kan kopiere
+        teksten før du laster inn på nytt.
+      </BodyLong>
+      <BodyLong>Meld feilen i Porten hvis du ikke får løst den selv.</BodyLong>
+    </>
+  ),
+  button: {
+    label: 'Last siden på nytt',
+    icon: <ArrowCirclepathIcon />,
+    callback: () => window.location.reload(),
+  },
 };
 
 export const restartAction: ErrorFixAction = {
-  label: 'Tilbake til forsiden',
-  icon: <ArrowCirclepathReverseIcon />,
   info: 'Prøv å starte på nytt fra forsiden. Meld feil i Porten hvis du ikke får løst den selv.',
-  href: '/',
+  button: {
+    label: 'Tilbake til forsiden',
+    icon: <ArrowCirclepathReverseIcon />,
+    href: '/',
+  },
 };

--- a/packages/v2/gui/src/app/errorhandling/ui/FixButton.tsx
+++ b/packages/v2/gui/src/app/errorhandling/ui/FixButton.tsx
@@ -1,12 +1,20 @@
-import type { ErrorFixAction } from "./ErrorFixAction.js";
-import type { FC } from "react";
-import { Button } from "@navikt/ds-react";
+import type { ErrorFixAction } from './ErrorFixAction.js';
+import type { FC } from 'react';
+import { Button } from '@navikt/ds-react';
 
 export type FixButtonProps = Readonly<{
-  fixAction: ErrorFixAction
-}>
+  fixAction: ErrorFixAction;
+}>;
 
-export const FixButton: FC<FixButtonProps> = ({fixAction: {label, icon, href, callback}}) => {
-  const variableProps = callback != null ? {onClick: callback} as const : {href, as: "a"} as const
-  return <Button variant="primary" data-color="neutral" size="small" icon={icon} iconPosition="right" {...variableProps}>{label}</Button>
-}
+export const FixButton: FC<FixButtonProps> = ({ fixAction: { button } }) => {
+  if (button == null) {
+    return null;
+  }
+  const { label, icon, href, callback } = button;
+  const variableProps = callback != null ? ({ onClick: callback } as const) : ({ href, as: 'a' } as const);
+  return (
+    <Button variant="primary" data-color="neutral" size="small" icon={icon} iconPosition="right" {...variableProps}>
+      {label}
+    </Button>
+  );
+};

--- a/packages/v2/gui/src/app/errorhandling/ui/resolveApiErrorViewProps.tsx
+++ b/packages/v2/gui/src/app/errorhandling/ui/resolveApiErrorViewProps.tsx
@@ -25,53 +25,63 @@ export const resolveApiErrorViewProps = (error: ExtendedApiError): ErrorViewProp
     errorInfo = <BodyLong>Du er ikke innlogget.</BodyLong>;
   } else if (error.isForbidden) {
     title = 'Ikke tilgang';
-    errorInfo = <BodyLong> Du har ikke tilgang til å gjøre denne handlingen eller se denne informasjonen. </BodyLong>
+    errorInfo = <BodyLong> Du har ikke tilgang til å gjøre denne handlingen eller se denne informasjonen. </BodyLong>;
     fixAction = {
       ...restartAction,
-      info: <>
-        <BodyLong>
-          Hvis du mener at du skal ha rolle/rettighet til dette, tar du kontakt med din ident-ansvarlig.
-        </BodyLong>
-        <BodyLong>
-          Hvis du vet at du har den nødvendige tilgangen, melder du feilen i Porten.
-        </BodyLong>
-      </>,
-    }
+      info: (
+        <>
+          <BodyLong>
+            Hvis du mener at du skal ha rolle/rettighet til dette, tar du kontakt med din ident-ansvarlig.
+          </BodyLong>
+          <BodyLong>Hvis du vet at du har den nødvendige tilgangen, melder du feilen i Porten.</BodyLong>
+        </>
+      ),
+    };
   } else if (error.isNotFound) {
-    title = 'Finner ikke det du spør om'
-    errorInfo = 'Systemet finner ikke det du ber om.'
+    title = 'Finner ikke det du spør om';
+    errorInfo = 'Systemet finner ikke det du ber om.';
     fixAction = {
       ...restartAction,
-      info: <>
-        <BodyLong>Prøv å starte på nytt fra forsiden.</BodyLong>
-        <BodyLong>Rapporter feil i Porten hvis du ikke får løst den selv.</BodyLong>
-      </>
-    }
+      info: (
+        <>
+          <BodyLong>Prøv å starte på nytt fra forsiden.</BodyLong>
+          <BodyLong>Meld feil i Porten hvis du ikke får løst den selv.</BodyLong>
+        </>
+      ),
+    };
   } else if (error.isBadRequest) {
-    title = 'Feltene mangler eller har feil informasjon';
-    errorInfo = (
-      <>
-        <BodyLong>Et eller flere av feltene er enten fylt inn feil eller mangler utfylling.</BodyLong>
-      </>
+    const feilmelding = error.bodyFeilmelding;
+    const harFeilmelding = feilmelding != null && feilmelding.trim().length > 5;
+
+    title = 'Innsendt forespørsel var ugyldig';
+    errorInfo = harFeilmelding ? (
+      <BodyLong weight="semibold">{feilmelding}</BodyLong>
+    ) : (
+      <BodyLong>Et eller flere av feltene er enten fylt inn feil eller mangler utfylling.</BodyLong>
     );
     fixAction = {
       ...reloadAction,
-      info: <>
-        <BodyLong>Se over feltene og vær sikker på at du har fylt dem inn riktig, før du prøver på nytt.</BodyLong>
-        <BodyLong>Obs! Hvis du trykker på "Last siden på nytt", må du fylle inn alle feltene på nytt.</BodyLong>
-        <BodyLong>Rapporter feil i porten hvis du ikke får løst det.</BodyLong>
-      </>
-    }
+      info: (
+        <>
+          <BodyLong>Se over feltene og vær sikker på at du har fylt dem inn riktig, før du prøver på nytt.</BodyLong>
+          <BodyLong>Obs! Hvis du trykker på "Last siden på nytt", må du fylle inn alle feltene på nytt.</BodyLong>
+          <BodyLong>Meld feil i porten hvis du ikke får løst det.</BodyLong>
+        </>
+      ),
+    };
   } else if (error.isConflict) {
-    title = "Saksinformasjonen er utdatert"
-    errorInfo = <BodyLong>
-      Saken har blitt oppdatert med ny informasjon av systemet eller av en annen saksbehandler mens du har jobbet med den.
-    </BodyLong>
-    fixAction = reloadActionWithFormResetWarning
+    title = 'Saksinformasjonen er utdatert';
+    errorInfo = (
+      <BodyLong>
+        Saken har blitt oppdatert med ny informasjon av systemet eller av en annen saksbehandler mens du har jobbet med
+        den.
+      </BodyLong>
+    );
+    fixAction = reloadActionWithFormResetWarning;
   } else if (error.isGatewayTimeout) {
-    title = 'Dette tok for lang tid'
-    errorInfo = 'Systemet har brukt for lang tid på å svare deg.'
-    fixAction = reloadAction
+    title = 'Dette tok for lang tid';
+    errorInfo = 'Systemet har brukt for lang tid på å svare deg.';
+    fixAction = reloadAction;
   }
 
   return {

--- a/packages/v2/gui/src/app/errorhandling/ui/resolveApiErrorViewProps.tsx
+++ b/packages/v2/gui/src/app/errorhandling/ui/resolveApiErrorViewProps.tsx
@@ -62,11 +62,16 @@ export const resolveApiErrorViewProps = (error: ExtendedApiError): ErrorViewProp
       <BodyLong>Et eller flere av feltene er enten fylt inn feil eller mangler utfylling.</BodyLong>
     );
     fixAction = {
-      ...reloadAction,
-      info: (
+      info: harFeilmelding ? (
+        <>
+          <BodyLong>
+            Korriger feil rapportert i feilmeldingen over. Prøv deretter å utføre handlingen som feilet på nytt.
+          </BodyLong>
+          <BodyLong>Meld feil i porten hvis du ikke får løst det.</BodyLong>
+        </>
+      ) : (
         <>
           <BodyLong>Se over feltene og vær sikker på at du har fylt dem inn riktig, før du prøver på nytt.</BodyLong>
-          <BodyLong>Obs! Hvis du trykker på "Last siden på nytt", må du fylle inn alle feltene på nytt.</BodyLong>
           <BodyLong>Meld feil i porten hvis du ikke får løst det.</BodyLong>
         </>
       ),

--- a/packages/v2/gui/src/app/errorhandling/ui/resolveApiErrorViewProps.tsx
+++ b/packages/v2/gui/src/app/errorhandling/ui/resolveApiErrorViewProps.tsx
@@ -16,10 +16,12 @@ export const resolveApiErrorViewProps = (error: ExtendedApiError): ErrorViewProp
   if (error.isUnauthorized) {
     const loginUrl = withRedirectToCurrentLocation(resolveLoginURL(error.location))?.toString() ?? '/';
     fixAction = {
-      label: 'Logg inn',
-      icon: <EnterIcon />,
-      href: loginUrl,
       info: 'Prøv å logge inn på nytt. Meld feil i Porten hvis du ikke får løst den selv.',
+      button: {
+        label: 'Logg inn',
+        icon: <EnterIcon />,
+        href: loginUrl,
+      },
     };
     title = 'Ikke innlogget';
     errorInfo = <BodyLong>Du er ikke innlogget.</BodyLong>;

--- a/packages/v2/gui/src/app/errorhandling/ui/resolveAxiosErrorView.tsx
+++ b/packages/v2/gui/src/app/errorhandling/ui/resolveAxiosErrorView.tsx
@@ -47,6 +47,15 @@ const resolveTeapotProps = (error: AxiosError) => {
   return { status, eta, systemMelding };
 };
 
+// Hent ut "feilmelding" frå server-responsen (t.d. ved BadRequestException). Returnerer null viss den ikkje finst.
+const getBodyFeilmelding = (error: AxiosError): string | null => {
+  const data = asRecord(getEffectiveResponseData(error));
+  if (data != null && typeof data['feilmelding'] === 'string') {
+    return data['feilmelding'];
+  }
+  return null;
+};
+
 export const resolveAxiosErrorÅrsakIkkeTilgang = (error: AxiosError): ReadonlyArray<ÅrsakIkkeTilgang> => {
   if (error.status === 403) {
     const data = asRecord(getEffectiveResponseData(error));
@@ -203,13 +212,15 @@ export const resolveAxiosErrorView = (error: AxiosError): ErrorViewProps => {
 
   // 400 — ugyldig forespørsel. Speglar resolveApiErrorViewProps.
   if (status === 400) {
+    const feilmelding = getBodyFeilmelding(error);
+    const harFeilmelding = feilmelding != null && feilmelding.trim().length > 5;
     return {
       error,
-      title: 'Feltene mangler eller har feil informasjon',
-      errorInfo: (
-        <>
-          <BodyLong>Et eller flere av feltene er enten fylt inn feil eller mangler utfylling.</BodyLong>
-        </>
+      title: 'Innsendt forespørsel var ugyldig',
+      errorInfo: harFeilmelding ? (
+        <BodyLong weight="semibold">{feilmelding}</BodyLong>
+      ) : (
+        <BodyLong>Et eller flere av feltene er enten fylt inn feil eller mangler utfylling.</BodyLong>
       ),
       fixAction: {
         ...reloadAction,

--- a/packages/v2/gui/src/app/errorhandling/ui/resolveAxiosErrorView.tsx
+++ b/packages/v2/gui/src/app/errorhandling/ui/resolveAxiosErrorView.tsx
@@ -87,10 +87,12 @@ export const resolveAxiosErrorView = (error: AxiosError): ErrorViewProps => {
       title: 'Ikke innlogget',
       errorInfo: <BodyLong>Du er ikke innlogget.</BodyLong>,
       fixAction: {
-        label: 'Logg inn',
-        icon: <EnterIcon />,
-        href: loginUrl,
         info: 'Prøv å logge inn på nytt. Meld feil i Porten hvis du ikke får løst den selv.',
+        button: {
+          label: 'Logg inn',
+          icon: <EnterIcon />,
+          href: loginUrl,
+        },
       },
     };
   }

--- a/packages/v2/gui/src/app/errorhandling/ui/resolveAxiosErrorView.tsx
+++ b/packages/v2/gui/src/app/errorhandling/ui/resolveAxiosErrorView.tsx
@@ -216,24 +216,32 @@ export const resolveAxiosErrorView = (error: AxiosError): ErrorViewProps => {
   if (status === 400) {
     const feilmelding = getBodyFeilmelding(error);
     const harFeilmelding = feilmelding != null && feilmelding.trim().length > 5;
+
+    const errorInfo = harFeilmelding ? (
+      <BodyLong weight="semibold">{feilmelding}</BodyLong>
+    ) : (
+      <BodyLong>Et eller flere av feltene er enten fylt inn feil eller mangler utfylling.</BodyLong>
+    );
+    const fixAction = {
+      info: harFeilmelding ? (
+        <>
+          <BodyLong>
+            Korriger feil rapportert i feilmeldingen over. Prøv deretter å utføre handlingen som feilet på nytt.
+          </BodyLong>
+          <BodyLong>Meld feil i porten hvis du ikke får løst det.</BodyLong>
+        </>
+      ) : (
+        <>
+          <BodyLong>Se over feltene og vær sikker på at du har fylt dem inn riktig, før du prøver på nytt.</BodyLong>
+          <BodyLong>Meld feil i porten hvis du ikke får løst det.</BodyLong>
+        </>
+      ),
+    };
     return {
       error,
       title: 'Innsendt forespørsel var ugyldig',
-      errorInfo: harFeilmelding ? (
-        <BodyLong weight="semibold">{feilmelding}</BodyLong>
-      ) : (
-        <BodyLong>Et eller flere av feltene er enten fylt inn feil eller mangler utfylling.</BodyLong>
-      ),
-      fixAction: {
-        ...reloadAction,
-        info: (
-          <>
-            <BodyLong>Se over feltene og vær sikker på at du har fylt dem inn riktig, før du prøver på nytt.</BodyLong>
-            <BodyLong>Obs! Hvis du trykker på "Last siden på nytt", må du fylle inn alle feltene på nytt.</BodyLong>
-            <BodyLong>Meld feil i porten hvis du ikke får løst det.</BodyLong>
-          </>
-        ),
-      },
+      errorInfo,
+      fixAction,
     };
   }
 

--- a/packages/v2/gui/src/app/errorhandling/ui/resolveErrorViewProps.tsx
+++ b/packages/v2/gui/src/app/errorhandling/ui/resolveErrorViewProps.tsx
@@ -34,14 +34,16 @@ const authAbortedViewProps = (error: AuthAbortedError): ErrorViewProps => {
       </>
     ),
     fixAction: {
-      label: 'Logg inn',
-      icon: <EnterIcon />,
       info: (
         <BodyShort>
           Hvis du ønsker å logge inn, prøv på nytt med <i>Logg inn</i> knappen.
         </BodyShort>
       ),
-      href: `${error.retryURL ?? '/'}`,
+      button: {
+        label: 'Logg inn',
+        icon: <EnterIcon />,
+        href: `${error.retryURL ?? '/'}`,
+      },
     },
   };
 };


### PR DESCRIPTION
### Behov / Bakgrunn

400 feil betyr at bruker har sendt ugyldig forespørsel. Det hjelpe då ikkje å laste på nytt og prøve igjen med samme data. 

Når server svare med 400 feil inneheld gjerne feilmelding konkret info om kva bruker må korrigere for å få utført forespørsel.

### Løsning

- Viser feilmelding frå server ved 400 feil.
- Fjerner "last på nytt" knapp ved 400 feil.


