### PR TITLE
Fiks redigering av nattevåk og beredskap

### DIFF
--- a/packages/behandling-opplaeringspenger/src/components/EtablertTilsyn.tsx
+++ b/packages/behandling-opplaeringspenger/src/components/EtablertTilsyn.tsx
@@ -19,6 +19,8 @@ export default ({ aksjonspunkter, behandling, readOnly, submitCallback }) => {
 
   const harUløstAksjonspunktForBeredskap = beredskapAksjonspunkt?.status.kode === aksjonspunktStatus.OPPRETTET;
   const harUløstAksjonspunktForNattevåk = nattevåkAksjonspunkt?.status.kode === aksjonspunktStatus.OPPRETTET;
+  const harLøstAksjonspunktForBeredskap = beredskapAksjonspunkt?.status.kode === aksjonspunktStatus.UTFORT;
+  const harLøstAksjonspunktForNattevåk = nattevåkAksjonspunkt?.status.kode === aksjonspunktStatus.UTFORT;
 
   return (
     <EtablertTilsynContainer
@@ -32,8 +34,10 @@ export default ({ aksjonspunkter, behandling, readOnly, submitCallback }) => {
         ]),
         lagreBeredskapvurdering: løsBeredskapAksjonspunkt,
         lagreNattevåkvurdering: løsNattevåkAksjonspunkt,
-        harAksjonspunktForBeredskap: harUløstAksjonspunktForBeredskap,
-        harAksjonspunktForNattevåk: harUløstAksjonspunktForNattevåk,
+        harUløstAksjonspunktForBeredskap,
+        harUløstAksjonspunktForNattevåk,
+        harLøstAksjonspunktForBeredskap,
+        harLøstAksjonspunktForNattevåk,
       }}
     />
   );

--- a/packages/behandling-pleiepenger/src/components/EtablertTilsyn.tsx
+++ b/packages/behandling-pleiepenger/src/components/EtablertTilsyn.tsx
@@ -20,6 +20,8 @@ export default ({ aksjonspunkter, behandling, readOnly, submitCallback }) => {
 
   const harUløstAksjonspunktForBeredskap = beredskapAksjonspunkt?.status.kode === aksjonspunktStatus.OPPRETTET;
   const harUløstAksjonspunktForNattevåk = nattevåkAksjonspunkt?.status.kode === aksjonspunktStatus.OPPRETTET;
+  const harLøstAksjonspunktForBeredskap = beredskapAksjonspunkt?.status.kode === aksjonspunktStatus.UTFORT;
+  const harLøstAksjonspunktForNattevåk = nattevåkAksjonspunkt?.status.kode === aksjonspunktStatus.UTFORT;
 
   return (
     <EtablertTilsynContainer
@@ -33,8 +35,10 @@ export default ({ aksjonspunkter, behandling, readOnly, submitCallback }) => {
         ]),
         lagreBeredskapvurdering: løsBeredskapAksjonspunkt,
         lagreNattevåkvurdering: løsNattevåkAksjonspunkt,
-        harAksjonspunktForBeredskap: harUløstAksjonspunktForBeredskap,
-        harAksjonspunktForNattevåk: harUløstAksjonspunktForNattevåk,
+        harUløstAksjonspunktForBeredskap,
+        harUløstAksjonspunktForNattevåk,
+        harLøstAksjonspunktForBeredskap,
+        harLøstAksjonspunktForNattevåk,
       }}
     />
   );

--- a/packages/fakta-etablert-tilsyn/src/types/ContainerContract.ts
+++ b/packages/fakta-etablert-tilsyn/src/types/ContainerContract.ts
@@ -8,8 +8,10 @@ interface ContainerContract {
   errorNotifier: (error: Error) => void;
   lagreBeredskapvurdering: (data: any) => void;
   lagreNattevåkvurdering: (data: any) => void;
-  harAksjonspunktForBeredskap: boolean;
-  harAksjonspunktForNattevåk: boolean;
+  harUløstAksjonspunktForBeredskap: boolean;
+  harUløstAksjonspunktForNattevåk: boolean;
+  harLøstAksjonspunktForBeredskap: boolean;
+  harLøstAksjonspunktForNattevåk: boolean;
 }
 
 export default ContainerContract;

--- a/packages/fakta-etablert-tilsyn/src/ui/EtablertTilsyn.stories.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/EtablertTilsyn.stories.tsx
@@ -342,14 +342,18 @@ export const LøstAksjonspunktBeredskap: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
-    await step('skal starte på tilsyn-fanen (ikke beredskap) når aksjonspunkt er løst', async () => {
+    await step('skal starte på Etablert tilsyn-fanen (ikke beredskap) når aksjonspunkt er løst', async () => {
       await waitFor(async () => {
-        await expect(canvas.getByRole('tab', { name: 'Tilsyn' })).toHaveAttribute('aria-selected', 'true');
+        await expect(canvas.getByRole('tab', { name: 'Etablert tilsyn' })).toHaveAttribute('aria-selected', 'true');
       });
     });
 
     await step('skal vise rediger-knapp for ferdig vurderte perioder', async () => {
       await userEvent.click(canvas.getByRole('tab', { name: 'Beredskap' }));
+      await waitFor(async () => {
+        await expect(canvas.getByText('Alle perioder')).toBeInTheDocument();
+      });
+      await userEvent.click(canvas.getAllByRole('button')[0]);
       await waitFor(async () => {
         await expect(canvas.getByText('Vurdering av beredskap')).toBeInTheDocument();
       });
@@ -388,15 +392,15 @@ export const LøstAksjonspunktNattevåk: Story = {
   play: async ({ canvasElement, step }) => {
     const canvas = within(canvasElement);
 
-    await step('skal starte på tilsyn-fanen (ikke nattevåk) når aksjonspunkt er løst', async () => {
+    await step('skal starte på Etablert tilsyn-fanen (ikke nattevåk) når aksjonspunkt er løst', async () => {
       await waitFor(async () => {
-        await expect(canvas.getByRole('tab', { name: 'Tilsyn' })).toHaveAttribute('aria-selected', 'true');
+        await expect(canvas.getByRole('tab', { name: 'Etablert tilsyn' })).toHaveAttribute('aria-selected', 'true');
       });
     });
 
     await step('skal ikke vise varselikon på nattevåk-fane når aksjonspunkt er løst', async () => {
       const nattevåkTab = canvas.getByRole('tab', { name: 'Nattevåk' });
-      await expect(nattevåkTab.querySelector('svg')).not.toBeInTheDocument();
+      void expect(nattevåkTab.querySelector('svg')).toBeNull();
     });
   },
 };
@@ -473,6 +477,10 @@ export const IngenRedigeringUtenAksjonspunkt: Story = {
 
     await step('skal ikke vise rediger-knapp for beredskap uten aksjonspunkt', async () => {
       await userEvent.click(canvas.getByRole('tab', { name: 'Beredskap' }));
+      await waitFor(async () => {
+        await expect(canvas.getByText('Alle perioder')).toBeInTheDocument();
+      });
+      await userEvent.click(canvas.getAllByRole('button')[0]);
       await waitFor(async () => {
         await expect(canvas.getByText('Vurdering av beredskap')).toBeInTheDocument();
       });

--- a/packages/fakta-etablert-tilsyn/src/ui/EtablertTilsyn.stories.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/EtablertTilsyn.stories.tsx
@@ -19,8 +19,10 @@ const meta = {
       errorNotifier: () => {},
       lagreBeredskapvurdering: fn(),
       lagreNattevåkvurdering: fn(),
-      harAksjonspunktForBeredskap: true,
-      harAksjonspunktForNattevåk: true,
+      harUløstAksjonspunktForBeredskap: true,
+      harUløstAksjonspunktForNattevåk: true,
+      harLøstAksjonspunktForBeredskap: false,
+      harLøstAksjonspunktForNattevåk: false,
     },
   },
   parameters: {
@@ -132,8 +134,10 @@ export const UtenAksjonspunkter: Story = {
       errorNotifier: () => {},
       lagreBeredskapvurdering: fn(),
       lagreNattevåkvurdering: fn(),
-      harAksjonspunktForBeredskap: false,
-      harAksjonspunktForNattevåk: false,
+      harUløstAksjonspunktForBeredskap: false,
+      harUløstAksjonspunktForNattevåk: false,
+      harLøstAksjonspunktForBeredskap: false,
+      harLøstAksjonspunktForNattevåk: false,
     },
   },
   parameters: {
@@ -182,8 +186,10 @@ export const BareNattevåkAksjonspunkt: Story = {
       errorNotifier: () => {},
       lagreBeredskapvurdering: fn(),
       lagreNattevåkvurdering: fn(),
-      harAksjonspunktForBeredskap: false,
-      harAksjonspunktForNattevåk: true,
+      harUløstAksjonspunktForBeredskap: false,
+      harUløstAksjonspunktForNattevåk: true,
+      harLøstAksjonspunktForBeredskap: false,
+      harLøstAksjonspunktForNattevåk: false,
     },
   },
   parameters: {
@@ -232,8 +238,10 @@ export const BareBeredskapAksjonspunkt: Story = {
       errorNotifier: () => {},
       lagreBeredskapvurdering: fn(),
       lagreNattevåkvurdering: fn(),
-      harAksjonspunktForBeredskap: true,
-      harAksjonspunktForNattevåk: false,
+      harUløstAksjonspunktForBeredskap: true,
+      harUløstAksjonspunktForNattevåk: false,
+      harLøstAksjonspunktForBeredskap: false,
+      harLøstAksjonspunktForNattevåk: false,
     },
   },
   parameters: {
@@ -282,8 +290,10 @@ export const BeredskapFerdigVurdert: Story = {
       errorNotifier: () => {},
       lagreBeredskapvurdering: data => console.log('Lagrer beredskap:', data),
       lagreNattevåkvurdering: data => console.log('Lagrer nattevåk:', data),
-      harAksjonspunktForBeredskap: true,
-      harAksjonspunktForNattevåk: false,
+      harUløstAksjonspunktForBeredskap: true,
+      harUløstAksjonspunktForNattevåk: false,
+      harLøstAksjonspunktForBeredskap: false,
+      harLøstAksjonspunktForNattevåk: false,
     },
   },
   parameters: {
@@ -302,6 +312,175 @@ export const BeredskapFerdigVurdert: Story = {
         ).toBeInTheDocument();
       });
       await expect(canvas.getByRole('button', { name: 'Fortsett' })).toBeInTheDocument();
+    });
+  },
+};
+
+export const LøstAksjonspunktBeredskap: Story = {
+  args: {
+    data: {
+      readOnly: false,
+      endpoints: {
+        tilsyn: `${mockUrlPrepend}/mock/tilsyn-ferdig-vurdert`,
+        sykdom: `${mockUrlPrepend}/mock/sykdom`,
+        sykdomInnleggelse: `${mockUrlPrepend}/mock/sykdomInnleggelse`,
+      },
+      errorNotifier: () => {},
+      lagreBeredskapvurdering: fn(),
+      lagreNattevåkvurdering: fn(),
+      harUløstAksjonspunktForBeredskap: false,
+      harUløstAksjonspunktForNattevåk: false,
+      harLøstAksjonspunktForBeredskap: true,
+      harLøstAksjonspunktForNattevåk: false,
+    },
+  },
+  parameters: {
+    msw: {
+      handlers,
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('skal starte på tilsyn-fanen (ikke beredskap) når aksjonspunkt er løst', async () => {
+      await waitFor(async () => {
+        await expect(canvas.getByRole('tab', { name: 'Tilsyn' })).toHaveAttribute('aria-selected', 'true');
+      });
+    });
+
+    await step('skal vise rediger-knapp for ferdig vurderte perioder', async () => {
+      await userEvent.click(canvas.getByRole('tab', { name: 'Beredskap' }));
+      await waitFor(async () => {
+        await expect(canvas.getByText('Vurdering av beredskap')).toBeInTheDocument();
+      });
+      await expect(canvas.getByRole('button', { name: 'Rediger vurdering' })).toBeInTheDocument();
+    });
+
+    await step('skal ikke vise fortsett-knapp når aksjonspunkt er løst', async () => {
+      await expect(canvas.queryByRole('button', { name: 'Fortsett' })).not.toBeInTheDocument();
+    });
+  },
+};
+
+export const LøstAksjonspunktNattevåk: Story = {
+  args: {
+    data: {
+      readOnly: false,
+      endpoints: {
+        tilsyn: `${mockUrlPrepend}/mock/tilsyn-ferdig-vurdert`,
+        sykdom: `${mockUrlPrepend}/mock/sykdom`,
+        sykdomInnleggelse: `${mockUrlPrepend}/mock/sykdomInnleggelse`,
+      },
+      errorNotifier: () => {},
+      lagreBeredskapvurdering: fn(),
+      lagreNattevåkvurdering: fn(),
+      harUløstAksjonspunktForBeredskap: false,
+      harUløstAksjonspunktForNattevåk: false,
+      harLøstAksjonspunktForBeredskap: false,
+      harLøstAksjonspunktForNattevåk: true,
+    },
+  },
+  parameters: {
+    msw: {
+      handlers,
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('skal starte på tilsyn-fanen (ikke nattevåk) når aksjonspunkt er løst', async () => {
+      await waitFor(async () => {
+        await expect(canvas.getByRole('tab', { name: 'Tilsyn' })).toHaveAttribute('aria-selected', 'true');
+      });
+    });
+
+    await step('skal ikke vise varselikon på nattevåk-fane når aksjonspunkt er løst', async () => {
+      const nattevåkTab = canvas.getByRole('tab', { name: 'Nattevåk' });
+      await expect(nattevåkTab.querySelector('svg')).not.toBeInTheDocument();
+    });
+  },
+};
+
+export const VarseltrekantVedUløstAksjonspunkt: Story = {
+  args: {
+    data: {
+      readOnly: false,
+      endpoints: {
+        tilsyn: `${mockUrlPrepend}/mock/tilsyn`,
+        sykdom: `${mockUrlPrepend}/mock/sykdom`,
+        sykdomInnleggelse: `${mockUrlPrepend}/mock/sykdomInnleggelse`,
+      },
+      errorNotifier: () => {},
+      lagreBeredskapvurdering: fn(),
+      lagreNattevåkvurdering: fn(),
+      harUløstAksjonspunktForBeredskap: true,
+      harUløstAksjonspunktForNattevåk: true,
+      harLøstAksjonspunktForBeredskap: false,
+      harLøstAksjonspunktForNattevåk: false,
+    },
+  },
+  parameters: {
+    msw: {
+      handlers,
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('skal vise varselikon på beredskap-fane ved uløst aksjonspunkt', async () => {
+      await waitFor(async () => {
+        const beredskapTab = canvas.getByRole('tab', { name: 'Beredskap' });
+        await expect(beredskapTab.querySelector('svg')).toBeInTheDocument();
+      });
+    });
+
+    await step('skal vise varselikon på nattevåk-fane ved uløst aksjonspunkt', async () => {
+      const nattevåkTab = canvas.getByRole('tab', { name: 'Nattevåk' });
+      await expect(nattevåkTab.querySelector('svg')).toBeInTheDocument();
+    });
+
+    await step('skal auto-velge beredskap-fane som default ved uløst aksjonspunkt', async () => {
+      await expect(canvas.getByRole('tab', { name: 'Beredskap' })).toHaveAttribute('aria-selected', 'true');
+    });
+  },
+};
+
+export const IngenRedigeringUtenAksjonspunkt: Story = {
+  args: {
+    data: {
+      readOnly: false,
+      endpoints: {
+        tilsyn: `${mockUrlPrepend}/mock/tilsyn-ferdig-vurdert`,
+        sykdom: `${mockUrlPrepend}/mock/sykdom`,
+        sykdomInnleggelse: `${mockUrlPrepend}/mock/sykdomInnleggelse`,
+      },
+      errorNotifier: () => {},
+      lagreBeredskapvurdering: fn(),
+      lagreNattevåkvurdering: fn(),
+      harUløstAksjonspunktForBeredskap: false,
+      harUløstAksjonspunktForNattevåk: false,
+      harLøstAksjonspunktForBeredskap: false,
+      harLøstAksjonspunktForNattevåk: false,
+    },
+  },
+  parameters: {
+    msw: {
+      handlers,
+    },
+  },
+  play: async ({ canvasElement, step }) => {
+    const canvas = within(canvasElement);
+
+    await step('skal ikke vise rediger-knapp for beredskap uten aksjonspunkt', async () => {
+      await userEvent.click(canvas.getByRole('tab', { name: 'Beredskap' }));
+      await waitFor(async () => {
+        await expect(canvas.getByText('Vurdering av beredskap')).toBeInTheDocument();
+      });
+      await expect(canvas.queryByRole('button', { name: 'Rediger vurdering' })).not.toBeInTheDocument();
+    });
+
+    await step('skal ikke vise fortsett-knapp for beredskap uten aksjonspunkt', async () => {
+      await expect(canvas.queryByRole('button', { name: 'Fortsett' })).not.toBeInTheDocument();
     });
   },
 };

--- a/packages/fakta-etablert-tilsyn/src/ui/EtablertTilsynContainer.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/EtablertTilsynContainer.tsx
@@ -43,11 +43,14 @@ const TabItem = ({ label, showWarningIcon }: TabItemProps) => {
   );
 };
 
-const getDefaultActiveTab = ({ harAksjonspunktForBeredskap, harAksjonspunktForNattevåk }: ContainerContract) => {
-  if (harAksjonspunktForBeredskap) {
+const getDefaultActiveTab = ({
+  harUløstAksjonspunktForBeredskap,
+  harUløstAksjonspunktForNattevåk,
+}: ContainerContract) => {
+  if (harUløstAksjonspunktForBeredskap) {
     return tabs[1];
   }
-  if (harAksjonspunktForNattevåk) {
+  if (harUløstAksjonspunktForNattevåk) {
     return tabs[2];
   }
   return tabs[0];
@@ -87,7 +90,7 @@ const transformSykdomResponse = (response: SykdomResponse) => {
 };
 
 const EtablertTilsynContainer = ({ data }: MainComponentProps) => {
-  const { endpoints, errorNotifier, harAksjonspunktForBeredskap, harAksjonspunktForNattevåk } = data;
+  const { endpoints, errorNotifier, harUløstAksjonspunktForBeredskap, harUløstAksjonspunktForNattevåk } = data;
 
   const getTilsyn = (signal: AbortSignal) =>
     get<TilsynResponse>(endpoints.tilsyn, errorNotifier, {
@@ -186,7 +189,8 @@ const EtablertTilsynContainer = ({ data }: MainComponentProps) => {
                   <TabItem
                     label={tabName}
                     showWarningIcon={
-                      (index === 1 && harAksjonspunktForBeredskap) || (index === 2 && harAksjonspunktForNattevåk)
+                      (index === 1 && harUløstAksjonspunktForBeredskap) ||
+                      (index === 2 && harUløstAksjonspunktForNattevåk)
                     }
                   />
                 }

--- a/packages/fakta-etablert-tilsyn/src/ui/components/beredskap/beredskapsperiode-vurderingsdetaljer/BeredskapsperiodeVurderingsdetaljer.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/beredskap/beredskapsperiode-vurderingsdetaljer/BeredskapsperiodeVurderingsdetaljer.tsx
@@ -22,7 +22,11 @@ const BeredskapsperiodeVurderingsdetaljer = ({
   onEditClick,
   beskrivelser,
 }: BeredskapsperiodeVurderingsdetaljerProps): JSX.Element => {
-  const { readOnly = false, harLøstAksjonspunktForBeredskap = false } = useContext(ContainerContext) || {};
+  const {
+    readOnly = false,
+    harUløstAksjonspunktForBeredskap = false,
+    harLøstAksjonspunktForBeredskap = false,
+  } = useContext(ContainerContext) || {};
   const { opprettetAv, opprettetTidspunkt } = beredskapsperiode;
   return (
     <DetailView
@@ -34,7 +38,7 @@ const BeredskapsperiodeVurderingsdetaljer = ({
               Rediger vurdering
             </Button>
           )}
-          readOnly={readOnly || !harLøstAksjonspunktForBeredskap}
+          readOnly={readOnly || (!harUløstAksjonspunktForBeredskap && !harLøstAksjonspunktForBeredskap)}
         />
       )}
     >

--- a/packages/fakta-etablert-tilsyn/src/ui/components/beredskap/beredskapsperiode-vurderingsdetaljer/BeredskapsperiodeVurderingsdetaljer.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/beredskap/beredskapsperiode-vurderingsdetaljer/BeredskapsperiodeVurderingsdetaljer.tsx
@@ -22,7 +22,7 @@ const BeredskapsperiodeVurderingsdetaljer = ({
   onEditClick,
   beskrivelser,
 }: BeredskapsperiodeVurderingsdetaljerProps): JSX.Element => {
-  const { readOnly = false, harAksjonspunktForBeredskap = false } = useContext(ContainerContext) || {};
+  const { readOnly = false, harLøstAksjonspunktForBeredskap = false } = useContext(ContainerContext) || {};
   const { opprettetAv, opprettetTidspunkt } = beredskapsperiode;
   return (
     <DetailView
@@ -34,7 +34,7 @@ const BeredskapsperiodeVurderingsdetaljer = ({
               Rediger vurdering
             </Button>
           )}
-          readOnly={readOnly || !harAksjonspunktForBeredskap}
+          readOnly={readOnly || !harLøstAksjonspunktForBeredskap}
         />
       )}
     >

--- a/packages/fakta-etablert-tilsyn/src/ui/components/beredskap/beredskapsperioderoversikt/Beredskapsperiodeoversikt.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/beredskap/beredskapsperioderoversikt/Beredskapsperiodeoversikt.tsx
@@ -20,7 +20,7 @@ const Beredskapsperiodeoversikt = ({ beredskapData }: BeredskapsperiodeoversiktP
   const {
     lagreBeredskapvurdering = () => {},
     readOnly = false,
-    harAksjonspunktForBeredskap = false,
+    harUløstAksjonspunktForBeredskap = false,
   } = React.useContext(ContainerContext) || {};
 
   const perioderTilVurdering = beredskapData.finnPerioderTilVurdering();
@@ -41,7 +41,7 @@ const Beredskapsperiodeoversikt = ({ beredskapData }: BeredskapsperiodeoversiktP
     <VStack gap="space-24">
       <BeredskapsperiodeoversiktMessages
         beredskapData={beredskapData}
-        skalViseFortsettUtenEndring={!readOnly && harAksjonspunktForBeredskap}
+        skalViseFortsettUtenEndring={!readOnly && harUløstAksjonspunktForBeredskap}
         fortsettUtenEndring={() => lagreBeredskapvurdering(beredskapData.vurderinger)}
       />
       <NavigationWithDetailView

--- a/packages/fakta-etablert-tilsyn/src/ui/components/beredskap/vurdering-av-beredskapsperioder-form/VurderingAvBeredskapsperioderForm.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/beredskap/vurdering-av-beredskapsperioder-form/VurderingAvBeredskapsperioderForm.tsx
@@ -57,9 +57,10 @@ const VurderingAvBeredskapsperioderForm = ({
   const {
     lagreBeredskapvurdering,
     readOnly,
-    harAksjonspunktForBeredskap = false,
+    harUløstAksjonspunktForBeredskap = false,
+    harLøstAksjonspunktForBeredskap = false,
   } = React.useContext(ContainerContext) || {};
-  const disabled = readOnly || !harAksjonspunktForBeredskap;
+  const disabled = readOnly || (!harUløstAksjonspunktForBeredskap && !harLøstAksjonspunktForBeredskap);
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const defaultBehovForBeredeskap = () => {
     if (beredskapsperiode.resultat === Vurderingsresultat.OPPFYLT) {

--- a/packages/fakta-etablert-tilsyn/src/ui/components/nattevåk/nattevåksperiode-vurderingsdetaljer/NattevåksperiodeVurderingsdetaljer.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/nattevåk/nattevåksperiode-vurderingsdetaljer/NattevåksperiodeVurderingsdetaljer.tsx
@@ -22,7 +22,11 @@ const NattevåksperiodeVurderingsdetaljer = ({
   onEditClick,
   beskrivelser,
 }: NattevåksperiodeVurderingsdetaljerProps) => {
-  const { readOnly = false, harLøstAksjonspunktForNattevåk = false } = useContext(ContainerContext) || {};
+  const {
+    readOnly = false,
+    harUløstAksjonspunktForNattevåk = false,
+    harLøstAksjonspunktForNattevåk = false,
+  } = useContext(ContainerContext) || {};
   const { opprettetAv, opprettetTidspunkt } = nattevåksperiode;
   return (
     <DetailView
@@ -34,7 +38,7 @@ const NattevåksperiodeVurderingsdetaljer = ({
               Rediger vurdering
             </Button>
           )}
-          readOnly={readOnly || !harLøstAksjonspunktForNattevåk}
+          readOnly={readOnly || (!harUløstAksjonspunktForNattevåk && !harLøstAksjonspunktForNattevåk)}
         />
       )}
     >

--- a/packages/fakta-etablert-tilsyn/src/ui/components/nattevåk/nattevåksperiode-vurderingsdetaljer/NattevåksperiodeVurderingsdetaljer.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/nattevåk/nattevåksperiode-vurderingsdetaljer/NattevåksperiodeVurderingsdetaljer.tsx
@@ -22,7 +22,7 @@ const NattevåksperiodeVurderingsdetaljer = ({
   onEditClick,
   beskrivelser,
 }: NattevåksperiodeVurderingsdetaljerProps) => {
-  const { readOnly = false, harAksjonspunktForNattevåk = false } = useContext(ContainerContext) || {};
+  const { readOnly = false, harLøstAksjonspunktForNattevåk = false } = useContext(ContainerContext) || {};
   const { opprettetAv, opprettetTidspunkt } = nattevåksperiode;
   return (
     <DetailView
@@ -34,7 +34,7 @@ const NattevåksperiodeVurderingsdetaljer = ({
               Rediger vurdering
             </Button>
           )}
-          readOnly={readOnly || !harAksjonspunktForNattevåk}
+          readOnly={readOnly || !harLøstAksjonspunktForNattevåk}
         />
       )}
     >

--- a/packages/fakta-etablert-tilsyn/src/ui/components/nattevåk/nattevåksperiodeoversikt/Nattevåksperiodeoversikt.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/nattevåk/nattevåksperiodeoversikt/Nattevåksperiodeoversikt.tsx
@@ -19,7 +19,7 @@ const Nattevåksperiodeoversikt = ({ nattevåkData }: NattevåksperiodeoversiktP
   const {
     lagreNattevåkvurdering = () => {},
     readOnly = false,
-    harAksjonspunktForNattevåk = false,
+    harUløstAksjonspunktForNattevåk = false,
   } = React.useContext(ContainerContext) || {};
 
   const perioderTilVurdering = nattevåkData.finnPerioderTilVurdering();
@@ -40,7 +40,7 @@ const Nattevåksperiodeoversikt = ({ nattevåkData }: NattevåksperiodeoversiktP
     <>
       <NattevåksperiodeoversiktMessages
         nattevåkData={nattevåkData}
-        skalViseFortsettUtenEndring={!readOnly && harAksjonspunktForNattevåk}
+        skalViseFortsettUtenEndring={!readOnly && harUløstAksjonspunktForNattevåk}
         fortsettUtenEndring={() => lagreNattevåkvurdering(nattevåkData.vurderinger)}
       />
       <NavigationWithDetailView

--- a/packages/fakta-etablert-tilsyn/src/ui/components/nattevåk/vurdering-av-nattevåksperioder-form/VurderingAvNattevåksperioderForm.tsx
+++ b/packages/fakta-etablert-tilsyn/src/ui/components/nattevåk/vurdering-av-nattevåksperioder-form/VurderingAvNattevåksperioderForm.tsx
@@ -56,9 +56,10 @@ const VurderingAvNattevåksperioderForm = ({
   const {
     lagreNattevåkvurdering,
     readOnly,
-    harAksjonspunktForNattevåk = false,
+    harUløstAksjonspunktForNattevåk = false,
+    harLøstAksjonspunktForNattevåk = false,
   } = React.useContext(ContainerContext) || {};
-  const disabled = readOnly || !harAksjonspunktForNattevåk;
+  const disabled = readOnly || (!harUløstAksjonspunktForNattevåk && !harLøstAksjonspunktForNattevåk);
   const [isSubmitting, setIsSubmitting] = React.useState(false);
   const defaultBehovForNattevåk = () => {
     if (nattevåksperiode.resultat === Vurderingsresultat.OPPFYLT) {


### PR DESCRIPTION
### Behov / Bakgrunn
Det går ikke an å redigere nattevåk og beredskap når aksjonspunktet er UTFO

### Løsning
Introduserer nytt flagg så vi kan sjekke om aksjonspunktet er utført og skal kunne redigeres

### Andre endringer
Stories med testcase for å dekke forskjellige scenarioer
