### PR TITLE
Notat badge skal kun vise når det er notater på sak.

### DIFF
--- a/packages/sak-app/src/behandlingsupport/BehandlingSupportIndex.tsx
+++ b/packages/sak-app/src/behandlingsupport/BehandlingSupportIndex.tsx
@@ -176,11 +176,7 @@ const BehandlingSupportIndex = ({
   const notatBackendClient = useContext(NotatBackendClientContext);
 
   const notaterQueryKey = ['notater', notatBackendClient?.backend, fagsak?.saksnummer];
-  const {
-    data: notater,
-    isError: notaterFetchFailed,
-    isLoading: notaterIsLoading,
-  } = useQuery({
+  const { data: notater, isError: notaterFetchFailed } = useQuery({
     queryKey: notaterQueryKey,
     queryFn: () => notatBackendClient!.getNotater(fagsak.saksnummer),
     enabled: !!fagsak && !!notatBackendClient,
@@ -211,7 +207,7 @@ const BehandlingSupportIndex = ({
     } else {
       setAntallUlesteNotater('');
     }
-  }, [notater, notaterIsLoading, notaterFetchFailed]);
+  }, [notater, notaterFetchFailed]);
 
   const { selected: valgtSupportPanel, location } = useTrackRouteParam<string>({
     paramName: 'stotte',

--- a/packages/sak-app/src/behandlingsupport/BehandlingSupportIndex.tsx
+++ b/packages/sak-app/src/behandlingsupport/BehandlingSupportIndex.tsx
@@ -76,7 +76,7 @@ export const hentValgbarePaneler = (
 
 interface GetSvgProps {
   tooltip: string;
-  antallUlesteNotater: string | undefined;
+  antallUlesteNotater: string;
   isActive: boolean;
 }
 
@@ -126,7 +126,7 @@ const TABS = {
   [SupportTabs.NOTATER]: {
     getSvg: ({ antallUlesteNotater, isActive }: GetSvgProps) => (
       <div className={styles.pencilSvgContainer}>
-        {antallUlesteNotater != null && <div className={styles.ulesteNotater}>{antallUlesteNotater}</div>}
+        {antallUlesteNotater !== '' && <div className={styles.ulesteNotater}>{antallUlesteNotater}</div>}
         {isActive ? (
           <PencilWritingFillIcon title="Notater" fontSize="1.625rem" className={styles.pencilSvg} />
         ) : (
@@ -168,7 +168,7 @@ const BehandlingSupportIndex = ({
   navAnsatt,
   featureToggles,
 }: OwnProps) => {
-  const [antallUlesteNotater, setAntallUlesteNotater] = useState<undefined | string>();
+  const [antallUlesteNotater, setAntallUlesteNotater] = useState<string>('');
 
   const kodeverkoppslag = useContext(K9KodeverkoppslagContext);
   const formidlingClient = useContext(FormidlingClientContext);
@@ -176,7 +176,11 @@ const BehandlingSupportIndex = ({
   const notatBackendClient = useContext(NotatBackendClientContext);
 
   const notaterQueryKey = ['notater', notatBackendClient?.backend, fagsak?.saksnummer];
-  const { data: notater, isError: notaterFetchFailed, isLoading: notaterIsLoading } = useQuery({
+  const {
+    data: notater,
+    isError: notaterFetchFailed,
+    isLoading: notaterIsLoading,
+  } = useQuery({
     queryKey: notaterQueryKey,
     queryFn: () => notatBackendClient!.getNotater(fagsak.saksnummer),
     enabled: !!fagsak && !!notatBackendClient,
@@ -184,24 +188,28 @@ const BehandlingSupportIndex = ({
     throwOnError: false,
   });
 
-  const lagTabs = useCallback((tilgjengeligeTabs: string[], valgtIndex?: number) =>
-    Object.keys(TABS)
-      .filter(key => tilgjengeligeTabs.includes(key))
-      .map((key, index) => ({
-        getSvg: TABS[key].getSvg,
-        tooltip: TABS[key].tooltipTextCode,
-        isActive: index === valgtIndex,
-        antallUlesteNotater,
-        tabKey: TABS[key].tabKey,
-      })), [antallUlesteNotater]);
+  const lagTabs = useCallback(
+    (tilgjengeligeTabs: string[], valgtIndex?: number) =>
+      Object.keys(TABS)
+        .filter(key => tilgjengeligeTabs.includes(key))
+        .map((key, index) => ({
+          getSvg: TABS[key].getSvg,
+          tooltip: TABS[key].tooltipTextCode,
+          isActive: index === valgtIndex,
+          antallUlesteNotater,
+          tabKey: TABS[key].tabKey,
+        })),
+    [antallUlesteNotater],
+  );
 
   useEffect(() => {
-    if(notaterIsLoading) {
-      setAntallUlesteNotater(undefined)
-    } else if(!notaterFetchFailed && notater != null) {
-      setAntallUlesteNotater("" + notater.filter(notat => !notat.skjult).length);
+    if (notaterFetchFailed) {
+      setAntallUlesteNotater('?');
+    } else if (notater != null) {
+      const antall = notater.filter(notat => !notat.skjult).length;
+      setAntallUlesteNotater(antall > 0 ? '' + antall : '');
     } else {
-      setAntallUlesteNotater("?")
+      setAntallUlesteNotater('');
     }
   }, [notater, notaterIsLoading, notaterFetchFailed]);
 
@@ -236,10 +244,7 @@ const BehandlingSupportIndex = ({
 
   const valgtIndex = synligeSupportPaneler.findIndex(p => p === aktivtSupportPanel);
 
-  const tabs = useMemo(
-    () => lagTabs(synligeSupportPaneler, valgtIndex),
-    [synligeSupportPaneler, valgtIndex, lagTabs],
-  );
+  const tabs = useMemo(() => lagTabs(synligeSupportPaneler, valgtIndex), [synligeSupportPaneler, valgtIndex, lagTabs]);
 
   const behandlingTypeKode = behandling?.type.kode;
   const erTilbakekreving =

--- a/packages/ung/sak-app/behandlingsupport/BehandlingSupportIndex.tsx
+++ b/packages/ung/sak-app/behandlingsupport/BehandlingSupportIndex.tsx
@@ -66,7 +66,7 @@ export const hentValgbarePaneler = (
 
 interface GetSvgProps {
   tooltip: string;
-  antallUlesteNotater: string | undefined;
+  antallUlesteNotater: string;
   isActive: boolean;
 }
 
@@ -116,7 +116,7 @@ const TABS = {
   [SupportTabs.NOTATER]: {
     getSvg: ({ antallUlesteNotater, isActive }: GetSvgProps) => (
       <div className={styles.pencilSvgContainer}>
-        {antallUlesteNotater != null && <div className={styles.ulesteNotater}>{antallUlesteNotater}</div>}
+        {antallUlesteNotater !== '' && <div className={styles.ulesteNotater}>{antallUlesteNotater}</div>}
         {isActive ? (
           <PencilWritingFillIcon title="Notater" fontSize="1.625rem" className={styles.pencilSvg} />
         ) : (
@@ -154,7 +154,7 @@ const BehandlingSupportIndex = ({
   navAnsatt,
   featureToggles,
 }: OwnProps) => {
-  const [antallUlesteNotater, setAntallUlesteNotater] = useState<undefined | string>();
+  const [antallUlesteNotater, setAntallUlesteNotater] = useState<string>('');
 
   const kodeverkoppslag = useContext(UngKodeverkoppslagContext);
   const historikkBackendClient = new UngHistorikkBackendClient(kodeverkoppslag);
@@ -188,12 +188,13 @@ const BehandlingSupportIndex = ({
   );
 
   useEffect(() => {
-    if (notaterIsLoading) {
-      setAntallUlesteNotater(undefined);
-    } else if (!notaterFetchFailed && notater != null) {
-      setAntallUlesteNotater('' + notater.filter(notat => !notat.skjult).length);
-    } else {
+    if (notaterFetchFailed) {
       setAntallUlesteNotater('?');
+    } else if (notater != null) {
+      const antall = notater.filter(notat => !notat.skjult).length;
+      setAntallUlesteNotater(antall > 0 ? '' + antall : '');
+    } else {
+      setAntallUlesteNotater('');
     }
   }, [notater, notaterIsLoading, notaterFetchFailed]);
 
@@ -228,10 +229,7 @@ const BehandlingSupportIndex = ({
 
   const valgtIndex = synligeSupportPaneler.findIndex(p => p === aktivtSupportPanel);
 
-  const tabs = useMemo(
-    () => lagTabs(synligeSupportPaneler, valgtIndex),
-    [synligeSupportPaneler, valgtIndex, lagTabs],
-  );
+  const tabs = useMemo(() => lagTabs(synligeSupportPaneler, valgtIndex), [synligeSupportPaneler, valgtIndex, lagTabs]);
 
   const behandlingTypeKode = behandling?.type.kode;
   const erTilbakekreving =

--- a/packages/ung/sak-app/behandlingsupport/BehandlingSupportIndex.tsx
+++ b/packages/ung/sak-app/behandlingsupport/BehandlingSupportIndex.tsx
@@ -161,11 +161,7 @@ const BehandlingSupportIndex = ({
   const notatBackendClient = useContext(NotatBackendClientContext);
 
   const notaterQueryKey = ['notater', notatBackendClient?.backend, fagsak?.saksnummer];
-  const {
-    data: notater,
-    isError: notaterFetchFailed,
-    isLoading: notaterIsLoading,
-  } = useQuery({
+  const { data: notater, isError: notaterFetchFailed } = useQuery({
     queryKey: notaterQueryKey,
     queryFn: () => notatBackendClient!.getNotater(fagsak.saksnummer),
     enabled: !!fagsak && !!notatBackendClient,
@@ -196,7 +192,7 @@ const BehandlingSupportIndex = ({
     } else {
       setAntallUlesteNotater('');
     }
-  }, [notater, notaterIsLoading, notaterFetchFailed]);
+  }, [notater, notaterFetchFailed]);
 
   const { selected: valgtSupportPanel, location } = useTrackRouteParam<string>({
     paramName: 'stotte',


### PR DESCRIPTION
### Behov / Bakgrunn

Utilsikta endring gjorde at varsel badge på notat tab viste også når det var 0 notater på saka.

Meldt på FAGSYSTEM-436988

### Løsning

Endra tilbake til tidlegare oppførsel.

Forøvrig: Viss lasting av notater feila, blir det vist ? slik at bruker kan opne panelet for å sjekke meir/sjå feilmelding.