### PR TITLE
Fix visningsnavn for aktivitetstyper i uttak gradering

### DIFF
--- a/packages/v2/backend/src/k9sak/kodeverk/uttak/UttakArbeidType.ts
+++ b/packages/v2/backend/src/k9sak/kodeverk/uttak/UttakArbeidType.ts
@@ -1,0 +1,8 @@
+import {
+  type k9_kodeverk_uttak_UttakArbeidType as typeUnion,
+  k9_kodeverk_uttak_UttakArbeidType as enumObj,
+} from '../../generated/types.js';
+
+export type UttakArbeidType = typeUnion;
+
+export const UttakArbeidType = enumObj;

--- a/packages/v2/backend/src/k9sak/kontrakt/uttak/InntektgraderingPeriodeDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/uttak/InntektgraderingPeriodeDto.ts
@@ -1,0 +1,1 @@
+export type { k9_sak_kontrakt_uttak_inntektgradering_InntektgraderingPeriodeDto as InntektgraderingPeriodeDto } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/uttak/Utbetalingsgrader.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/uttak/Utbetalingsgrader.ts
@@ -1,0 +1,1 @@
+export type { pleiepengerbarn_uttak_kontrakter_Utbetalingsgrader as Utbetalingsgrader } from '../../generated/types.js';

--- a/packages/v2/backend/src/k9sak/kontrakt/uttak/UttaksperiodeInfo.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/uttak/UttaksperiodeInfo.ts
@@ -1,0 +1,1 @@
+export type { pleiepengerbarn_uttak_kontrakter_UttaksperiodeInfo as UttaksperiodeInfo } from '../../generated/types.js';

--- a/packages/v2/gui/src/prosess/uttak/Uttak.stories.tsx
+++ b/packages/v2/gui/src/prosess/uttak/Uttak.stories.tsx
@@ -1,10 +1,12 @@
 import { BehandlingProvider } from '@k9-sak-web/gui/context/BehandlingContext.js';
 import { withFakeUttakBackend } from '@k9-sak-web/gui/storybook/decorators/withFakeUttakBackend.js';
 import {
+  defaultArbeidsgivere,
   arbeidsgivereWithTilkommet,
   Endringsstatus,
   FagsakYtelseType,
   inntektsgraderingFlereArbeidsgivere,
+  lagInntektgraderingPeriodeDto,
   lagAvsluttetBehandling,
   lagIkkeOppfyltPeriode,
   lagInntektsgraderingPeriode,
@@ -279,6 +281,91 @@ export const UttakGradertMotInntekt: Story = {
 };
 
 /**
+ * UttakGradertMedUlikeAktivitetstyper
+ *
+ * Viser at aktivitetstyper uten arbeidsgiver vises med navn i stedet for fallback-tekst.
+ */
+export const UttakGradertMedUlikeAktivitetstyper: Story = {
+  decorators: [
+    withFakeUttakBackend({
+      arbeidsgivere: defaultArbeidsgivere,
+      inntektsgraderinger: {
+        perioder: [
+          lagInntektgraderingPeriodeDto(
+            '2024-03-01/2024-03-15',
+            [
+              {
+                arbeidsgiverIdentifikator: '123456789',
+                arbeidstidprosent: 0,
+                bruttoInntekt: 500000,
+                erNytt: false,
+                type: 'AT',
+              },
+              {
+                arbeidstidprosent: 100,
+                bruttoInntekt: 200000,
+                erNytt: false,
+                type: 'SN',
+              },
+              {
+                arbeidstidprosent: 50,
+                bruttoInntekt: 100000,
+                erNytt: false,
+                type: 'FL',
+              },
+              {
+                arbeidstidprosent: 100,
+                bruttoInntekt: 150000,
+                erNytt: false,
+                type: 'DP',
+              },
+            ],
+            950000,
+          ),
+        ],
+      },
+    }),
+  ],
+  args: {
+    behandling: lagUtredBehandling(),
+    uttak: lagUttak([
+      lagOppfyltPeriode('2024-03-01/2024-03-15', {
+        uttaksgrad: 58,
+        søkersTapteArbeidstid: 52,
+        årsaker: [Årsak.AVKORTET_MOT_INNTEKT],
+        utbetalingsgrader: [
+          {
+            arbeidsforhold: { type: 'AT', organisasjonsnummer: '123456789' },
+            normalArbeidstid: 'PT7H30M',
+            faktiskArbeidstid: 'PT0S',
+            utbetalingsgrad: 100,
+            tilkommet: false,
+          },
+          {
+            arbeidsforhold: { type: 'SN' },
+            normalArbeidstid: 'PT7H30M',
+            faktiskArbeidstid: 'PT7H30M',
+            utbetalingsgrad: 0,
+            tilkommet: false,
+          },
+          {
+            arbeidsforhold: { type: 'FL' },
+            normalArbeidstid: 'PT5H',
+            faktiskArbeidstid: 'PT2H30M',
+            utbetalingsgrad: 50,
+            tilkommet: false,
+          },
+        ],
+      }),
+    ]),
+    erOverstyrer: false,
+    aksjonspunkter: [],
+    relevanteAksjonspunkter: relevanteAksjonspunkterAlle,
+    readOnly: false,
+  },
+};
+
+/**
  * UttakGradertMotTilsyn
  *
  * Viser perioder med gradering mot tilsyn
@@ -490,4 +577,3 @@ export const UttakPleiepengerNærstående: Story = {
     });
   },
 };
-

--- a/packages/v2/gui/src/prosess/uttak/Uttak.stories.tsx
+++ b/packages/v2/gui/src/prosess/uttak/Uttak.stories.tsx
@@ -302,6 +302,13 @@ export const UttakGradertMedUlikeAktivitetstyper: Story = {
                 type: 'AT',
               },
               {
+                arbeidsgiverIdentifikator: '123456789',
+                arbeidstidprosent: 100,
+                bruttoInntekt: 175000,
+                erNytt: false,
+                type: 'IKKE_YRKESAKTIV',
+              },
+              {
                 arbeidstidprosent: 100,
                 bruttoInntekt: 200000,
                 erNytt: false,
@@ -346,6 +353,13 @@ export const UttakGradertMedUlikeAktivitetstyper: Story = {
             normalArbeidstid: 'PT7H30M',
             faktiskArbeidstid: 'PT7H30M',
             utbetalingsgrad: 0,
+            tilkommet: false,
+          },
+          {
+            arbeidsforhold: { type: 'IKKE_YRKESAKTIV', organisasjonsnummer: '123456789' },
+            normalArbeidstid: 'PT8H',
+            faktiskArbeidstid: 'PT0S',
+            utbetalingsgrad: 100,
             tilkommet: false,
           },
           {

--- a/packages/v2/gui/src/prosess/uttak/constants/Arbeidstype.ts
+++ b/packages/v2/gui/src/prosess/uttak/constants/Arbeidstype.ts
@@ -1,6 +1,6 @@
-import type { k9_kodeverk_uttak_UttakArbeidType } from '@k9-sak-web/backend/k9sak/generated/types.js';
+import type { UttakArbeidType } from '@k9-sak-web/backend/k9sak/kodeverk/uttak/UttakArbeidType.js';
 
-export const arbeidstypeTilVisning: Record<k9_kodeverk_uttak_UttakArbeidType, string> = {
+export const arbeidstypeTilVisning: Record<UttakArbeidType, string> = {
   AT: 'Arbeidstaker',
   FL: 'Frilanser',
   DP: 'Dagpenger',

--- a/packages/v2/gui/src/prosess/uttak/utils/aktivitetVisning.test.ts
+++ b/packages/v2/gui/src/prosess/uttak/utils/aktivitetVisning.test.ts
@@ -19,6 +19,10 @@ describe('aktivitetVisning', () => {
     await expect(utledAktivitetVisningsnavn('DP', undefined, arbeidsgivere)).toBe('Dagpenger');
   });
 
+  it('behandler ikke prototype-egenskaper som gyldige aktivitetstyper', async () => {
+    await expect(utledAktivitetVisningsnavn('toString', undefined, arbeidsgivere)).toBe('Mangler navn');
+  });
+
   it('viser arbeidsgivernavn for arbeidstaker', async () => {
     await expect(utledAktivitetVisningsnavn('AT', '123', arbeidsgivere)).toBe('BEDRIFT AS (123)');
   });

--- a/packages/v2/gui/src/prosess/uttak/utils/aktivitetVisning.test.ts
+++ b/packages/v2/gui/src/prosess/uttak/utils/aktivitetVisning.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import type { ArbeidsgiverOversiktDto } from '@k9-sak-web/backend/combined/kontrakt/arbeidsgiver/ArbeidsgiverOversiktDto.js';
+import { utledAktivitetVisningsnavn, utledArbeidsgiverNavn } from './aktivitetVisning';
+
+const arbeidsgivere = {
+  '123': {
+    navn: 'BEDRIFT AS',
+    identifikator: '123',
+    arbeidsforholdreferanser: [],
+  },
+} as ArbeidsgiverOversiktDto['arbeidsgivere'];
+
+describe('aktivitetVisning', () => {
+  it('viser ikke arbeidsgiverlinje når backend ikke sender identifikator', async () => {
+    await expect(utledArbeidsgiverNavn(undefined, arbeidsgivere)).toBeUndefined();
+  });
+
+  it('viser aktivitetstype for dagpenger uten arbeidsgiver', async () => {
+    await expect(utledAktivitetVisningsnavn('DP', undefined, arbeidsgivere)).toBe('Dagpenger');
+  });
+
+  it('viser arbeidsgivernavn for arbeidstaker', async () => {
+    await expect(utledAktivitetVisningsnavn('AT', '123', arbeidsgivere)).toBe('BEDRIFT AS (123)');
+  });
+
+  it('beholder eksisterende fallback for arbeidstaker uten arbeidsgivernavn', async () => {
+    await expect(utledAktivitetVisningsnavn('AT', '999', arbeidsgivere)).toBe('Mangler navn (999)');
+  });
+
+  it('viser arbeidsgivernavn også for ikke yrkesaktiv når backend sender identifikator', async () => {
+    await expect(utledAktivitetVisningsnavn('IKKE_YRKESAKTIV', '123', arbeidsgivere)).toBe('BEDRIFT AS (123)');
+  });
+});

--- a/packages/v2/gui/src/prosess/uttak/utils/aktivitetVisning.test.ts
+++ b/packages/v2/gui/src/prosess/uttak/utils/aktivitetVisning.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { ArbeidsgiverOversiktDto } from '@k9-sak-web/backend/combined/kontrakt/arbeidsgiver/ArbeidsgiverOversiktDto.js';
-import { utledAktivitetVisningsnavn, utledArbeidsgiverNavn } from './aktivitetVisning';
+import { utledAktivitetVisningsnavn, utledArbeidsgiverNavn, utledArbeidstypeVisningsnavn } from './aktivitetVisning';
 
 const arbeidsgivere = {
   '123': {
@@ -17,6 +17,10 @@ describe('aktivitetVisning', () => {
 
   it('viser aktivitetstype for dagpenger uten arbeidsgiver', async () => {
     await expect(utledAktivitetVisningsnavn('DP', undefined, arbeidsgivere)).toBe('Dagpenger');
+  });
+
+  it('viser aktivitetstype for ikke yrkesaktiv', async () => {
+    await expect(utledArbeidstypeVisningsnavn('IKKE_YRKESAKTIV')).toBe('Ikke yrkesaktiv');
   });
 
   it('behandler ikke prototype-egenskaper som gyldige aktivitetstyper', async () => {

--- a/packages/v2/gui/src/prosess/uttak/utils/aktivitetVisning.ts
+++ b/packages/v2/gui/src/prosess/uttak/utils/aktivitetVisning.ts
@@ -3,7 +3,8 @@ import { arbeidstypeTilVisning } from '../constants/Arbeidstype';
 
 type UttakArbeidType = keyof typeof arbeidstypeTilVisning;
 
-const erKjentArbeidstype = (type: string): type is UttakArbeidType => type in arbeidstypeTilVisning;
+const erKjentArbeidstype = (type: string): type is UttakArbeidType =>
+  Object.prototype.hasOwnProperty.call(arbeidstypeTilVisning, type);
 
 const formatArbeidsgiverNavn = (navn?: string, identifikator?: string): string | undefined => {
   if (navn && identifikator) {

--- a/packages/v2/gui/src/prosess/uttak/utils/aktivitetVisning.ts
+++ b/packages/v2/gui/src/prosess/uttak/utils/aktivitetVisning.ts
@@ -50,3 +50,11 @@ export const utledAktivitetVisningsnavn = (
 
   return 'Mangler navn';
 };
+
+export const utledArbeidstypeVisningsnavn = (type: string | null | undefined): string | undefined => {
+  if (type && erKjentArbeidstype(type)) {
+    return arbeidstypeTilVisning[type];
+  }
+
+  return undefined;
+};

--- a/packages/v2/gui/src/prosess/uttak/utils/aktivitetVisning.ts
+++ b/packages/v2/gui/src/prosess/uttak/utils/aktivitetVisning.ts
@@ -1,0 +1,51 @@
+import type { ArbeidsgiverOversiktDto } from '@k9-sak-web/backend/combined/kontrakt/arbeidsgiver/ArbeidsgiverOversiktDto.js';
+import { arbeidstypeTilVisning } from '../constants/Arbeidstype';
+
+type UttakArbeidType = keyof typeof arbeidstypeTilVisning;
+
+const erKjentArbeidstype = (type: string): type is UttakArbeidType => type in arbeidstypeTilVisning;
+
+const formatArbeidsgiverNavn = (navn?: string, identifikator?: string): string | undefined => {
+  if (navn && identifikator) {
+    return `${navn} (${identifikator})`;
+  }
+  if (navn) {
+    return navn;
+  }
+  if (identifikator) {
+    return `Mangler navn (${identifikator})`;
+  }
+  return undefined;
+};
+
+export const utledArbeidsgiverNavn = (
+  arbeidsgiverIdentifikator: string | null | undefined,
+  arbeidsgivere: ArbeidsgiverOversiktDto['arbeidsgivere'] | undefined,
+): string | undefined => {
+  if (!arbeidsgiverIdentifikator) {
+    return undefined;
+  }
+
+  const arbeidsforholdData = arbeidsgivere?.[arbeidsgiverIdentifikator];
+  return formatArbeidsgiverNavn(
+    arbeidsforholdData?.navn,
+    arbeidsforholdData?.identifikator || arbeidsgiverIdentifikator || undefined,
+  );
+};
+
+export const utledAktivitetVisningsnavn = (
+  type: string | null | undefined,
+  arbeidsgiverIdentifikator: string | null | undefined,
+  arbeidsgivere: ArbeidsgiverOversiktDto['arbeidsgivere'] | undefined,
+): string => {
+  const arbeidsgiverNavn = utledArbeidsgiverNavn(arbeidsgiverIdentifikator, arbeidsgivere);
+  if (arbeidsgiverNavn) {
+    return arbeidsgiverNavn;
+  }
+
+  if (type && erKjentArbeidstype(type)) {
+    return arbeidstypeTilVisning[type];
+  }
+
+  return 'Mangler navn';
+};

--- a/packages/v2/gui/src/prosess/uttak/uttak-detaljer/GraderingMotArbeidstidDetaljer.tsx
+++ b/packages/v2/gui/src/prosess/uttak/uttak-detaljer/GraderingMotArbeidstidDetaljer.tsx
@@ -1,13 +1,12 @@
 import type { FC } from 'react';
 import { BodyShort, Box, Detail, HelpText, HStack, Tag, VStack } from '@navikt/ds-react';
-import {
-  k9_kodeverk_uttak_UttakArbeidType as UttakArbeidsforholdType,
-  type pleiepengerbarn_uttak_kontrakter_Utbetalingsgrader as Utbetalingsgrader,
-  type pleiepengerbarn_uttak_kontrakter_UttaksperiodeInfo as UttaksperiodeInfo,
-} from '@k9-sak-web/backend/k9sak/generated/types.js';
+import type { UttakArbeidType as UttakArbeidsforholdType } from '@k9-sak-web/backend/k9sak/kodeverk/uttak/UttakArbeidType.js';
+import type { Utbetalingsgrader } from '@k9-sak-web/backend/k9sak/kontrakt/uttak/Utbetalingsgrader.js';
+import type { UttaksperiodeInfo } from '@k9-sak-web/backend/k9sak/kontrakt/uttak/UttaksperiodeInfo.js';
 import { beregnDagerTimer } from '@k9-sak-web/gui/utils/formatters.js';
 import { arbeidstypeTilVisning } from '../constants/Arbeidstype';
 import { useUttakContext } from '../context/UttakContext';
+import { utledArbeidsgiverNavn } from '../utils/aktivitetVisning';
 import styles from './uttakDetaljer.module.css';
 
 interface ownProps {
@@ -34,7 +33,6 @@ const GraderingMotArbeidstidDetaljer: FC<ownProps> = ({ utbetalingsgrader, søke
         {utbetalingsgrader.map(utbetalingsgradItem => {
           const arbeidsgiverIdentifikator =
             utbetalingsgradItem?.arbeidsforhold?.aktørId || utbetalingsgradItem?.arbeidsforhold?.organisasjonsnummer;
-          const arbeidsforholdData = arbeidsgiverIdentifikator ? arbeidsgivere?.[arbeidsgiverIdentifikator] : undefined;
           const { normalArbeidstid, faktiskArbeidstid, arbeidsforhold } = utbetalingsgradItem;
           const beregnetNormalArbeidstid = normalArbeidstid ? beregnDagerTimer(normalArbeidstid) : '-';
           const beregnetFaktiskArbeidstid = faktiskArbeidstid ? beregnDagerTimer(faktiskArbeidstid) : '-';
@@ -47,10 +45,11 @@ const GraderingMotArbeidstidDetaljer: FC<ownProps> = ({ utbetalingsgrader, søke
           const arbeidstype = arbeidsforhold?.type
             ? arbeidstypeTilVisning[arbeidsforhold?.type as UttakArbeidsforholdType]
             : undefined;
+          const arbeidsgiverNavn = utledArbeidsgiverNavn(arbeidsgiverIdentifikator, arbeidsgivere);
           const erNyInntekt = utbetalingsgradItem?.tilkommet;
 
           return (
-            <Box key={`${arbeidsgiverIdentifikator}_avkorting_arbeidstid`}>
+            <Box key={`${arbeidsforhold?.type ?? 'ukjent'}_${arbeidsgiverIdentifikator ?? 'uten-id'}_avkorting_arbeidstid`}>
               <BodyShort size="small" className="text-ax-text-neutral-subtle font-semibold leading-6">
                 {arbeidstype}{' '}
                 {erNyInntekt && (
@@ -59,10 +58,9 @@ const GraderingMotArbeidstidDetaljer: FC<ownProps> = ({ utbetalingsgrader, søke
                   </Tag>
                 )}
               </BodyShort>
-              {arbeidsforhold?.type !== UttakArbeidsforholdType.FRILANSER && (
+              {arbeidsgiverNavn && (
                 <BodyShort size="small" weight="semibold" className="leading-6">
-                  {arbeidsforholdData?.navn || 'Mangler navn'} (
-                  {arbeidsforholdData?.identifikator || arbeidsgiverIdentifikator})
+                  {arbeidsgiverNavn}
                 </BodyShort>
               )}
               <BodyShort size="small" className="leading-6">

--- a/packages/v2/gui/src/prosess/uttak/uttak-detaljer/GraderingMotInntektDetaljer.tsx
+++ b/packages/v2/gui/src/prosess/uttak/uttak-detaljer/GraderingMotInntektDetaljer.tsx
@@ -35,11 +35,10 @@ const GraderingMotInntektDetaljer: FC<ownProps> = ({ inntektsgradering }) => {
     const aktivitetVisningsnavn = utledAktivitetVisningsnavn(type, arbeidsgiverIdentifikator, arbeidsgivere);
     const arbeidsgiverNavn = utledArbeidsgiverNavn(arbeidsgiverIdentifikator, arbeidsgivere);
     const arbeidstype = utledArbeidstypeVisningsnavn(type);
-    const visArbeidstypeOverArbeidsgiver = !!arbeidsgiverNavn && !!arbeidstype && type !== 'AT';
 
-    if (visArbeidstypeOverArbeidsgiver) {
-      return (
-        <>
+    return (
+      <>
+        {arbeidstype && (
           <BodyShort size="small" className="text-ax-text-neutral-subtle font-semibold leading-6">
             {arbeidstype}{' '}
             {erNytt && (
@@ -48,22 +47,24 @@ const GraderingMotInntektDetaljer: FC<ownProps> = ({ inntektsgradering }) => {
               </Tag>
             )}
           </BodyShort>
+        )}
+        {arbeidsgiverNavn ? (
           <BodyShort size="small" weight="semibold" className="leading-6">
             {arbeidsgiverNavn}
           </BodyShort>
-        </>
-      );
-    }
-
-    return (
-      <BodyShort size="small" weight="semibold" className="leading-6">
-        {aktivitetVisningsnavn}{' '}
-        {erNytt && (
-          <Tag data-color="info" size="small" variant="outline">
-            Ny
-          </Tag>
+        ) : (
+          !arbeidstype && (
+            <BodyShort size="small" weight="semibold" className="leading-6">
+              {aktivitetVisningsnavn}{' '}
+              {erNytt && (
+                <Tag data-color="info" size="small" variant="outline">
+                  Ny
+                </Tag>
+              )}
+            </BodyShort>
+          )
         )}
-      </BodyShort>
+      </>
     );
   };
 

--- a/packages/v2/gui/src/prosess/uttak/uttak-detaljer/GraderingMotInntektDetaljer.tsx
+++ b/packages/v2/gui/src/prosess/uttak/uttak-detaljer/GraderingMotInntektDetaljer.tsx
@@ -4,7 +4,7 @@ import type { InntektgraderingPeriodeDto } from '@k9-sak-web/backend/k9sak/kontr
 import { tilNOK } from '@k9-sak-web/gui/utils/formatters.js';
 import UttakDetaljerEkspanderbar from './UttakDetaljerEkspanderbar';
 import { useUttakContext } from '../context/UttakContext';
-import { utledAktivitetVisningsnavn } from '../utils/aktivitetVisning';
+import { utledAktivitetVisningsnavn, utledArbeidsgiverNavn, utledArbeidstypeVisningsnavn } from '../utils/aktivitetVisning';
 import styles from './uttakDetaljer.module.css';
 
 interface ownProps {
@@ -27,6 +27,46 @@ const GraderingMotInntektDetaljer: FC<ownProps> = ({ inntektsgradering }) => {
   const løpendeInntekt = formatNOK(inntektsgradering.løpendeInntekt);
   const bortfaltInntekt = formatNOK(inntektsgradering.bortfaltInntekt);
 
+  const renderAktivitetHeader = (
+    type: string | null | undefined,
+    arbeidsgiverIdentifikator: string | null | undefined,
+    erNytt: boolean,
+  ) => {
+    const aktivitetVisningsnavn = utledAktivitetVisningsnavn(type, arbeidsgiverIdentifikator, arbeidsgivere);
+    const arbeidsgiverNavn = utledArbeidsgiverNavn(arbeidsgiverIdentifikator, arbeidsgivere);
+    const arbeidstype = utledArbeidstypeVisningsnavn(type);
+    const visArbeidstypeOverArbeidsgiver = !!arbeidsgiverNavn && !!arbeidstype && type !== 'AT';
+
+    if (visArbeidstypeOverArbeidsgiver) {
+      return (
+        <>
+          <BodyShort size="small" className="text-ax-text-neutral-subtle font-semibold leading-6">
+            {arbeidstype}{' '}
+            {erNytt && (
+              <Tag data-color="info" size="small" variant="outline">
+                Ny
+              </Tag>
+            )}
+          </BodyShort>
+          <BodyShort size="small" weight="semibold" className="leading-6">
+            {arbeidsgiverNavn}
+          </BodyShort>
+        </>
+      );
+    }
+
+    return (
+      <BodyShort size="small" weight="semibold" className="leading-6">
+        {aktivitetVisningsnavn}{' '}
+        {erNytt && (
+          <Tag data-color="info" size="small" variant="outline">
+            Ny
+          </Tag>
+        )}
+      </BodyShort>
+    );
+  };
+
   return (
     <VStack className={`${styles.uttakDetaljerDetailItem} mt-2`}>
       <UttakDetaljerEkspanderbar title={`Beregningsgrunnlag: ${beregningsgrunnlag}`}>
@@ -40,14 +80,7 @@ const GraderingMotInntektDetaljer: FC<ownProps> = ({ inntektsgradering }) => {
                 key={`${type ?? 'ukjent'}_${arbeidsgiverIdentifikator ?? 'uten-id'}_avkorting_inntekt_grunnlag`}
                 className={styles.uttakDetaljerBeregningFirma}
               >
-                <BodyShort size="small" weight="semibold" className="leading-6">
-                  {utledAktivitetVisningsnavn(type, arbeidsgiverIdentifikator, arbeidsgivere)}{' '}
-                  {inntForhold.erNytt && (
-                    <Tag data-color="info" size="small" variant="outline">
-                      Ny
-                    </Tag>
-                  )}
-                </BodyShort>
+                {renderAktivitetHeader(type, arbeidsgiverIdentifikator, inntForhold.erNytt)}
                 <BodyShort size="small">Inntekt: {formatNOK(inntForhold.bruttoInntekt)}</BodyShort>
               </Box>
             );
@@ -59,14 +92,7 @@ const GraderingMotInntektDetaljer: FC<ownProps> = ({ inntektsgradering }) => {
           return (
             <Fragment key={`${type ?? 'ukjent'}_${arbeidsgiverIdentifikator ?? 'uten-id'}_avkorting_inntekt_utbetalt`}>
               <Box className={styles.uttakDetaljerBeregningFirma}>
-                <BodyShort size="small" weight="semibold">
-                  {utledAktivitetVisningsnavn(type, arbeidsgiverIdentifikator, arbeidsgivere)}{' '}
-                  {inntForhold.erNytt && (
-                    <Tag data-color="info" size="small" variant="outline">
-                      Ny
-                    </Tag>
-                  )}
-                </BodyShort>
+                {renderAktivitetHeader(type, arbeidsgiverIdentifikator, inntForhold.erNytt)}
                 <BodyShort className="leading-6" size="small">
                   Inntekt: {formatNOK(inntForhold.bruttoInntekt)}
                 </BodyShort>

--- a/packages/v2/gui/src/prosess/uttak/uttak-detaljer/GraderingMotInntektDetaljer.tsx
+++ b/packages/v2/gui/src/prosess/uttak/uttak-detaljer/GraderingMotInntektDetaljer.tsx
@@ -1,12 +1,10 @@
 import { Fragment, type FC } from 'react';
 import { BodyShort, Box, Tag, VStack } from '@navikt/ds-react';
-import {
-  k9_kodeverk_uttak_UttakArbeidType as InntektsforholdDtoType,
-  type k9_sak_kontrakt_uttak_inntektgradering_InntektgraderingPeriodeDto as InntektgraderingPeriodeDto,
-} from '@k9-sak-web/backend/k9sak/generated/types.js';
+import type { InntektgraderingPeriodeDto } from '@k9-sak-web/backend/k9sak/kontrakt/uttak/InntektgraderingPeriodeDto.js';
 import { tilNOK } from '@k9-sak-web/gui/utils/formatters.js';
 import UttakDetaljerEkspanderbar from './UttakDetaljerEkspanderbar';
 import { useUttakContext } from '../context/UttakContext';
+import { utledAktivitetVisningsnavn } from '../utils/aktivitetVisning';
 import styles from './uttakDetaljer.module.css';
 
 interface ownProps {
@@ -36,20 +34,14 @@ const GraderingMotInntektDetaljer: FC<ownProps> = ({ inntektsgradering }) => {
           // Ikke vise tilkommende inntekstforhold i beregningsgrunnlag
           .filter(inntForhold => !inntForhold.erNytt)
           .map(inntForhold => {
-            const { arbeidsgiverIdentifikator } = inntForhold;
-            const arbeidsforholdData =
-              arbeidsgiverIdentifikator && arbeidsgivere && !Array.isArray(arbeidsgivere)
-                ? arbeidsgivere[arbeidsgiverIdentifikator]
-                : undefined;
+            const { arbeidsgiverIdentifikator, type } = inntForhold;
             return (
               <Box
-                key={`${arbeidsgiverIdentifikator}_avkorting_inntekt_grunnlag`}
+                key={`${type ?? 'ukjent'}_${arbeidsgiverIdentifikator ?? 'uten-id'}_avkorting_inntekt_grunnlag`}
                 className={styles.uttakDetaljerBeregningFirma}
               >
                 <BodyShort size="small" weight="semibold" className="leading-6">
-                  {inntForhold.type !== InntektsforholdDtoType.FRILANSER
-                    ? `${arbeidsforholdData?.navn || 'Mangler navn'} (${arbeidsforholdData?.identifikator || arbeidsgiverIdentifikator})`
-                    : 'Frilanser'}{' '}
+                  {utledAktivitetVisningsnavn(type, arbeidsgiverIdentifikator, arbeidsgivere)}{' '}
                   {inntForhold.erNytt && (
                     <Tag data-color="info" size="small" variant="outline">
                       Ny
@@ -63,18 +55,12 @@ const GraderingMotInntektDetaljer: FC<ownProps> = ({ inntektsgradering }) => {
       </UttakDetaljerEkspanderbar>
       <UttakDetaljerEkspanderbar title={`Utbetalt lønn: ${løpendeInntekt}`}>
         {inntektsforhold.map(inntForhold => {
-          const { arbeidsgiverIdentifikator } = inntForhold;
-          const arbeidsforholdData =
-            arbeidsgiverIdentifikator && arbeidsgivere && !Array.isArray(arbeidsgivere)
-              ? arbeidsgivere[arbeidsgiverIdentifikator]
-              : undefined;
+          const { arbeidsgiverIdentifikator, type } = inntForhold;
           return (
-            <Fragment key={`${arbeidsgiverIdentifikator}_avkorting_inntekt_utbetalt`}>
+            <Fragment key={`${type ?? 'ukjent'}_${arbeidsgiverIdentifikator ?? 'uten-id'}_avkorting_inntekt_utbetalt`}>
               <Box className={styles.uttakDetaljerBeregningFirma}>
                 <BodyShort size="small" weight="semibold">
-                  {inntForhold.type !== InntektsforholdDtoType.FRILANSER
-                    ? `${arbeidsforholdData?.navn || 'Mangler navn'} (${arbeidsforholdData?.identifikator || arbeidsgiverIdentifikator})`
-                    : 'Frilanser'}{' '}
+                  {utledAktivitetVisningsnavn(type, arbeidsgiverIdentifikator, arbeidsgivere)}{' '}
                   {inntForhold.erNytt && (
                     <Tag data-color="info" size="small" variant="outline">
                       Ny


### PR DESCRIPTION
### Behov / Bakgrunn

Ved gradering i uttak ble aktivitetstyper uten arbeidsgiver vist med fallback-tekst som `Mangler navn`.

Dette gjaldt både gradering mot arbeidstid og gradering mot arbeidsinntekt, selv om backend leverte aktivitetstype som kunne vises med et forståelig navn, for eksempel `Selvstendig næringsdrivende`, `Frilanser` og `Dagpenger`.

https://jira.adeo.no/browse/FAGSYSTEM-438682
### Løsning

- lagt til en felles helper for å utlede visningsnavn for aktiviteter i uttak
- viser arbeidsgivernavn når arbeidsgiveridentifikator finnes
- viser label for aktivitetstype når aktiviteten ikke har arbeidsgiver
- Justert visningen slik at samme logikk brukes i både gradering mot arbeidstid og gradering mot arbeidsinntekt.
- tatt i bruk stabile re-eksporter fra `packages/v2/backend` i stedet for direkte import fra genererte typer
- lagt til enhetstester for visningslogikken

### Andre endringer

- lagt til en Storybook story som viser aktivitetstyper med og uten arbeidsgiver i uttak

