### PR TITLE
Vis revurdert omsorgsperiode i redigeringsmodus

### DIFF
--- a/loosely-type-checked-files.json
+++ b/loosely-type-checked-files.json
@@ -169,7 +169,6 @@
   "packages/fakta-omsorgen-for/src/ui/OmsorgenForContainer.tsx",
   "packages/fakta-omsorgen-for/src/ui/components/fosterbarn/Fosterbarn.tsx",
   "packages/fakta-omsorgen-for/src/ui/components/omsorgsperiodeoversikt/Omsorgsperiodeoversikt.tsx",
-  "packages/fakta-omsorgen-for/src/ui/components/periodenavigasjon/Periodenavigasjon.tsx",
   "packages/fakta-omsorgen-for/src/ui/components/vurdering-av-omsorgsperioder-form/VurderingAvOmsorgsperioderForm.tsx",
   "packages/fakta-omsorgen-for/src/ui/reducer.ts",
   "packages/fakta-omsorgen-for/src/util/hooks.ts",

--- a/packages/fakta-omsorgen-for/mock/mocked-data/mockedOmsorgsperioder.ts
+++ b/packages/fakta-omsorgen-for/mock/mocked-data/mockedOmsorgsperioder.ts
@@ -7,6 +7,7 @@ const mockedOmsorgsperioder = {
       resultat: 'IKKE_VURDERT',
       resultatEtterAutomatikk: 'IKKE_VURDERT',
       begrunnelse: '',
+      readOnly: false,
     },
     {
       periode: { fom: '2023-07-01', tom: '2023-12-31' },
@@ -15,6 +16,7 @@ const mockedOmsorgsperioder = {
       resultat: 'IKKE_VURDERT',
       resultatEtterAutomatikk: 'IKKE_VURDERT',
       begrunnelse: '',
+      readOnly: false,
     },
   ],
   registrertSammeBosted: true,
@@ -33,6 +35,7 @@ export const mockedOmsorgsperioderVurdert = {
       begrunnelse: 'Bekreftet omsorgsrelasjon.',
       vurdertAv: 'Z123456',
       vurdertTidspunkt: '2023-07-01T10:00:00',
+      readOnly: true,
     },
   ],
   registrertSammeBosted: true,

--- a/packages/fakta-omsorgen-for/src/types/Omsorgsperiode.ts
+++ b/packages/fakta-omsorgen-for/src/types/Omsorgsperiode.ts
@@ -18,8 +18,6 @@ class Omsorgsperiode {
 
   vurdertTidspunkt?: string;
 
-  readOnly?: boolean;
-
   skalTvingesTilManuellVurdering?: boolean;
 
   constructor({
@@ -31,7 +29,6 @@ class Omsorgsperiode {
     relasjon,
     vurdertAv,
     vurdertTidspunkt,
-    readOnly,
     skalTvingesTilManuellVurdering,
   }: Partial<Omsorgsperiode>) {
     this.periode = new Period(periode.fom, periode.tom);
@@ -42,7 +39,6 @@ class Omsorgsperiode {
     this.relasjon = relasjon ? relasjon[0].toUpperCase() + relasjon.slice(1).toLowerCase() : '';
     this.vurdertAv = vurdertAv;
     this.vurdertTidspunkt = vurdertTidspunkt;
-    this.readOnly = readOnly;
     this.skalTvingesTilManuellVurdering = skalTvingesTilManuellVurdering;
   }
 

--- a/packages/fakta-omsorgen-for/src/types/Omsorgsperiode.ts
+++ b/packages/fakta-omsorgen-for/src/types/Omsorgsperiode.ts
@@ -18,6 +18,10 @@ class Omsorgsperiode {
 
   vurdertTidspunkt?: string;
 
+  readOnly?: boolean;
+
+  skalTvingesTilManuellVurdering?: boolean;
+
   constructor({
     periode,
     resultatEtterAutomatikk,
@@ -27,6 +31,8 @@ class Omsorgsperiode {
     relasjon,
     vurdertAv,
     vurdertTidspunkt,
+    readOnly,
+    skalTvingesTilManuellVurdering,
   }: Partial<Omsorgsperiode>) {
     this.periode = new Period(periode.fom, periode.tom);
     this.resultatEtterAutomatikk = resultatEtterAutomatikk;
@@ -36,6 +42,8 @@ class Omsorgsperiode {
     this.relasjon = relasjon ? relasjon[0].toUpperCase() + relasjon.slice(1).toLowerCase() : '';
     this.vurdertAv = vurdertAv;
     this.vurdertTidspunkt = vurdertTidspunkt;
+    this.readOnly = readOnly;
+    this.skalTvingesTilManuellVurdering = skalTvingesTilManuellVurdering;
   }
 
   erOppfylt(): boolean {
@@ -69,6 +77,10 @@ class Omsorgsperiode {
       this.resultat === Vurderingsresultat.IKKE_VURDERT &&
       this.resultatEtterAutomatikk === Vurderingsresultat.IKKE_VURDERT
     );
+  }
+
+  skalVisesIRedigeringsmodus(): boolean {
+    return this.manglerVurdering() || !!this.skalTvingesTilManuellVurdering;
   }
 
   hentResultat(): Vurderingsresultat {

--- a/packages/fakta-omsorgen-for/src/types/Omsorgsperiodeoversikt.ts
+++ b/packages/fakta-omsorgen-for/src/types/Omsorgsperiodeoversikt.ts
@@ -33,6 +33,10 @@ class Omsorgsperiodeoversikt {
   finnPerioderTilVurdering(): Omsorgsperiode[] {
     return this.perioder.filter(omsorgsperiode => omsorgsperiode.manglerVurdering());
   }
+
+  finnRedigerbarePerioder(): Omsorgsperiode[] {
+    return this.perioder.filter(omsorgsperiode => omsorgsperiode.skalVisesIRedigeringsmodus());
+  }
 }
 
 export default Omsorgsperiodeoversikt;

--- a/packages/fakta-omsorgen-for/src/ui/components/omsorgsperiodeoversikt/Omsorgsperiodeoversikt.tsx
+++ b/packages/fakta-omsorgen-for/src/ui/components/omsorgsperiodeoversikt/Omsorgsperiodeoversikt.tsx
@@ -1,7 +1,7 @@
 import { fagsakYtelsesType } from '@k9-sak-web/backend/k9sak/kodeverk/FagsakYtelsesType.js';
 import { NavigationWithDetailView } from '@k9-sak-web/gui/shared/navigation-with-detail-view/NavigationWithDetailView.js';
 import hash from 'object-hash';
-import React, { useEffect, type JSX } from 'react';
+import React, { type JSX, useEffect } from 'react';
 import Omsorgsperiode from '../../../types/Omsorgsperiode';
 import OmsorgsperiodeoversiktType from '../../../types/Omsorgsperiodeoversikt';
 import { useOmsorgenForContext } from '../../context/ContainerContext';
@@ -30,8 +30,9 @@ const Omsorgsperiodeoversikt = ({ omsorgsperiodeoversikt }: Omsorgsperiodeoversi
   };
 
   useEffect(() => {
-    if (omsorgsperiodeoversikt.harPerioderTilVurdering()) {
-      setValgtPeriode(perioderTilVurdering[0]);
+    const [førstePeriodeTilRedigering] = omsorgsperiodeoversikt.finnRedigerbarePerioder();
+    if (førstePeriodeTilRedigering) {
+      setValgtPeriode(førstePeriodeTilRedigering);
     }
   }, []);
 
@@ -45,12 +46,12 @@ const Omsorgsperiodeoversikt = ({ omsorgsperiodeoversikt }: Omsorgsperiodeoversi
             perioderTilVurdering={perioderTilVurdering}
             vurdertePerioder={vurderteOmsorgsperioder}
             onPeriodeValgt={velgPeriode}
-            harValgtPeriode={valgtPeriode !== null}
+            valgtPeriode={valgtPeriode}
           />
         )}
         showDetailSection={!!valgtPeriode}
         detailSection={() => {
-          if (perioderTilVurdering.includes(valgtPeriode) || erRedigeringsmodus) {
+          if (valgtPeriode?.skalVisesIRedigeringsmodus() || erRedigeringsmodus) {
             return (
               <VurderingAvOmsorgsperioderForm
                 key={hash(valgtPeriode)}

--- a/packages/fakta-omsorgen-for/src/ui/components/periodenavigasjon/Periodenavigasjon.tsx
+++ b/packages/fakta-omsorgen-for/src/ui/components/periodenavigasjon/Periodenavigasjon.tsx
@@ -1,9 +1,8 @@
 import { Period } from '@fpsak-frontend/utils';
 import { Box, Heading } from '@navikt/ds-react';
 import { InteractiveList } from '@navikt/ft-plattform-komponenter';
-import React, { useEffect, type JSX } from 'react';
+import React, { type JSX, useEffect } from 'react';
 import Omsorgsperiode from '../../../types/Omsorgsperiode';
-import { usePrevious } from '../../../util/hooks';
 import { sortPeriodsByFomDate } from '../../../util/periodUtils';
 import PeriodeSomSkalVurderes from '../periode-som-skal-vurderes/PeriodeSomSkalVurderes';
 import VurderingsperiodeElement from '../vurderingsperiode/VurderingsperiodeElement';
@@ -12,44 +11,44 @@ import styles from './periodenavigasjon.module.css';
 interface PeriodenavigasjonProps {
   perioderTilVurdering: Omsorgsperiode[];
   vurdertePerioder: Omsorgsperiode[];
+  valgtPeriode: Omsorgsperiode | null;
   onPeriodeValgt: (periode: Omsorgsperiode) => void;
-  harValgtPeriode?: boolean;
 }
 
 const Periodenavigasjon = ({
   perioderTilVurdering,
   vurdertePerioder,
+  valgtPeriode,
   onPeriodeValgt,
-  harValgtPeriode,
 }: PeriodenavigasjonProps): JSX.Element => {
-  const harPerioderSomSkalVurderes = perioderTilVurdering?.length > 0;
-  const [activeIndex, setActiveIndex] = React.useState(harPerioderSomSkalVurderes ? 0 : -1);
-  const previousHarValgtPeriode = usePrevious(harValgtPeriode);
+  const listeContainerRef = React.useRef<HTMLDivElement>(null);
 
-  useEffect(() => {
-    if (harValgtPeriode === false && previousHarValgtPeriode === true) {
-      setActiveIndex(-1);
-    }
-  }, [harValgtPeriode]);
+  const vurdertePerioderSortert = [...vurdertePerioder].sort((op1, op2) => {
+    const omsorgsperiode1 = new Period(op1.periode.fom, op1.periode.tom);
+    const omsorgsperiode2 = new Period(op2.periode.fom, op2.periode.tom);
+    return sortPeriodsByFomDate(omsorgsperiode1, omsorgsperiode2);
+  });
 
-  const vurdertePerioderElements = vurdertePerioder
-    .sort((op1, op2) => {
-      const omsorgsperiode1 = new Period(op1.periode.fom, op1.periode.tom);
-      const omsorgsperiode2 = new Period(op2.periode.fom, op2.periode.tom);
-      return sortPeriodsByFomDate(omsorgsperiode1, omsorgsperiode2);
-    })
-    .map(omsorgsperiode => {
-      const { periode } = omsorgsperiode;
-      return <VurderingsperiodeElement periode={periode} resultat={omsorgsperiode.hentResultat()} />;
-    });
+  const vurdertePerioderElements = vurdertePerioderSortert.map(omsorgsperiode => {
+    const { periode } = omsorgsperiode;
+    return <VurderingsperiodeElement periode={periode} resultat={omsorgsperiode.hentResultat()} />;
+  });
 
   const periodeTilVurderingElements = perioderTilVurdering.map(({ periode }) => (
     <PeriodeSomSkalVurderes periode={periode} />
   ));
 
-  const perioder = [...perioderTilVurdering, ...vurdertePerioder];
+  const perioder = [...perioderTilVurdering, ...vurdertePerioderSortert];
   const elements = [...periodeTilVurderingElements, ...vurdertePerioderElements];
   const antallPerioder = elements.length;
+  const activeIndex = valgtPeriode ? perioder.indexOf(valgtPeriode) : -1;
+
+  useEffect(() => {
+    if (activeIndex >= 0) {
+      const aktivKnapp = listeContainerRef.current?.querySelectorAll('button')[activeIndex];
+      aktivKnapp?.focus();
+    }
+  }, [activeIndex]);
 
   return (
     <div className={styles.vurderingsnavigasjon}>
@@ -60,14 +59,13 @@ const Periodenavigasjon = ({
       </Box>
       {antallPerioder === 0 && <p>Ingen vurderinger å vise</p>}
       {antallPerioder > 0 && (
-        <div className={styles.vurderingsvelgerContainer}>
+        <div className={styles.vurderingsvelgerContainer} ref={listeContainerRef}>
           <InteractiveList
             elements={elements.map((element, currentIndex) => ({
               content: element,
               active: activeIndex === currentIndex,
               key: `${currentIndex}`,
               onClick: () => {
-                setActiveIndex(currentIndex);
                 const periodeIndex = elements.indexOf(element);
                 onPeriodeValgt(perioder[periodeIndex]);
               },


### PR DESCRIPTION
### Behov / Bakgrunn

[TSFF-2721](https://nav.atlassian.net/browse/TSFF-2721)

Vi ønsker at dersom omsorgsvilkåret revurderes som del av manuell revurdering, skal periode under vurdering åpne i redigeringsmodus, heller enn lesemodus. https://github.com/navikt/k9-sak/pull/13133 introduserer et felt i `omsorgsperiode` som utledes basert på hvorvidt perioden er under vurdering, og sender dette til frontend.

### Løsning

Benytt nytt felt for å vurdere om en periode skal redigeres.

### Andre endringer

Endrer omsorgsperiodeoversikten slik at relevant periode velges om initielt valg i oversikten, og åpner første periode under vurdering.