### PR TITLE
Ignorer 404 feil i useQuery kall som tidlegare ignorerte alle feil

### DIFF
--- a/packages/behandling-aktivitetspenger/package.json
+++ b/packages/behandling-aktivitetspenger/package.json
@@ -8,6 +8,7 @@
     "@fpsak-frontend/kodeverk": "1.0.0",
     "@fpsak-frontend/shared-components": "1.0.0",
     "@k9-sak-web/behandling-felles": "1.0.0",
+    "@k9-sak-web/gui": "workspace:^",
     "@k9-sak-web/konstanter": "1.0.0",
     "@k9-sak-web/rest-api": "1.0.0",
     "@k9-sak-web/rest-api-hooks": "1.0.0",

--- a/packages/behandling-aktivitetspenger/src/components/prosess/BeregnetUtbetalingStegInitPanel.tsx
+++ b/packages/behandling-aktivitetspenger/src/components/prosess/BeregnetUtbetalingStegInitPanel.tsx
@@ -15,6 +15,7 @@ import {
 } from '@k9-sak-web/gui/prosess/aktivitetspenger-prosess/aktivitetspengerQueryOptions.js';
 import { DagsatsOgUtbetaling, sortSatser } from '@k9-sak-web/gui/shared/dagsats-og-utbetaling/DagsatsOgUtbetaling.js';
 import { ArbeidOgInntekt } from '@k9-sak-web/gui/shared/kontroll-inntekt/ArbeidOgInntekt.js';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 import { prosessStegCodes } from '@k9-sak-web/konstanter';
 import { ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';
 import { Alert, Box, Heading, Loader, Tabs, VStack } from '@navikt/ds-react';
@@ -71,6 +72,7 @@ export const BeregnetUtbetalingStegInitPanel = ({ api, behandling, onAksjonspunk
 
   const { data: arbeidsgivere } = useQuery({
     queryKey: ['aktivitetspenger-arbeidsgivere', behandling.uuid],
+    throwOnError: ignore404Errors,
     queryFn: () => aktivitetspengerBeregningApi.getArbeidsgiverOpplysninger(behandling.uuid),
   });
 

--- a/packages/fakta-medisinsk-vilkår/package.json
+++ b/packages/fakta-medisinsk-vilkår/package.json
@@ -8,6 +8,7 @@
   "private": true,
   "dependencies": {
     "@fpsak-frontend/form": "1.0.0",
+    "@k9-sak-web/gui": "workspace:^",
     "@navikt/aksel-icons": "8.13.1",
     "@navikt/diagnosekoder": "1.2026.0",
     "@navikt/ds-css": "8.13.1",

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/diagnosekodeoversikt/Diagnosekodeoversikt.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/diagnosekodeoversikt/Diagnosekodeoversikt.tsx
@@ -5,6 +5,7 @@ import { initDiagnosekodeSearcher } from '@k9-sak-web/gui/shared/diagnosekodeVel
 import WriteAccessBoundContent from '@k9-sak-web/gui/shared/write-access-bound-content/WriteAccessBoundContent.js';
 import { Alert, Box, Heading, HStack, Loader } from '@navikt/ds-react';
 import { useMutation, useQueries, useQuery } from '@tanstack/react-query';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 import React, { type JSX } from 'react';
 import LinkRel from '../../../constants/LinkRel';
 import Diagnosekode from '../../../types/Diagnosekode';
@@ -46,6 +47,7 @@ const Diagnosekodeoversikt = ({ onDiagnosekoderUpdated }: DiagnosekodeoversiktPr
 
   const { isLoading, data, refetch } = useQuery({
     queryKey: ['diagnosekodeResponse'],
+    throwOnError: ignore404Errors,
     queryFn: hentDiagnosekoder,
     placeholderData: { diagnosekoder: [], links: [], behandlingUuid: '', versjon: null },
     staleTime: 10000,

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/medisinsk-vilkår/MedisinskVilkår.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/medisinsk-vilkår/MedisinskVilkår.tsx
@@ -3,6 +3,7 @@ import { fagsakYtelsesType, FagsakYtelsesType } from '@k9-sak-web/backend/k9sak/
 import { ChildEyesFillIcon, ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';
 import { Alert, Box, Tabs, VStack } from '@navikt/ds-react';
 import { useQuery } from '@tanstack/react-query';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 import classnames from 'classnames';
 import React, { useMemo, type JSX } from 'react';
 
@@ -114,6 +115,7 @@ const MedisinskVilkår = (): JSX.Element => {
 
   const { isLoading: diagnosekoderLoading, data: diagnosekoderData } = useQuery({
     queryKey: ['diagnosekodeResponse'],
+    throwOnError: ignore404Errors,
     queryFn: hentDiagnosekoder,
     enabled: !erFagsakOLPEllerPLS(fagsakYtelseType),
     placeholderData: { diagnosekoder: [], links: [], behandlingUuid: '', versjon: '' },

--- a/packages/prosess-tilkjent-ytelse/package.json
+++ b/packages/prosess-tilkjent-ytelse/package.json
@@ -10,6 +10,7 @@
     "@fpsak-frontend/shared-components": "1.0.0",
     "@fpsak-frontend/tidslinje": "1.0.0",
     "@fpsak-frontend/utils": "1.0.0",
+    "@k9-sak-web/gui": "workspace:^",
     "@k9-sak-web/types": "1.0.0",
     "moment": "2.30.1",
     "react": "19.2.7",

--- a/packages/prosess-tilkjent-ytelse/src/TilkjentYtelseProsessIndex.tsx
+++ b/packages/prosess-tilkjent-ytelse/src/TilkjentYtelseProsessIndex.tsx
@@ -3,14 +3,15 @@ import {
   k9_sak_kontrakt_arbeidsforhold_ArbeidsgiverOversiktDto,
   k9_sak_kontrakt_beregningsresultat_BeregningsresultatMedUtbetaltePeriodeDto as BeregningsresultatMedUtbetaltePeriodeDto,
 } from '@k9-sak-web/backend/k9sak/generated/types.js';
-import {fagsakYtelsesType} from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
-import {Fagsak} from '@k9-sak-web/types';
-import {useQuery} from '@tanstack/react-query';
-import {createIntl, createIntlCache, RawIntlProvider} from 'react-intl';
-import {useContext} from 'react';
+import { fagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
+import { Fagsak } from '@k9-sak-web/types';
+import { useQuery } from '@tanstack/react-query';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
+import { createIntl, createIntlCache, RawIntlProvider } from 'react-intl';
+import { useContext } from 'react';
 import TilkjentYtelsePanel from './components/TilkjentYtelsePanel';
-import {type FeriepengerPrÅr, hentFeriepengegrunnlagPrÅr} from './api/tilkjentYtelseApi.js';
-import {TilkjentYtelseV1ApiContext} from './api/TilkjentYtelseApiContext.js';
+import { type FeriepengerPrÅr, hentFeriepengegrunnlagPrÅr } from './api/tilkjentYtelseApi.js';
+import { TilkjentYtelseV1ApiContext } from './api/TilkjentYtelseApiContext.js';
 
 const EMPTY_FERIEPENGER_MAP: FeriepengerPrÅr = new Map();
 
@@ -47,6 +48,7 @@ const TilkjentYtelseProsessIndex = ({
 
   const { data: feriepengerPrÅr = EMPTY_FERIEPENGER_MAP } = useQuery({
     queryKey: ['feriepengegrunnlag', behandlingUuid],
+    throwOnError: ignore404Errors,
     queryFn: () => fetchFn(behandlingUuid!),
     enabled: !!behandlingUuid,
   });

--- a/packages/sak-app/src/fagsak/FagsakIndex.tsx
+++ b/packages/sak-app/src/fagsak/FagsakIndex.tsx
@@ -44,6 +44,7 @@ import { FagsakProfileIndex } from '../fagsakprofile/FagsakProfileIndex';
 import FagsakGrid from './components/FagsakGrid';
 import useHentAlleBehandlinger from './useHentAlleBehandlinger';
 import useHentFagsakRettigheter from './useHentFagsakRettigheter';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 
 const erTilbakekreving = (behandlingType: Kodeverk): boolean =>
   behandlingType &&
@@ -191,7 +192,7 @@ const FagsakIndex = () => {
       const data = await k9StatusBackendClient.getMerknader(behandling?.uuid);
       return data ?? null;
     },
-    throwOnError: false,
+    throwOnError: ignore404Errors, // Denne feiler med 404 for klage/tilbake behandlinger
     enabled: !!behandling?.uuid,
   });
 

--- a/packages/ung/sak-app/behandlingmenu/BehandlingMenuIndex.spec.tsx
+++ b/packages/ung/sak-app/behandlingmenu/BehandlingMenuIndex.spec.tsx
@@ -9,6 +9,8 @@ import { fagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtel
 import { BehandlingAppKontekst, Fagsak } from '@k9-sak-web/types';
 
 import { VergeBehandlingmenyValg } from '@k9-sak-web/sak-app/src/behandling/behandlingRettigheterTsType';
+import { MenyEndreFristApiContext } from '@k9-sak-web/gui/sak/meny/endre-frist/MenyEndreFristApiContext.js';
+import { FakeMenyEndreFristApi } from '@k9-sak-web/gui/storybook/mocks/FakeMenyEndreFristApi.js';
 import { QueryClientProvider } from '@tanstack/react-query';
 import { UngSakApiKeys, requestApi } from '../data/ungsakApi';
 import { BehandlingMenuIndex } from './BehandlingMenuIndex';
@@ -57,6 +59,8 @@ const alleBehandlinger = [
   },
 ];
 
+const menyEndreFristApi = new FakeMenyEndreFristApi();
+
 vi.mock('react-router', async () => {
   const actual = (await vi.importActual('react-router')) as Record<string, unknown>;
   return {
@@ -75,7 +79,6 @@ vi.mock('react-router', async () => {
 
 const queryClient = createQueryClient({
   queries: {
-    throwOnError: false,
     retry: false,
   },
 });
@@ -118,22 +121,24 @@ describe('BehandlingMenuIndex', () => {
     render(
       <MemoryRouter>
         <QueryClientProvider client={queryClient}>
-          <BehandlingMenuIndex
-            fagsak={fagsak as Fagsak}
-            // @ts-expect-error: Skal endres til behandlingPåVent når det er gjort i ung-sak
-            alleBehandlinger={alleBehandlinger as BehandlingAppKontekst[]}
-            behandlingId={1}
-            behandlingVersjon={2}
-            oppfriskBehandlinger={vi.fn()}
-            behandlingRettigheter={behandlingRettigheter}
-            sakRettigheter={sakRettigheter}
-            behandlendeEnheter={[
-              {
-                enhetId: 'TEST',
-                enhetNavn: 'TEST',
-              },
-            ]}
-          />
+          <MenyEndreFristApiContext value={menyEndreFristApi}>
+            <BehandlingMenuIndex
+              fagsak={fagsak as Fagsak}
+              // @ts-expect-error: Skal endres til behandlingPåVent når det er gjort i ung-sak
+              alleBehandlinger={alleBehandlinger as BehandlingAppKontekst[]}
+              behandlingId={1}
+              behandlingVersjon={2}
+              oppfriskBehandlinger={vi.fn()}
+              behandlingRettigheter={behandlingRettigheter}
+              sakRettigheter={sakRettigheter}
+              behandlendeEnheter={[
+                {
+                  enhetId: 'TEST',
+                  enhetNavn: 'TEST',
+                },
+              ]}
+            />
+          </MenyEndreFristApiContext>
         </QueryClientProvider>
       </MemoryRouter>,
     );

--- a/packages/ung/sak-app/behandlingmenu/BehandlingMenuIndex.tsx
+++ b/packages/ung/sak-app/behandlingmenu/BehandlingMenuIndex.tsx
@@ -7,7 +7,7 @@ import FeatureTogglesContext from '@k9-sak-web/gui/featuretoggles/FeatureToggles
 import MenyData from '@k9-sak-web/gui/sak/meny/MenyData.js';
 import { MenySakIndex as MenySakIndexV2 } from '@k9-sak-web/gui/sak/meny/MenySakIndex.js';
 import MenyEndreBehandlendeEnhetIndexV2 from '@k9-sak-web/gui/sak/meny/endre-enhet/MenyEndreBehandlendeEnhetIndex.js';
-import MenyEndreFristBackendClient from '@k9-sak-web/gui/sak/meny/endre-frist/MenyEndreFristBackendClient.js';
+import { MenyEndreFristApiContext } from '@k9-sak-web/gui/sak/meny/endre-frist/MenyEndreFristApiContext.js';
 import { MenyEndreFristIndex } from '@k9-sak-web/gui/sak/meny/endre-frist/MenyEndreFristIndex.js';
 import MenyHenleggIndexV2 from '@k9-sak-web/gui/sak/meny/henlegg-behandling/MenyHenleggIndex.js';
 import MenyMarkerBehandlingV2 from '@k9-sak-web/gui/sak/meny/marker-behandling/MenyMarkerBehandling.js';
@@ -31,7 +31,7 @@ import { ChevronDownIcon } from '@navikt/aksel-icons';
 import { Button } from '@navikt/ds-react';
 import { useQuery } from '@tanstack/react-query';
 import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
-import { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
+import { use, useCallback, useContext, useEffect, useMemo, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { getLocationWithDefaultProsessStegAndFakta, pathToBehandling } from '../app/paths';
 import useGetEnabledApplikasjonContext from '../app/useGetEnabledApplikasjonContext';
@@ -164,7 +164,7 @@ export const BehandlingMenuIndex = ({
   const { startRequest: hentMottakere } = restApiHooks.useRestApiRunner<KlagePart[]>(
     UngSakApiKeys.PARTER_MED_KLAGERETT,
   );
-  const menyEndreFristClient = useMemo(() => new MenyEndreFristBackendClient(), []);
+  const menyEndreFristClient = use(MenyEndreFristApiContext);
   const { data: etterlysninger = [] } = useQuery({
     queryKey: ['etterlysninger', behandling?.uuid],
     throwOnError: ignore404Errors,
@@ -331,7 +331,6 @@ export const BehandlingMenuIndex = ({
                 behandlingId={behandling.id}
                 behandlingUuid={behandling?.uuid}
                 behandlingVersjon={behandling.versjon}
-                api={menyEndreFristClient}
               />
             );
           }

--- a/packages/ung/sak-app/behandlingmenu/BehandlingMenuIndex.tsx
+++ b/packages/ung/sak-app/behandlingmenu/BehandlingMenuIndex.tsx
@@ -30,6 +30,7 @@ import {
 import { ChevronDownIcon } from '@navikt/aksel-icons';
 import { Button } from '@navikt/ds-react';
 import { useQuery } from '@tanstack/react-query';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 import { useCallback, useContext, useEffect, useMemo, useRef } from 'react';
 import { useLocation, useNavigate } from 'react-router';
 import { getLocationWithDefaultProsessStegAndFakta, pathToBehandling } from '../app/paths';
@@ -166,6 +167,7 @@ export const BehandlingMenuIndex = ({
   const menyEndreFristClient = useMemo(() => new MenyEndreFristBackendClient(), []);
   const { data: etterlysninger = [] } = useQuery({
     queryKey: ['etterlysninger', behandling?.uuid],
+    throwOnError: ignore404Errors,
     queryFn: () => menyEndreFristClient.hentEtterlysninger(behandling?.uuid ?? ''),
     enabled: !!behandling?.uuid,
     select: etterlysninger =>

--- a/packages/ung/sak-app/fagsak/FagsakIndex.tsx
+++ b/packages/ung/sak-app/fagsak/FagsakIndex.tsx
@@ -22,6 +22,7 @@ import {
   Personopplysninger,
 } from '@k9-sak-web/types';
 import { useQuery } from '@tanstack/react-query';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 import { useCallback, useContext, useMemo, useState } from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router';
 import { behandlingerRoutePath, erBehandlingValgt, erUrlUnderBehandling, pathToMissingPage } from '../app/paths';
@@ -158,6 +159,7 @@ const FagsakIndex = () => {
 
   const { data: saksbehandlereSomHarGjortEndringerIBehandlingen } = useQuery({
     queryKey: ['saksbehandlere', api.backend, behandling?.uuid, behandling?.versjon],
+    throwOnError: ignore404Errors,
     queryFn: () => api.hentSaksbehandlere(behandling?.uuid ?? ''),
     enabled: !!behandling?.uuid && !skalIkkeHenteData,
   });

--- a/packages/v2/gui/src/app/errorhandling/ignore404Errors.test.ts
+++ b/packages/v2/gui/src/app/errorhandling/ignore404Errors.test.ts
@@ -1,0 +1,32 @@
+import { AxiosError, AxiosHeaders } from 'axios';
+import { describe, expect, it } from 'vitest';
+import { makeFakeExtendedApiError } from '../../storybook/mocks/fakeExtendedApiError.js';
+import { ignore404Errors } from './ignore404Errors.js';
+
+const makeFakeAxiosError = (status: number): AxiosError => {
+  const config = { headers: new AxiosHeaders() };
+  const response = {
+    status,
+    statusText: '',
+    data: undefined,
+    headers: new AxiosHeaders(),
+    config,
+  };
+  return new AxiosError(`Request failed with status code ${status}`, 'ERR_BAD_RESPONSE', config, undefined, response);
+};
+
+describe('ignore404Errors', () => {
+  it('returnerer false for AxiosError med status 404 (legacy)', () => {
+    expect(ignore404Errors(makeFakeAxiosError(404))).toBe(false);
+  });
+
+  it('returnerer false for ExtendedApiError med status 404', () => {
+    expect(ignore404Errors(makeFakeExtendedApiError({ status: 404 }))).toBe(false);
+  });
+
+  it('returnerer true for andre feil', () => {
+    expect(ignore404Errors(new Error('noko gjekk gale'))).toBe(true);
+    expect(ignore404Errors(makeFakeAxiosError(500))).toBe(true);
+    expect(ignore404Errors(makeFakeExtendedApiError({ status: 500 }))).toBe(true);
+  });
+});

--- a/packages/v2/gui/src/app/errorhandling/ignore404Errors.ts
+++ b/packages/v2/gui/src/app/errorhandling/ignore404Errors.ts
@@ -1,0 +1,19 @@
+import { ExtendedApiError } from '@k9-sak-web/backend/shared/errorhandling/ExtendedApiError.js';
+import { AxiosError } from 'axios';
+
+/**
+ * Brukast som verdi for `throwOnError`-opsjonen i useQuery. Returnerer `false` for 404-feil, slik at
+ * dei vert svelgde i staden for å bli kasta vidare til næraste ErrorBoundary. Alle andre feil vert kasta som vanleg.
+ *
+ * Handterer både AxiosError (legacy, status 404) og ExtendedApiError (isNotFound === true).
+ */
+export const ignore404Errors = (error: Error): boolean => {
+  if (error instanceof AxiosError && error.response?.status === 404) {
+    return false;
+  }
+  const apiError = ExtendedApiError.findInError(error);
+  if (apiError?.isNotFound) {
+    return false;
+  }
+  return true;
+};

--- a/packages/v2/gui/src/app/errorhandling/ignore404Errors.ts
+++ b/packages/v2/gui/src/app/errorhandling/ignore404Errors.ts
@@ -6,6 +6,15 @@ import { AxiosError } from 'axios';
  * dei vert svelgde i staden for å bli kasta vidare til næraste ErrorBoundary. Alle andre feil vert kasta som vanleg.
  *
  * Handterer både AxiosError (legacy, status 404) og ExtendedApiError (isNotFound === true).
+ *
+ * k9-sak returnerer 404 feil viss TomtResultatException blir kasta. Viss klient gjere kall til endepunkt/adresse som ikkje
+ * finnast (eigentleg 404 feil), returnerast pr no 500 feil. Så den type feil blir ikkje ignorert av denne funksjon.
+ *
+ * Denne blir lagt til på useQuery kall som tidlegare ignorerte alle feil ved overgang til ny feilhandtering der ein
+ * eksplisitt må ignorere feil som ikkje skal rapporterast, for å unngå for mange feilrapporter i overgang. Det er ikkje
+ * sikkert alle stader den er lagt til faktisk treng denne.
+ *
+ * Ved omskriving/ny kode bør ein heller skrive koden slik at den ikkje feiler med 404 feil ved normale situasjoner.
  */
 export const ignore404Errors = (error: Error): boolean => {
   if (error instanceof AxiosError && error.response?.status === 404) {

--- a/packages/v2/gui/src/fakta/sykdom-og-opplæring/SykdomOgOpplæringQueries.ts
+++ b/packages/v2/gui/src/fakta/sykdom-og-opplæring/SykdomOgOpplæringQueries.ts
@@ -1,4 +1,5 @@
 import { useMutation, useQuery, type UseQueryOptions } from '@tanstack/react-query';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 import {
   type GetBrevMottakerinfoEregData,
   type GetBrevMottakerinfoEregResponse,
@@ -29,6 +30,7 @@ export const useVilkår = (behandlingUuid: string) => {
 
   return useQuery({
     queryKey: ['vilkår', behandlingUuid],
+    throwOnError: ignore404Errors,
     queryFn: () => backendClient.getVilkår(behandlingUuid),
     retry: MAX_RETRIES,
   });
@@ -39,6 +41,7 @@ export const useLangvarigSykVurderingerFagsak = (behandlingUuid: string) => {
 
   return useQuery({
     queryKey: ['langvarigSykVurderingerFagsak', behandlingUuid],
+    throwOnError: ignore404Errors,
     queryFn: () => backendClient.hentLangvarigSykVurderingerFagsak(behandlingUuid),
     enabled: !!behandlingUuid,
     retry: MAX_RETRIES,
@@ -50,6 +53,7 @@ export const useVurdertLangvarigSykdom = (behandlingUuid: string) => {
 
   return useQuery({
     queryKey: ['vurdertLangvarigSykdom', behandlingUuid],
+    throwOnError: ignore404Errors,
     queryFn: () => backendClient.hentVurdertLangvarigSykdom(behandlingUuid),
     retry: MAX_RETRIES,
   });
@@ -61,6 +65,7 @@ export const useInstitusjonInfo = (behandlingUuid: string) => {
 
   return useQuery({
     queryKey: ['institusjonInfo', behandlingUuid],
+    throwOnError: ignore404Errors,
     queryFn: () => backendClient.getInstitusjonInfo(behandlingUuid),
     enabled: !!behandlingUuid,
     retry: MAX_RETRIES,
@@ -72,6 +77,7 @@ export const useAlleInstitusjoner = () => {
 
   return useQuery({
     queryKey: ['alleInstitusjoner'],
+    throwOnError: ignore404Errors,
     queryFn: () => backendClient.hentAlleInstitusjoner(),
     retry: MAX_RETRIES,
   });
@@ -97,6 +103,7 @@ export const useVurdertOpplæring = (
 
   return useQuery({
     queryKey: ['vurdertOpplæring', behandlingUuid],
+    throwOnError: ignore404Errors,
     queryFn: () => backendClient.getVurdertOpplæring(behandlingUuid),
     retry: MAX_RETRIES,
     ...options,
@@ -113,6 +120,7 @@ export const useVurdertReisetid = (
 
   return useQuery({
     queryKey: ['vurdertReisetid', behandlingUuid],
+    throwOnError: ignore404Errors,
     queryFn: () => backendClient.getVurdertReisetid(behandlingUuid),
     retry: MAX_RETRIES,
     ...options,

--- a/packages/v2/gui/src/prosess/klagevurdering/KlagevurderingProsessIndex.tsx
+++ b/packages/v2/gui/src/prosess/klagevurdering/KlagevurderingProsessIndex.tsx
@@ -5,6 +5,7 @@ import type { BehandlingDto as K9KlageBehandlingDto } from '@k9-sak-web/backend/
 import type { BehandlingDto as UngSakBehandlingDto } from '@k9-sak-web/backend/ungsak/kontrakt/behandling/BehandlingDto.js';
 import AksjonspunktCodes from '@k9-sak-web/lib/kodeverk/types/AksjonspunktCodes.js';
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 import { useContext } from 'react';
 import { LoadingPanel } from '../../shared/loading-panel/LoadingPanel';
 import { assertDefined } from '../../utils/validation/assertDefined.js';
@@ -33,11 +34,13 @@ export const KlagevurderingProsessIndex = ({
   const api = assertDefined(useContext(KlageVurderingApiContext));
   const { data: ungHjemler = [] } = useQuery({
     queryKey: ['klage-hjemler', api.backend],
+    throwOnError: ignore404Errors,
     queryFn: () => api.hentValgbareKlagehjemlerForUng?.() ?? Promise.resolve([]),
     enabled: api.hentValgbareKlagehjemlerForUng !== undefined,
   });
   const { data: klageVurdering, isLoading } = useQuery({
     queryKey: ['klageVurdering', behandling, api.backend],
+    throwOnError: ignore404Errors,
     queryFn: () => api.getKlageVurdering(behandling.uuid),
   });
   const { mutateAsync: previewCallback } = useMutation({

--- a/packages/v2/gui/src/prosess/ung-beregning/UngBeregning.tsx
+++ b/packages/v2/gui/src/prosess/ung-beregning/UngBeregning.tsx
@@ -7,6 +7,7 @@ import { aksjonspunktCodes } from '@k9-sak-web/backend/ungsak/kodeverk/Aksjonspu
 import { ExclamationmarkTriangleFillIcon } from '@navikt/aksel-icons';
 import { Alert, Box, Heading, Loader, Tabs } from '@navikt/ds-react';
 import { useQuery } from '@tanstack/react-query';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 import { DagsatsOgUtbetaling, sortSatser } from '../../shared/dagsats-og-utbetaling/DagsatsOgUtbetaling';
 import { ArbeidOgInntekt, type ArbeidOgInntektProps } from '../../shared/kontroll-inntekt/ArbeidOgInntekt';
 import { BarnPanel } from './BarnPanel';
@@ -71,6 +72,7 @@ const UngBeregning = ({ api, behandling, barn, inntektKontrollertCallback, aksjo
 
   const { data: arbeidsgivere } = useQuery({
     queryKey: ['arbeidsgivere', behandling.uuid],
+    throwOnError: ignore404Errors,
     queryFn: () => api.getArbeidsgiverOpplysninger(behandling.uuid),
   });
 

--- a/packages/v2/gui/src/prosess/ung-vedtak/UngVedtakIndex.tsx
+++ b/packages/v2/gui/src/prosess/ung-vedtak/UngVedtakIndex.tsx
@@ -1,5 +1,6 @@
 import { Box, Heading } from '@navikt/ds-react';
 import { useQuery } from '@tanstack/react-query';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 import { UngVedtak, type UngVedtakProps } from './UngVedtak';
 import UngVedtakBackendClient from './UngVedtakBackendClient';
 import type { UngVedtakBehandlingDto } from './UngVedtakBehandlingDto';
@@ -32,6 +33,7 @@ export const UngVedtakIndex = ({
     refetch: refetchVedtaksbrevValg,
   } = useQuery({
     queryKey: ['vedtaksbrevValg', behandling.id, api.backend],
+    throwOnError: ignore404Errors,
     queryFn: async () => {
       const response = await api.vedtaksbrevValg(behandling.id!);
       return response;

--- a/packages/v2/gui/src/prosess/ung-vedtak/brev/FritekstBrevpanel.tsx
+++ b/packages/v2/gui/src/prosess/ung-vedtak/brev/FritekstBrevpanel.tsx
@@ -6,6 +6,7 @@ import type {
 import { FileSearchIcon } from '@navikt/aksel-icons';
 import { Button, Heading, Modal, VStack } from '@navikt/ds-react';
 import { useQuery, type UseMutateFunction } from '@tanstack/react-query';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useFormContext, useWatch } from 'react-hook-form';
 import { type FormData } from '../FormData';
@@ -66,6 +67,7 @@ export const FritekstBrevpanel = ({
 
   const { data: fritekstEditorData } = useQuery({
     queryKey: ['fritekstEditorData', behandlingId, vedtaksbrevValg?.dokumentMalType],
+    throwOnError: ignore404Errors,
     queryFn: async () => {
       if (vedtaksbrevValg?.dokumentMalType) {
         const response = await api.formidling_editor(`${behandlingId}`, vedtaksbrevValg.dokumentMalType.kilde);

--- a/packages/v2/gui/src/prosess/uttak/context/UttakContext.tsx
+++ b/packages/v2/gui/src/prosess/uttak/context/UttakContext.tsx
@@ -7,6 +7,7 @@ import type {
 } from '@k9-sak-web/backend/k9sak/generated/types.js';
 import { k9_kodeverk_behandling_aksjonspunkt_AksjonspunktDefinisjon as AksjonspunktDefinisjon } from '@k9-sak-web/backend/k9sak/generated/types.js';
 import { useQuery, useSuspenseQuery } from '@tanstack/react-query';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 import {
   createContext,
   useCallback,
@@ -163,6 +164,7 @@ export const useUttakContext = () => {
    */
   const { refetch: hentUttak } = useQuery({
     queryKey: ['uttak', behandling.uuid],
+    throwOnError: ignore404Errors,
     queryFn: async () => {
       const hentetUttak = await uttakApi.hentUttak(behandling.uuid);
       return hentetUttak;

--- a/packages/v2/gui/src/prosess/uttak/overstyr-uttak/OverstyrUttak.stories.tsx
+++ b/packages/v2/gui/src/prosess/uttak/overstyr-uttak/OverstyrUttak.stories.tsx
@@ -13,7 +13,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { action } from 'storybook/actions';
 import { expect, fn, userEvent, waitFor, within } from 'storybook/test';
 import Uttak from '../Uttak';
-import { withQueryClientProvider } from "../../../storybook/decorators/withQueryClientProvider.js";
+import { withQueryClientProvider } from '../../../storybook/decorators/withQueryClientProvider.js';
 
 /**
  * OverstyrUttak-komponenten lar saksbehandlere med overstyrerrolle manuelt overstyre
@@ -35,7 +35,7 @@ const meta = {
     },
   },
   decorators: [
-    withQueryClientProvider({queries: {throwOnError: false}}),
+    withQueryClientProvider(),
     Story => (
       <BehandlingProvider refetchBehandling={fn()}>
         <Story />

--- a/packages/v2/gui/src/prosess/uttak/overstyr-uttak/OverstyrUttak.tsx
+++ b/packages/v2/gui/src/prosess/uttak/overstyr-uttak/OverstyrUttak.tsx
@@ -8,6 +8,7 @@ import { useRefetchBehandling } from '@k9-sak-web/gui/context/BehandlingContext.
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Alert, BodyShort, Button, Heading, HelpText, HStack, Loader, Modal, Table } from '@navikt/ds-react';
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 import { useState, type FC } from 'react';
 import { useUttakContext } from '../context/UttakContext';
 import type { OverstyringUttakHandling } from '../types/OverstyringUttakTypes';
@@ -37,6 +38,7 @@ const OverstyrUttak: FC<OverstyrUttakProps> = ({ overstyringAktiv }) => {
 
   const { data: overstyrte, isLoading: lasterOverstyrte } = useQuery({
     queryKey: ['overstyrte', behandling.uuid],
+    throwOnError: ignore404Errors,
     queryFn: () => uttakApi.hentOverstyringUttak(behandling.uuid),
   });
 

--- a/packages/v2/gui/src/prosess/uttak/overstyr-uttak/OverstyringUttakForm.tsx
+++ b/packages/v2/gui/src/prosess/uttak/overstyr-uttak/OverstyringUttakForm.tsx
@@ -21,6 +21,7 @@ import type {
 } from '@k9-sak-web/backend/k9sak/generated/types.js';
 import { RhfForm } from '@navikt/ft-form-hooks';
 import { useQuery } from '@tanstack/react-query';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 import type BehandlingUttakBackendClient from '../BehandlingUttakBackendClient';
 import type { HandleOverstyringType } from '../types/OverstyringUttakTypes';
 import {
@@ -111,6 +112,7 @@ const OverstyringUttakForm: FC<OwnProps> = ({
 
   const { isLoading: lasterAktiviteter } = useQuery({
     queryKey: ['overstyrte', behandling.uuid, watchFraDato, watchTilDato],
+    throwOnError: ignore404Errors,
     enabled: beggeDatoerValgt && erNyOverstyring, // Kun hent aktiviteter for nye overstyringer
     queryFn: async () => {
       const aktuelleAktiviteter = await api.hentAktuelleAktiviteter(

--- a/packages/v2/gui/src/sak/dokumenter/components/DocumentList.tsx
+++ b/packages/v2/gui/src/sak/dokumenter/components/DocumentList.tsx
@@ -17,6 +17,7 @@ import eksternLinkImageUrl from './icons/ekstern_link_pil_boks.svg';
 import internDokumentImageUrl from './icons/intern_dokument.svg';
 import mottaDokumentImageUrl from './icons/motta_dokument.svg';
 import sendDokumentImageUrl from './icons/send_dokument.svg';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 
 const getBackendPath = () => (isUngWeb() ? 'ung' : 'k9');
 
@@ -114,7 +115,7 @@ const DocumentList = ({ documents, behandlingId, fagsakPerson, saksnummer, behan
     queryKey: ['kompletthet'],
     queryFn: ({ signal }) => getInntektsmeldingerIBruk(signal),
     enabled: erStøttetFagsakYtelseType && !!behandlingUuid,
-    throwOnError: false, // k9-sak kaster 404 på dette kallet av og til. Uvisst når pr no
+    throwOnError: ignore404Errors, // k9-sak kaster 404 på dette kallet av og til. Uvisst når pr no
   });
 
   const ModiaLenke = () => (

--- a/packages/v2/gui/src/sak/meny/endre-frist/MenyEndreFristApiContext.tsx
+++ b/packages/v2/gui/src/sak/meny/endre-frist/MenyEndreFristApiContext.tsx
@@ -1,0 +1,5 @@
+import { createContext } from 'react';
+import MenyEndreFristBackendClient from './MenyEndreFristBackendClient.js';
+import type { MenyEndreFristApi } from './MenyEndreFristApi.js';
+
+export const MenyEndreFristApiContext = createContext<MenyEndreFristApi>(new MenyEndreFristBackendClient());

--- a/packages/v2/gui/src/sak/meny/endre-frist/MenyEndreFristIndex.tsx
+++ b/packages/v2/gui/src/sak/meny/endre-frist/MenyEndreFristIndex.tsx
@@ -1,5 +1,6 @@
 import { ung_kodeverk_varsel_EtterlysningStatus } from '@k9-sak-web/backend/ungsak/generated/types.js';
 import { useMutation, useQuery } from '@tanstack/react-query';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 import { useState } from 'react';
 import { MenyEndreFrist } from './MenyEndreFrist';
 import type { MenyEndreFristApi } from './MenyEndreFristApi';
@@ -22,6 +23,7 @@ export const MenyEndreFristIndex = ({
   const [nyFrist, setNyFrist] = useState<string | undefined>(undefined);
   const { data: etterlysninger = [], isLoading } = useQuery({
     queryKey: ['etterlysninger', behandlingUuid],
+    throwOnError: ignore404Errors,
     queryFn: () => api.hentEtterlysninger(behandlingUuid),
     select: etterlysninger =>
       etterlysninger.filter(etterlysning => etterlysning.status === ung_kodeverk_varsel_EtterlysningStatus.VENTER),

--- a/packages/v2/gui/src/sak/meny/endre-frist/MenyEndreFristIndex.tsx
+++ b/packages/v2/gui/src/sak/meny/endre-frist/MenyEndreFristIndex.tsx
@@ -1,16 +1,15 @@
 import { ung_kodeverk_varsel_EtterlysningStatus } from '@k9-sak-web/backend/ungsak/generated/types.js';
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
-import { useState } from 'react';
-import { MenyEndreFrist } from './MenyEndreFrist';
-import type { MenyEndreFristApi } from './MenyEndreFristApi';
+import { use, useState } from 'react';
+import { MenyEndreFrist } from './MenyEndreFrist.js';
+import { MenyEndreFristApiContext } from './MenyEndreFristApiContext.js';
 
 interface MenyEndreFristIndexProps {
   lukkModal: () => void;
   behandlingUuid: string;
   behandlingId: number;
   behandlingVersjon: number;
-  api: MenyEndreFristApi;
 }
 
 export const MenyEndreFristIndex = ({
@@ -18,8 +17,8 @@ export const MenyEndreFristIndex = ({
   behandlingUuid,
   behandlingId,
   behandlingVersjon,
-  api,
 }: MenyEndreFristIndexProps) => {
+  const api = use(MenyEndreFristApiContext);
   const [nyFrist, setNyFrist] = useState<string | undefined>(undefined);
   const { data: etterlysninger = [], isLoading } = useQuery({
     queryKey: ['etterlysninger', behandlingUuid],

--- a/packages/v2/gui/src/sak/meny/marker-behandling/components/MarkerBehandlingModal.tsx
+++ b/packages/v2/gui/src/sak/meny/marker-behandling/components/MarkerBehandlingModal.tsx
@@ -10,6 +10,7 @@ import React from 'react';
 import { useForm, useFormState, useWatch } from 'react-hook-form';
 import type { MarkerBehandlingBackendApi } from '../MarkerBehandlingBackendApi';
 import styles from './markerBehandlingModal.module.css';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 
 const minLength3 = minLength(3);
 const maxLength100000 = maxLength(100000);
@@ -73,7 +74,7 @@ const MarkerBehandlingModal: React.FC<PureOwnProps> = ({ lukkModal, behandlingUu
     refetch: hentMerknader,
     isFetching,
   } = useQuery({
-    throwOnError: false, // Denne feiler med 404 for klage/tilbake behandlinger
+    throwOnError: ignore404Errors, // Denne feiler med 404 for klage/tilbake behandlinger
     queryKey: ['merknader', behandlingUuid],
     queryFn: async () => {
       const data = await api.getMerknader(behandlingUuid);

--- a/packages/v2/gui/src/sak/meny/ny-behandling/MenyNyBehandlingIndex.tsx
+++ b/packages/v2/gui/src/sak/meny/ny-behandling/MenyNyBehandlingIndex.tsx
@@ -6,6 +6,7 @@ import { erTilbakekreving } from '@k9-sak-web/gui/utils/behandlingUtils.js';
 import FeatureTogglesContext from '@k9-sak-web/gui/featuretoggles/FeatureTogglesContext.js';
 import type { KodeverkObject } from '@k9-sak-web/lib/kodeverk/types.js';
 import { useQuery } from '@tanstack/react-query';
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 import dayjs from 'dayjs';
 import { use, useCallback } from 'react';
 import NyBehandlingModal, {
@@ -75,6 +76,7 @@ const MenyNyBehandlingIndexV2 = ({
   );
   const { data: vilkår } = useQuery({
     queryKey: ['vilkar', behandlingUuid],
+    throwOnError: ignore404Errors,
     queryFn: () => (behandlingUuid ? vilkårBackendClient.getVilkår(behandlingUuid) : []),
     enabled: !!behandlingUuid && !erTilbakekreving(behandlingType),
   });
@@ -93,7 +95,9 @@ const MenyNyBehandlingIndexV2 = ({
       const isTilbakekreving = TILBAKEKREVING_BEHANDLINGSTYPER.some(b => b === formValues.behandlingType);
       const tilbakekrevingBehandlingId = behandlingId && isTilbakekreving ? { behandlingId } : {};
       const filteredFormValues: Record<string, unknown> = Object.fromEntries(
-        Object.entries(formValues).filter(([, v]) => v !== '' && v !== undefined && (!Array.isArray(v) || v.length > 0)),
+        Object.entries(formValues).filter(
+          ([, v]) => v !== '' && v !== undefined && (!Array.isArray(v) || v.length > 0),
+        ),
       );
 
       if (REVURDERING_FRA_STEG_V2 && formValues.revurderingModus === 'FULL') {

--- a/packages/v2/gui/src/storybook/mocks/FakeMenyEndreFristApi.ts
+++ b/packages/v2/gui/src/storybook/mocks/FakeMenyEndreFristApi.ts
@@ -1,0 +1,28 @@
+import type {
+  ung_sak_kontrakt_etterlysning_EndreFristDto,
+  ung_sak_kontrakt_etterlysning_Etterlysning,
+} from '@k9-sak-web/backend/ungsak/generated/types.js';
+import type { MenyEndreFristApi } from '@k9-sak-web/gui/sak/meny/endre-frist/MenyEndreFristApi.js';
+import { ignoreUnusedDeclared } from './ignoreUnusedDeclared.js';
+
+export class FakeMenyEndreFristApi implements MenyEndreFristApi {
+  #etterlysninger: ung_sak_kontrakt_etterlysning_Etterlysning[];
+
+  constructor(etterlysninger: ung_sak_kontrakt_etterlysning_Etterlysning[] = []) {
+    this.#etterlysninger = etterlysninger;
+  }
+
+  hentEtterlysninger(behandlingUuid: string): Promise<ung_sak_kontrakt_etterlysning_Etterlysning[]> {
+    ignoreUnusedDeclared(behandlingUuid);
+    return Promise.resolve(this.#etterlysninger);
+  }
+
+  endreFrist(
+    behandlingId: number,
+    behandlingVersjon: number,
+    endretFrister: Array<ung_sak_kontrakt_etterlysning_EndreFristDto>,
+  ): Promise<void> {
+    ignoreUnusedDeclared({ behandlingId, behandlingVersjon, endretFrister });
+    return Promise.resolve();
+  }
+}

--- a/packages/v2/gui/src/storybook/mocks/FakeUttakBackendApi.ts
+++ b/packages/v2/gui/src/storybook/mocks/FakeUttakBackendApi.ts
@@ -11,13 +11,14 @@ import type {
 } from '@k9-sak-web/backend/k9sak/generated/types.js';
 import type { BehandlingUttakBackendApiType } from '../../prosess/uttak/BehandlingUttakBackendApiType.js';
 import { ignoreUnusedDeclared } from './ignoreUnusedDeclared.js';
-import { defaultArbeidsgivere } from './uttak/uttakStoryMocks.js';
+import { defaultArbeidsgivere, lagUttak } from './uttak/uttakStoryMocks.js';
 
 export interface FakeUttakBackendConfig {
   arbeidsgivere?: ArbeidsgiverOversiktDto['arbeidsgivere'];
   inntektsgraderinger?: InntektgraderingDto;
   overstyringer?: OverstyrtUttakDto['overstyringer'];
   egneOverlappendeSaker?: EgneOverlappendeSakerDto;
+  uttak?: k9_sak_web_app_tjenester_behandling_uttak_UttaksplanMedUtsattePerioder;
   allowedRanges?: Array<{ fom: string; tom: string }>;
   onBekreftAksjonspunkt?: (requestBody: k9_sak_kontrakt_aksjonspunkt_BekreftedeAksjonspunkterDto) => void;
   onOverstyringUttak?: (requestBody: k9_sak_kontrakt_aksjonspunkt_BekreftetOgOverstyrteAksjonspunkterDto) => void;
@@ -28,6 +29,7 @@ export class FakeUttakBackendApi implements BehandlingUttakBackendApiType {
   #inntektsgraderinger: InntektgraderingDto;
   #overstyringer: OverstyrtUttakDto['overstyringer'];
   #egneOverlappendeSaker: EgneOverlappendeSakerDto;
+  #uttak: k9_sak_web_app_tjenester_behandling_uttak_UttaksplanMedUtsattePerioder;
   #onBekreftAksjonspunkt: ((requestBody: k9_sak_kontrakt_aksjonspunkt_BekreftedeAksjonspunkterDto) => void) | undefined;
   #onOverstyringUttak:
     | ((requestBody: k9_sak_kontrakt_aksjonspunkt_BekreftetOgOverstyrteAksjonspunkterDto) => void)
@@ -39,6 +41,7 @@ export class FakeUttakBackendApi implements BehandlingUttakBackendApiType {
     this.#inntektsgraderinger = config?.inntektsgraderinger ?? { perioder: [] };
     this.#overstyringer = config?.overstyringer ?? [];
     this.#egneOverlappendeSaker = config?.egneOverlappendeSaker ?? { perioderMedOverlapp: [] };
+    this.#uttak = config?.uttak ?? lagUttak([]);
     this.#onBekreftAksjonspunkt = config?.onBekreftAksjonspunkt;
     this.#onOverstyringUttak = config?.onOverstyringUttak;
     this.#allowedRanges = config?.allowedRanges;
@@ -48,7 +51,7 @@ export class FakeUttakBackendApi implements BehandlingUttakBackendApiType {
     behandlingUuid: string,
   ): Promise<k9_sak_web_app_tjenester_behandling_uttak_UttaksplanMedUtsattePerioder> {
     ignoreUnusedDeclared(behandlingUuid);
-    throw new Error('hentUttak er ikke implementert i FakeUttakBackendApi');
+    return this.#uttak;
   }
 
   async getEgneOverlappendeSaker(behandlingUuid: string): Promise<EgneOverlappendeSakerDto> {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1368,6 +1368,7 @@ __metadata:
     "@fpsak-frontend/tidslinje": "npm:1.0.0"
     "@fpsak-frontend/utils": "npm:1.0.0"
     "@fpsak-frontend/utils-test": "npm:1.0.0"
+    "@k9-sak-web/gui": "workspace:^"
     "@k9-sak-web/types": "npm:1.0.0"
     "@types/react": "npm:19.2.15"
     moment: "npm:2.30.1"
@@ -2107,6 +2108,7 @@ __metadata:
     "@fpsak-frontend/kodeverk": "npm:1.0.0"
     "@fpsak-frontend/shared-components": "npm:1.0.0"
     "@k9-sak-web/behandling-felles": "npm:1.0.0"
+    "@k9-sak-web/gui": "workspace:^"
     "@k9-sak-web/konstanter": "npm:1.0.0"
     "@k9-sak-web/rest-api": "npm:1.0.0"
     "@k9-sak-web/rest-api-hooks": "npm:1.0.0"
@@ -2659,6 +2661,7 @@ __metadata:
   resolution: "@k9-sak-web/fakta-medisinsk-vilkar@workspace:packages/fakta-medisinsk-vilkår"
   dependencies:
     "@fpsak-frontend/form": "npm:1.0.0"
+    "@k9-sak-web/gui": "workspace:^"
     "@navikt/aksel-icons": "npm:8.13.1"
     "@navikt/diagnosekoder": "npm:1.2026.0"
     "@navikt/ds-css": "npm:8.13.1"


### PR DESCRIPTION
### Behov / Bakgrunn

Med ny feilhandtering blir alle feil frå `useQuery` kall i utgangspunktet kasta til error boundary.

Ein del kall som tidlegare ikkje rapporterte feil rapporterer no 404 feil fordi ei eller anna databasespørring på server returnerer tomt resultat (feks oppslag av behandling viss ein kaller k9-sak med behandling id tilhøyrande k9-klage) 

### Løsning

I overgangsfase legger vi til eksplisitt ignorering av 404 feil på alle useQuery kall som tidlegare ikkje rapporterte nokon feil.

Det er ikkje sikkert at alle `useQuery` som her får den lagt til faktisk kaster 404 feil av og til, men legger til på alle i første omgang, så kan ein fjerne dei enkeltvis seinare viss ein ønsker.

Merk at k9-sak pr no ikkje kaster 404 feil viss klient sende forespørsel til ikkje-eksisterande url. Den svare då med 500 feil. Trur det er kun `TomtResultatException` som fører til 404 feil frå k9-sak.


