### PR TITLE
Bug: Knapp for redigering av aksjonspunkt vises uten aktivt aksjonspunkt

### DIFF
--- a/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingFerdigvisning.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingFerdigvisning.tsx
@@ -24,9 +24,15 @@ interface InntektsmeldingFerdigvisningProps {
   tilstand: TilstandMedUiState;
   onEdit: () => void;
   readOnly: boolean;
+  harAksjonspunkt: boolean;
 }
 
-const InntektsmeldingFerdigvisning = ({ tilstand, onEdit, readOnly }: InntektsmeldingFerdigvisningProps) => {
+const InntektsmeldingFerdigvisning = ({
+  tilstand,
+  onEdit,
+  readOnly,
+  harAksjonspunkt,
+}: InntektsmeldingFerdigvisningProps) => {
   const config = tilstand.vurdering ? vurderingConfig[tilstand.vurdering] : null;
   if (!config) return null;
 
@@ -35,7 +41,7 @@ const InntektsmeldingFerdigvisning = ({ tilstand, onEdit, readOnly }: Inntektsme
       <Alert variant={config.variant} size="medium" className="mt-2">
         <div className="flex flex-col gap-4">
           <BodyShort>{config.melding}</BodyShort>
-          {!readOnly && (
+          {!readOnly && harAksjonspunkt && (
             <div>
               <Button variant="secondary" size="small" onClick={onEdit} icon={<PencilIcon />}>
                 Rediger vurdering

--- a/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingVurdering.tsx
+++ b/packages/v2/gui/src/fakta/inntektsmelding/ui/components/InntektsmeldingVurdering.tsx
@@ -43,7 +43,12 @@ const InntektsmeldingVurdering = ({
 
   if (skalViseFerdigvisning) {
     return (
-      <InntektsmeldingFerdigvisning tilstand={tilstand} onEdit={() => setRedigeringsmodus(true)} readOnly={readOnly} />
+      <InntektsmeldingFerdigvisning
+        tilstand={tilstand}
+        onEdit={() => setRedigeringsmodus(true)}
+        readOnly={readOnly}
+        harAksjonspunkt={!!aksjonspunkt}
+      />
     );
   }
 


### PR DESCRIPTION
### Behov / Bakgrunn
Knapp for redigering av vurdering på 9069 og 9071 i inntektsmelding vises selv om vi ikke har aksjonspunkt

### Løsning
sjekker om vi har aksjonspunkt

### Andre endringer

