### PR TITLE
TSFF-2807: poststed dukker opp som "null"

### DIFF
--- a/packages/v2/gui/src/utils/getAddresses.ts
+++ b/packages/v2/gui/src/utils/getAddresses.ts
@@ -33,12 +33,7 @@ const getAddresses = (addresses: PersonadresseDto[] = []): Adresser =>
     const country = address.land !== landkoder.NORGE ? address.land : undefined;
     return {
       ...acc,
-      [address.adresseType]: constructAddress(
-        currentAddress,
-        `${address.postNummer}`,
-        `${address.poststed}`,
-        country,
-      ).trim(),
+      [address.adresseType]: constructAddress(currentAddress, address.postNummer, address.poststed, country).trim(),
     };
   }, {});
 


### PR DESCRIPTION
### Behov / Bakgrunn
Gjør postnummer og poststed til string via template literal, så hvis de er null eller undefined blir de til stringen 'null' eller 'undefined'

### Løsning
Fjerner bruk av template literal

### Andre endringer

