### PR TITLE
Feature/meir info 500 feil

### DIFF
--- a/packages/utils/src/http-utils/axiosHttpUtils.ts
+++ b/packages/utils/src/http-utils/axiosHttpUtils.ts
@@ -2,6 +2,15 @@ import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
 import { addLegacySerializerOption } from '@k9-sak-web/gui/utils/axios/axiosUtils.js';
 import { blobToText, isOfTypeBlob } from '@k9-sak-web/gui/app/errorhandling/legacycompat/blobResponseHelper.js';
 import { BlobResponseAxiosError } from '@k9-sak-web/gui/app/errorhandling/legacycompat/BlobResponseAxiosError.js';
+import { generateNavCallidHeader } from '@k9-sak-web/backend/shared/instrumentation/navCallid.js';
+
+// Legg til Nav-Callid-header (i tillegg til legacy serializer-option) slik at forespørslar herifrå
+// kan sporast på tvers av tenester på lik linje med forespørslar via rest-api-klienten.
+const buildRequestConfig = (requestConfig?: AxiosRequestConfig): AxiosRequestConfig => {
+  const { headerName, headerValue } = generateNavCallidHeader();
+  const config = addLegacySerializerOption(requestConfig);
+  return { ...config, headers: { ...config.headers, [headerName]: headerValue } };
+};
 
 async function resolveErrorType(error: unknown): Promise<Error> {
   if (error instanceof AxiosError) {
@@ -31,7 +40,7 @@ export async function get<T>(
   requestConfig?: AxiosRequestConfig,
 ): Promise<T> {
   try {
-    const response: AxiosResponse<T> = await axios.get(url, addLegacySerializerOption(requestConfig));
+    const response: AxiosResponse<T> = await axios.get(url, buildRequestConfig(requestConfig));
     return response.data;
   } catch (error) {
     const resolved = await resolveErrorType(error);
@@ -47,7 +56,7 @@ export async function post<T>(
   requestConfig?: AxiosRequestConfig,
 ): Promise<any> {
   try {
-    const response: AxiosResponse = await axios.post(url, body, addLegacySerializerOption(requestConfig));
+    const response: AxiosResponse = await axios.post(url, body, buildRequestConfig(requestConfig));
     return response.data;
   } catch (error) {
     const resolved = await resolveErrorType(error);

--- a/packages/v2/gui/src/app/errorhandling/ui/makeErrorReportText.ts
+++ b/packages/v2/gui/src/app/errorhandling/ui/makeErrorReportText.ts
@@ -29,7 +29,7 @@ export const makeErrorReportText = (errors: ReadonlyArray<Error>): string => {
 };
 
 const makeErrorReportTextForJira = (errors: ReadonlyArray<Error>): string => {
-  const errLines = ['*Sett inn feilmelding/beskrivelse av problem her*', ...makeErrorReportLines(errors)];
+  const errLines = ['*Sett inn feilmelding/beskrivelse av problem her*', '->', ...makeErrorReportLines(errors)];
   return errLines.join('\\\\');
 };
 

--- a/packages/v2/gui/src/app/errorhandling/ui/resolveAxiosErrorView.tsx
+++ b/packages/v2/gui/src/app/errorhandling/ui/resolveAxiosErrorView.tsx
@@ -254,6 +254,24 @@ export const resolveAxiosErrorView = (error: AxiosError): ErrorViewProps => {
     };
   }
 
+  // 500 — intern serverfeil. Vis feilmelding frå server-responsen viss tilgjengeleg.
+  if (status === 500) {
+    const feilmelding = getBodyFeilmelding(error);
+    const harFeilmelding = feilmelding != null && feilmelding.trim().length > 5;
+
+    const errorInfo = harFeilmelding ? (
+      <BodyLong>{feilmelding}</BodyLong>
+    ) : (
+      <BodyLong>Systemet feilet ved behandling av forespørsel</BodyLong>
+    );
+    return {
+      error,
+      title: 'Forespørsel feilet',
+      errorInfo,
+      fixAction: reloadAction,
+    };
+  }
+
   // Ingen response (typisk nettverksfeil / CORS / avbrutt).
   if (error.response == null) {
     return {


### PR DESCRIPTION
### Behov / Bakgrunn

Ny feilhandtering viste ikkje feilmelding frå server for generelle 500 feil, sidan det var mykje unødvendig tekst med ny feilvisning.

I ein del tilfeller har 500 feil returnert frå server  informasjon om feil som har oppstått som kan vere nyttig for bruker å sjå, så det var problematisk å fjerne visning av dette. 

### Løsning

Viser feilmelding frå server. Har fjerna unødvendig ekstra tekst som vart returnert frå server, så dette vil forhåpentlegvis fungere bra.

### Andre endringer

Det vart oppdaga at nokre kall mangla nav-callid header. Fikser derfor dette problemet.

Legger og til ei linje med "->" teikn i forhåndsutfyllt tekstfelt ved melding av sak i porten, slik at det skal vere enklare for melder å skrive inn feilmelding/problembeskrivelse over forhåndsutfylt teknisk info. 

