### PR TITLE
build(deps): oppgrader @navikt/ung-sak-typescript-client

### DIFF
--- a/packages/v2/backend/package.json
+++ b/packages/v2/backend/package.json
@@ -19,7 +19,7 @@
     "@navikt/k9-klage-typescript-client": "3.1.20260629130445",
     "@navikt/k9-sak-typescript-client": "3.0.20260703123027",
     "@navikt/k9-tilbake-typescript-client": "1.1.20260510232128",
-    "@navikt/ung-sak-typescript-client": "2.0.20260708074719",
+    "@navikt/ung-sak-typescript-client": "2.0.20260709143150",
     "@navikt/ung-tilbake-typescript-client": "3.0.20260519143823"
   }
 }

--- a/packages/v2/gui/src/utils/formaterVisningsnavn.spec.ts
+++ b/packages/v2/gui/src/utils/formaterVisningsnavn.spec.ts
@@ -61,10 +61,21 @@ describe('formaterVisningsnavn', () => {
     });
   });
 
-  describe('når visningsnavn er OPPHØR_OPPHEVET', () => {
+  describe('når visningsnavn er UNGDOMSPROGRAM_OPPHØR_OPPHEVET', () => {
     it('skal returnere "Opphør opphevet"', () => {
-      const result = formaterVisningsnavn(ung_sak_kontrakt_behandling_BehandlingVisningsnavn.OPPHØR_OPPHEVET);
+      const result = formaterVisningsnavn(
+        ung_sak_kontrakt_behandling_BehandlingVisningsnavn.UNGDOMSPROGRAM_OPPHØR_OPPHEVET,
+      );
       expect(result).toBe('Opphør opphevet');
+    });
+  });
+
+  describe('når visningsnavn er UNGDOMSPROGRAM_OPPHØR_MOTTATT_OG_AVBRUTT_I_SAMME_BEHANDLING', () => {
+    it('skal returnere "Ungdomsprogram opphør mottatt og avbrutt i samme behandling"', () => {
+      const result = formaterVisningsnavn(
+        ung_sak_kontrakt_behandling_BehandlingVisningsnavn.UNGDOMSPROGRAM_OPPHØR_MOTTATT_OG_AVBRUTT_I_SAMME_BEHANDLING,
+      );
+      expect(result).toBe('Ungdomsprogram opphør mottatt og avbrutt i samme behandling');
     });
   });
 

--- a/packages/v2/gui/src/utils/formaterVisningsnavn.spec.ts
+++ b/packages/v2/gui/src/utils/formaterVisningsnavn.spec.ts
@@ -62,20 +62,20 @@ describe('formaterVisningsnavn', () => {
   });
 
   describe('når visningsnavn er UNGDOMSPROGRAM_OPPHØR_OPPHEVET', () => {
-    it('skal returnere "Opphør opphevet"', () => {
+    it('skal returnere "Ungdomsprogramopphør opphevet"', () => {
       const result = formaterVisningsnavn(
         ung_sak_kontrakt_behandling_BehandlingVisningsnavn.UNGDOMSPROGRAM_OPPHØR_OPPHEVET,
       );
-      expect(result).toBe('Opphør opphevet');
+      expect(result).toBe('Ungdomsprogramopphør opphevet');
     });
   });
 
   describe('når visningsnavn er UNGDOMSPROGRAM_OPPHØR_MOTTATT_OG_AVBRUTT_I_SAMME_BEHANDLING', () => {
-    it('skal returnere "Ungdomsprogram opphør mottatt og avbrutt i samme behandling"', () => {
+    it('skal returnere "Ungdomsprogramopphør avbrutt"', () => {
       const result = formaterVisningsnavn(
         ung_sak_kontrakt_behandling_BehandlingVisningsnavn.UNGDOMSPROGRAM_OPPHØR_MOTTATT_OG_AVBRUTT_I_SAMME_BEHANDLING,
       );
-      expect(result).toBe('Ungdomsprogram opphør mottatt og avbrutt i samme behandling');
+      expect(result).toBe('Ungdomsprogramopphør avbrutt');
     });
   });
 

--- a/packages/v2/gui/src/utils/formaterVisningsnavn.ts
+++ b/packages/v2/gui/src/utils/formaterVisningsnavn.ts
@@ -22,8 +22,10 @@ export const formaterVisningsnavn = (
       return 'Ungdomsprogramendring';
     case ung_sak_kontrakt_behandling_BehandlingVisningsnavn.OPPHØR_VED_MAKSDATO:
       return 'Opphør ved maksdato';
-    case ung_sak_kontrakt_behandling_BehandlingVisningsnavn.OPPHØR_OPPHEVET:
+    case ung_sak_kontrakt_behandling_BehandlingVisningsnavn.UNGDOMSPROGRAM_OPPHØR_OPPHEVET:
       return 'Opphør opphevet';
+    case ung_sak_kontrakt_behandling_BehandlingVisningsnavn.UNGDOMSPROGRAM_OPPHØR_MOTTATT_OG_AVBRUTT_I_SAMME_BEHANDLING:
+      return 'Opphør avbrutt';
     case ung_sak_kontrakt_behandling_BehandlingVisningsnavn.FLERE_BEHANDLINGÅRSAKER:
       return 'Flere behandlingsårsaker';
     default: {

--- a/packages/v2/gui/src/utils/formaterVisningsnavn.ts
+++ b/packages/v2/gui/src/utils/formaterVisningsnavn.ts
@@ -23,9 +23,9 @@ export const formaterVisningsnavn = (
     case ung_sak_kontrakt_behandling_BehandlingVisningsnavn.OPPHØR_VED_MAKSDATO:
       return 'Opphør ved maksdato';
     case ung_sak_kontrakt_behandling_BehandlingVisningsnavn.UNGDOMSPROGRAM_OPPHØR_OPPHEVET:
-      return 'Opphør opphevet';
+      return 'Ungdomsprogramopphør opphevet';
     case ung_sak_kontrakt_behandling_BehandlingVisningsnavn.UNGDOMSPROGRAM_OPPHØR_MOTTATT_OG_AVBRUTT_I_SAMME_BEHANDLING:
-      return 'Opphør avbrutt';
+      return 'Ungdomsprogramopphør avbrutt';
     case ung_sak_kontrakt_behandling_BehandlingVisningsnavn.FLERE_BEHANDLINGÅRSAKER:
       return 'Flere behandlingsårsaker';
     default: {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2184,7 +2184,7 @@ __metadata:
     "@navikt/k9-klage-typescript-client": "npm:3.1.20260629130445"
     "@navikt/k9-sak-typescript-client": "npm:3.0.20260703123027"
     "@navikt/k9-tilbake-typescript-client": "npm:1.1.20260510232128"
-    "@navikt/ung-sak-typescript-client": "npm:2.0.20260708074719"
+    "@navikt/ung-sak-typescript-client": "npm:2.0.20260709143150"
     "@navikt/ung-tilbake-typescript-client": "npm:3.0.20260519143823"
   languageName: unknown
   linkType: soft
@@ -3562,10 +3562,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@navikt/ung-sak-typescript-client@npm:2.0.20260708074719":
-  version: 2.0.20260708074719
-  resolution: "@navikt/ung-sak-typescript-client@npm:2.0.20260708074719::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fung-sak-typescript-client%2F2.0.20260708074719%2F9df560ef1a8a05b2d6f411b6f64bae41950d8f0b"
-  checksum: 10/873799426b355ddc80b198ed8d8711ba0fa3cb8442f8e143250222fd43d24ed51fbd07b5aacf50e5d56746b84fcf59b0f31c7d94b30e6a33d8a6519a8fffb7af
+"@navikt/ung-sak-typescript-client@npm:2.0.20260709143150":
+  version: 2.0.20260709143150
+  resolution: "@navikt/ung-sak-typescript-client@npm:2.0.20260709143150::__archiveUrl=https%3A%2F%2Fnpm.pkg.github.com%2Fdownload%2F%40navikt%2Fung-sak-typescript-client%2F2.0.20260709143150%2Ff929832b9c0f6cd1a1a0ab2ab36338eb5b254a80"
+  checksum: 10/9c0336ed9c21d18099029ecca5f043d894b7bdfcd4afa5fa90864c0b8cc9addc29d92c12ccd79346ffb526fc62946cb7256b3a5bb0219fe160ac3064f5b2afd7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
### Behov / Bakgrunn

@navikt/ung-sak-typescript-client hadde en nyere versjon (2.0.20260709143150) med endringer i enumet BehandlingVisningsnavn som ikke var støttet i k9-sak-web.

### Løsning

- Oppgradert @navikt/ung-sak-typescript-client fra 2.0.20260708074719 til 2.0.20260709143150 (package.json + yarn.lock)
- Lagt til støtte for ny verdi UNGDOMSPROGRAM_OPPHØR_MOTTATT_OG_AVBRUTT_I_SAMME_BEHANDLING i formaterVisningsnavn
- Oppdatert case for omdøpt verdi OPPHØR_OPPHEVET → UNGDOMSPROGRAM_OPPHØR_OPPHEVET

