### PR TITLE
Fiks feil og feilhandtering ved henleggelse av sak

### DIFF
--- a/packages/sak-app/src/behandlingmenu/BehandlingMenuIndex.tsx
+++ b/packages/sak-app/src/behandlingmenu/BehandlingMenuIndex.tsx
@@ -163,7 +163,9 @@ export const BehandlingMenuIndex = ({
   const { startRequest: lagNyBehandlingUnntak } = restApiHooks.useRestApiRunner<boolean>(
     K9sakApiKeys.NEW_BEHANDLING_UNNTAK,
   );
-  const { startRequest: hentMottakere } = restApiHooks.useRestApiRunner<KlagePart[]>(K9sakApiKeys.PARTER_MED_KLAGERETT);
+  const { startRequest: hentMottakere } = restApiHooks.useRestApiRunner<KlagePart[] | undefined | null>(
+    K9sakApiKeys.PARTER_MED_KLAGERETT,
+  );
 
   const featureToggles = useContext(FeatureTogglesContext);
 

--- a/packages/ung/sak-app/behandlingmenu/BehandlingMenuIndex.tsx
+++ b/packages/ung/sak-app/behandlingmenu/BehandlingMenuIndex.tsx
@@ -161,7 +161,7 @@ export const BehandlingMenuIndex = ({
   const { startRequest: lagNyBehandlingKlage } = restApiHooks.useRestApiRunner<boolean>(
     UngSakApiKeys.NEW_BEHANDLING_KLAGE,
   );
-  const { startRequest: hentMottakere } = restApiHooks.useRestApiRunner<KlagePart[]>(
+  const { startRequest: hentMottakere } = restApiHooks.useRestApiRunner<KlagePart[] | undefined | null>(
     UngSakApiKeys.PARTER_MED_KLAGERETT,
   );
   const menyEndreFristClient = use(MenyEndreFristApiContext);

--- a/packages/v2/gui/src/app/errorhandling/ui/resolveAxiosErrorView.tsx
+++ b/packages/v2/gui/src/app/errorhandling/ui/resolveAxiosErrorView.tsx
@@ -48,7 +48,7 @@ const resolveTeapotProps = (error: AxiosError) => {
 };
 
 // Hent ut "feilmelding" frå server-responsen (t.d. ved BadRequestException). Returnerer null viss den ikkje finst.
-const getBodyFeilmelding = (error: AxiosError): string | null => {
+export const getBodyFeilmelding = (error: AxiosError): string | null => {
   const data = asRecord(getEffectiveResponseData(error));
   if (data != null && typeof data['feilmelding'] === 'string') {
     return data['feilmelding'];

--- a/packages/v2/gui/src/sak/meny/henlegg-behandling/MenyHenleggIndex.spec.tsx
+++ b/packages/v2/gui/src/sak/meny/henlegg-behandling/MenyHenleggIndex.spec.tsx
@@ -11,7 +11,6 @@ import { createQueryClient } from '../../../shared/query/queryClient.js';
 
 const queryClient = createQueryClient({
   queries: {
-    throwOnError: false,
     retry: false,
   },
 });

--- a/packages/v2/gui/src/sak/meny/henlegg-behandling/MenyHenleggIndex.tsx
+++ b/packages/v2/gui/src/sak/meny/henlegg-behandling/MenyHenleggIndex.tsx
@@ -24,7 +24,7 @@ interface OwnProps {
   lukkModal: () => void;
   personopplysninger?: Personopplysninger;
   arbeidsgiverOpplysningerPerId?: ArbeidsgiverOversiktDto['arbeidsgivere'];
-  hentMottakere: () => Promise<Klagepart[]>;
+  hentMottakere: () => Promise<Klagepart[] | undefined | null>;
 }
 
 const MenyHenleggIndexV2 = ({
@@ -45,7 +45,10 @@ const MenyHenleggIndexV2 = ({
 
   const { data: brevmottakere } = useQuery<Klagepart[]>({
     queryKey: ['brevmottakere', behandlingId],
-    queryFn: hentMottakere,
+    queryFn: async () => {
+      // hentMottakere kan returnere undefined, som feiler i useQuery. Mapper derfor til tom array
+      return (await hentMottakere()) ?? [];
+    },
   });
 
   const submit = useCallback(

--- a/packages/v2/gui/src/sak/meny/henlegg-behandling/components/HenleggBehandlingModal.tsx
+++ b/packages/v2/gui/src/sak/meny/henlegg-behandling/components/HenleggBehandlingModal.tsx
@@ -199,10 +199,12 @@ export const HenleggBehandlingModal = ({
     } catch (e) {
       if (e instanceof AxiosError) {
         const msg = getBodyFeilmelding(e);
-        setSubmitErrorMsg(msg ?? '');
-      } else {
-        throw e;
+        if (msg != null) {
+          setSubmitErrorMsg(msg);
+          return;
+        }
       }
+      throw e;
     }
   };
 

--- a/packages/v2/gui/src/sak/meny/henlegg-behandling/components/HenleggBehandlingModal.tsx
+++ b/packages/v2/gui/src/sak/meny/henlegg-behandling/components/HenleggBehandlingModal.tsx
@@ -193,18 +193,15 @@ export const HenleggBehandlingModal = ({
   const valgtMottakerObjekt = brevmottakere?.find(mottaker => mottaker.identifikasjon.id === valgtMottaker);
 
   const submitWrapper: typeof handleSubmit = async formValues => {
+    setSubmitErrorMsg('');
     try {
       await handleSubmit(formValues);
     } catch (e) {
-      if (e instanceof AxiosError && e.status == 500) {
+      if (e instanceof AxiosError) {
         const msg = getBodyFeilmelding(e);
-        if (msg != null) {
-          setSubmitErrorMsg(msg);
-        } else {
-          setSubmitErrorMsg('');
-        }
+        setSubmitErrorMsg(msg ?? '');
       } else {
-        setSubmitErrorMsg('');
+        throw e;
       }
     }
   };

--- a/packages/v2/gui/src/sak/meny/henlegg-behandling/components/HenleggBehandlingModal.tsx
+++ b/packages/v2/gui/src/sak/meny/henlegg-behandling/components/HenleggBehandlingModal.tsx
@@ -6,7 +6,7 @@ import {
   type k9_sak_kontrakt_arbeidsforhold_ArbeidsgiverOversiktDto as ArbeidsgiverOversiktDto,
 } from '@k9-sak-web/backend/k9sak/generated/types.js';
 import { behandlingType as BehandlingTypeK9SAK } from '@k9-sak-web/backend/k9sak/kodeverk/behandling/BehandlingType.js';
-import { Bleed, Button, Detail, Fieldset, HGrid, Modal, VStack } from '@navikt/ds-react';
+import { Bleed, Button, Detail, Fieldset, HGrid, LocalAlert, Modal, VStack } from '@navikt/ds-react';
 import { RhfForm, RhfSelect, RhfTextarea } from '@navikt/ft-form-hooks';
 import { hasValidText, maxLength, required } from '@navikt/ft-form-validators';
 import { useMemo, useState } from 'react';
@@ -17,6 +17,8 @@ import Brevmottakere from './Brevmottakere';
 import dokumentMalType from './dokumentMalType';
 import styles from './henleggBehandlingModal.module.css';
 import type { HenleggBehandlingFormvalues } from './formValues';
+import { AxiosError } from 'axios';
+import { getBodyFeilmelding } from '../../../../app/errorhandling/ui/resolveAxiosErrorView.js';
 
 const maxLength1500 = maxLength(1500);
 
@@ -138,6 +140,7 @@ export const HenleggBehandlingModal = ({
   brevmottakere,
 }: HenleggBehandlingModalProps) => {
   const [isFetchingPreview, setIsFetchingPreview] = useState<boolean>(false);
+  const [submitErrorMsg, setSubmitErrorMsg] = useState<string>('');
 
   const previewHenleggBehandlingDoc =
     (
@@ -189,6 +192,23 @@ export const HenleggBehandlingModal = ({
 
   const valgtMottakerObjekt = brevmottakere?.find(mottaker => mottaker.identifikasjon.id === valgtMottaker);
 
+  const submitWrapper: typeof handleSubmit = async formValues => {
+    try {
+      await handleSubmit(formValues);
+    } catch (e) {
+      if (e instanceof AxiosError && e.status == 500) {
+        const msg = getBodyFeilmelding(e);
+        if (msg != null) {
+          setSubmitErrorMsg(msg);
+        } else {
+          setSubmitErrorMsg('');
+        }
+      } else {
+        setSubmitErrorMsg('');
+      }
+    }
+  };
+
   return (
     <Modal
       className={styles.modal}
@@ -202,7 +222,15 @@ export const HenleggBehandlingModal = ({
       }}
     >
       <Modal.Body>
-        <RhfForm<HenleggBehandlingFormvalues> formMethods={formMethods} onSubmit={handleSubmit}>
+        {submitErrorMsg.length > 0 && (
+          <LocalAlert status="error">
+            <LocalAlert.Header>
+              <LocalAlert.Title>Henleggelse feilet</LocalAlert.Title>
+            </LocalAlert.Header>
+            <LocalAlert.Content>{submitErrorMsg}</LocalAlert.Content>
+          </LocalAlert>
+        )}
+        <RhfForm<HenleggBehandlingFormvalues> formMethods={formMethods} onSubmit={submitWrapper}>
           <div>
             <Fieldset legend="Henlegg behandling" hideLegend>
               <VStack gap="space-16">


### PR DESCRIPTION
### Behov / Bakgrunn

Etter at default throwOnError vart satt true på useQuery feila eit kall ved lasting av dialog for henleggelse av sak fordi queryFn returnerte undefined, som ikkje er tillatt der.

Meldt som feil på FAGSYSTEM-437390, FAGSYSTEM-437315, FAGSYSTEM-437321.

Ser og at henleggelse av sak ikkje er støtta for feks PSB, så legger til betre inline visning av feil viss bruker prøver å henlegge sakstype som ikkje er støtta.

### Løsning

- Korrigert typing av hentMottakere kall.
- wrapper kall til hentMottakere i queryFn slik at det returnerast tom array istadenfor null/undefined.
- wrapper `handleSubmit`,  legger til visning av evt feil som oppstår i kallet (ved ugyldig sakstype feks) inni dialog, så dette blir tydleg å sjå for saksbehandler.

