### PR TITLE
Bytte gosyslenke

### DIFF
--- a/packages/v2/lib/src/paths/paths.ts
+++ b/packages/v2/lib/src/paths/paths.ts
@@ -19,8 +19,8 @@ export const getPathToK9Los = (): string | null => {
 
 export const getGosysUrl = (): string => {
   const { host } = window.location;
-  const devUrl = 'https://gosys-q2.dev.intern.nav.no/gosys/bruker/brukeroversikt.jsf';
-  const prodUrl = 'https://gosys.intern.nav.no/gosys/bruker/brukeroversikt.jsf';
+  const devUrl = 'https://gosys-q2.dev.intern.nav.no/gosys/oppgavebehandling/oppgaver/mine';
+  const prodUrl = 'https://gosys.intern.nav.no/gosys/oppgavebehandling/oppgaver/mine';
   if (devHosts.includes(host)) {
     return devUrl;
   }


### PR DESCRIPTION
### Behov / Bakgrunn
På nåværende lenke gjør gosys automatisk oppslag på forrige person saksbehandler gjorde oppslag på. Det er veldig forvirrende 

### Løsning
Bytte lenke til hovedsiden av gosys

### Andre endringer

