### PR TITLE
fix: prøver å mappe sourcemaps fra node_modules

### DIFF
--- a/ung.vite.config.js
+++ b/ung.vite.config.js
@@ -35,13 +35,14 @@ function nodeSourcemapsPlugin({ exclude } = {}) {
   return {
     name: 'node-sourcemaps',
     async transform(code, id) {
-      if (!id.includes('node_modules')) return null;
-      if (exclude?.test(id)) return null;
-      if (!/\.[cm]?[jt]sx?$/.test(id)) return null;
+      const cleanId = id.replace(/^\0/, '').split('?')[0].split('#')[0];
+      if (!/(^|[\\/])node_modules([\\/]|$)/.test(cleanId)) return null;
+      if (exclude?.test(cleanId)) return null;
+      if (!/\.[cm]?[jt]sx?$/.test(cleanId)) return null;
       const match = code.match(/\/\/[#@] sourceMappingURL=(\S+)/m);
       if (!match || match[1].startsWith('data:')) return null;
       try {
-        const mapPath = path.resolve(path.dirname(id), match[1]);
+        const mapPath = path.resolve(path.dirname(cleanId), match[1]);
         const map = JSON.parse(await fs.readFile(mapPath, 'utf-8'));
         return { code, map };
       } catch {

--- a/ung.vite.config.js
+++ b/ung.vite.config.js
@@ -31,6 +31,26 @@ const createProxy = (target, pathRewrite) => ({
   },
 });
 
+function nodeSourcemapsPlugin({ exclude } = {}) {
+  return {
+    name: 'node-sourcemaps',
+    async transform(code, id) {
+      if (!id.includes('node_modules')) return null;
+      if (exclude?.test(id)) return null;
+      if (!/\.[cm]?[jt]sx?$/.test(id)) return null;
+      const match = code.match(/\/\/[#@] sourceMappingURL=(\S+)/m);
+      if (!match || match[1].startsWith('data:')) return null;
+      try {
+        const mapPath = path.resolve(path.dirname(id), match[1]);
+        const map = JSON.parse(await fs.readFile(mapPath, 'utf-8'));
+        return { code, map };
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
 function excludeMsw() {
   return {
     name: "exclude-msw",
@@ -120,6 +140,7 @@ export default ({ mode }) => {
         external: [
           "mockServiceWorker.js"
         ],
+        plugins: [nodeSourcemapsPlugin({ exclude: /@sentry/ })],
       },
     },
   });

--- a/vite.config.js
+++ b/vite.config.js
@@ -30,6 +30,26 @@ const createProxy = (target, pathRewrite) => ({
   },
 });
 
+function nodeSourcemapsPlugin({ exclude } = {}) {
+  return {
+    name: 'node-sourcemaps',
+    async transform(code, id) {
+      if (!id.includes('node_modules')) return null;
+      if (exclude?.test(id)) return null;
+      if (!/\.[cm]?[jt]sx?$/.test(id)) return null;
+      const match = code.match(/\/\/[#@] sourceMappingURL=(\S+)/m);
+      if (!match || match[1].startsWith('data:')) return null;
+      try {
+        const mapPath = path.resolve(path.dirname(id), match[1]);
+        const map = JSON.parse(await fs.promises.readFile(mapPath, 'utf-8'));
+        return { code, map };
+      } catch {
+        return null;
+      }
+    },
+  };
+}
+
 function excludeMsw() {
   return {
     name: 'exclude-msw',
@@ -104,6 +124,7 @@ export default ({ mode }) => {
         release: {
           name: process.env.VITE_SENTRY_RELEASE,
         },
+        debug: true,
       }),
     ],
     build: {
@@ -114,6 +135,7 @@ export default ({ mode }) => {
         external: [
           "mockServiceWorker.js"
         ],
+        plugins: [nodeSourcemapsPlugin({ exclude: /@sentry/ })],
         output: {
           manualChunks(id) {
             if (id.includes('@navikt/diagnosekoder')) {

--- a/vite.config.js
+++ b/vite.config.js
@@ -34,13 +34,14 @@ function nodeSourcemapsPlugin({ exclude } = {}) {
   return {
     name: 'node-sourcemaps',
     async transform(code, id) {
-      if (!id.includes('node_modules')) return null;
-      if (exclude?.test(id)) return null;
-      if (!/\.[cm]?[jt]sx?$/.test(id)) return null;
+      const cleanId = id.replace(/^\0/, '').split('?')[0].split('#')[0];
+      if (!/(^|[\\/])node_modules([\\/]|$)/.test(cleanId)) return null;
+      if (exclude?.test(cleanId)) return null;
+      if (!/\.[cm]?[jt]sx?$/.test(cleanId)) return null;
       const match = code.match(/\/\/[#@] sourceMappingURL=(\S+)/m);
       if (!match || match[1].startsWith('data:')) return null;
       try {
-        const mapPath = path.resolve(path.dirname(id), match[1]);
+        const mapPath = path.resolve(path.dirname(cleanId), match[1]);
         const map = JSON.parse(await fs.promises.readFile(mapPath, 'utf-8'));
         return { code, map };
       } catch {


### PR DESCRIPTION
### Behov / Bakgrunn
Vi får ikke debugget filer fra tredjepartspakker i nettleseren, feks ft-pakkene. Tror det er skyldes endringer i hvordan sourcemaps produseres.

### Løsning
Legger inn vite-plugin som mapper sourcemaps i node_modules.

### Andre endringer
Debugger hvilke filer sentryVitePlugin sletter ved deploy.
