### PR TITLE
Fiks manglande feilmelding for 418 feil.

### DIFF
--- a/packages/rest-api/src/requestApi/RequestRunner.ts
+++ b/packages/rest-api/src/requestApi/RequestRunner.ts
@@ -107,7 +107,13 @@ class RequestRunner {
       } catch (error) {
         const responseData = error.response ? error.response.data : undefined;
         if (responseData && hasLocationAndStatusDelayedOrHalted(responseData)) {
+          // Oppgåva er halted/delayed. Hent behandlinga frå location likevel, slik at den kan visast
           response = await this.httpClientApi.get(responseData.location);
+          // Rapporter i tillegg 418-feilen til den nye feilhandteringa (errorNotifier ->
+          // resolveErrorViewProps/resolveAxiosErrorView) slik at brukar får melding om halted/delayed.
+          // Den gamle POLLING_HALTED_OR_DELAYED-notifikasjonen under har ikkje lenger nokon konsument som viser
+          // melding til brukar, berre ein som skjuler «ventar»-indikatoren.
+          this.errorNotifier?.(error);
           if ('data' in response) {
             this.notify(EventType.POLLING_HALTED_OR_DELAYED, response.data.taskStatus);
           }

--- a/packages/v2/gui/src/app/errorhandling/ui/resolveAxiosErrorView.tsx
+++ b/packages/v2/gui/src/app/errorhandling/ui/resolveAxiosErrorView.tsx
@@ -173,8 +173,8 @@ export const resolveAxiosErrorView = (error: AxiosError): ErrorViewProps => {
     if (status === 'HALTED') {
       return {
         error,
-        title: 'Oi! Noe gikk galt',
-        errorInfo: 'Noe gikk galt, men feilen kan være midlertidig.',
+        title: 'Bakgrunnsprosess feilet',
+        errorInfo: 'Noe gikk galt i bakgrunnsprosess knyttet til saken. Feilen kan være midlertidig.',
         fixAction: {
           ...reloadAction,
           info: (

--- a/packages/v2/gui/src/app/errorhandling/ui/resolveAxiosErrorView.tsx
+++ b/packages/v2/gui/src/app/errorhandling/ui/resolveAxiosErrorView.tsx
@@ -202,9 +202,7 @@ export const resolveAxiosErrorView = (error: AxiosError): ErrorViewProps => {
           info: (
             <>
               <BodyLong>Prøv å laste siden på nytt.</BodyLong>
-              <BodyLong>
-                Sjekk driftsmeldinger eller rapporter feil i Porten, hvis den ikke løser seg etter hvert.
-              </BodyLong>
+              <BodyLong>Sjekk driftsmeldinger eller meld feil i Porten, hvis den ikke løser seg etter hvert.</BodyLong>
             </>
           ),
         },


### PR DESCRIPTION
### Behov / Bakgrunn

Når server svare med statuskode 418 til legacy RequestRunner vart ikkje feilmelding vist lenger pga feil i ny feilhandtering.

### Løsning

Legger til kall til errorNotifier også for denne feiltype.

### Andre endringer

Litt justeringer av tekst på feilmelding.
