### PR TITLE
Innleggelsesperioder PILS: Ekskluderer allerede godkjente, eksisterende perioder på validator for innenfor søknadsperioden

### DIFF
--- a/packages/fakta-medisinsk-vilkår/src/ui/components/innleggelsesperiodeFormModal/InnleggelsesperiodeFormModal.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/innleggelsesperiodeFormModal/InnleggelsesperiodeFormModal.tsx
@@ -171,6 +171,10 @@ const InnleggelsesperiodeFormModal = ({
                     if (!innleggelsesperiodeBegrensning?.sammenhengendePerioder?.length) return null;
                     const { fom, tom } = periodValue;
                     if (!fom || !tom) return null;
+                    const erEksisterendePeriode = defaultValues[FieldName.INNLEGGELSESPERIODER].some(
+                      eksisterende => eksisterende.fom === fom && eksisterende.tom === tom,
+                    );
+                    if (erEksisterendePeriode) return null;
                     const period = new Period(fom, tom);
                     const erInnenfor = innleggelsesperiodeBegrensning.sammenhengendePerioder.some(sp => sp.covers(period));
                     if (!erInnenfor) {


### PR DESCRIPTION
### Behov / Bakgrunn
https://nav.atlassian.net/browse/TSFF-2645

Hvis det allerede eksisterte en periode med innleggelse i forrige søknadsperiode feilet validatoren (innenfor søknadsperiode) for denne søknadsperioden. Ekskluderer nå innleggelsesperioder som allerede er godkjente fra tidligere søknadsperioder og gjør bare sjekken på nye perioder som legges til.

