### PR TITLE
Opptjening ved 8-47 bokstav a og bokstav b skal også vise grønn og oppfylt opptjening

### DIFF
--- a/packages/v2/gui/src/prosess/vilkar-opptjening/components/OpptjeningVilkarAksjonspunktPanel.tsx
+++ b/packages/v2/gui/src/prosess/vilkar-opptjening/components/OpptjeningVilkarAksjonspunktPanel.tsx
@@ -172,7 +172,7 @@ export const OpptjeningVilkarAksjonspunktPanel = ({
         isAksjonspunktOpen={skalKunneEndreOpptjening}
         isDirty={formMethods.formState.isDirty}
         readOnly={readOnly || !field?.vurderesIBehandlingen}
-        originalErVilkarOk={field?.kode === 'OPPFYLT'}
+        originalErVilkarOk={field?.kode !== undefined ? erVilkarOk(field.kode) : undefined}
         aksjonspunktErLøst={aksjonspunktErLøst}
         lovReferanse={lovReferanse}
         behandlingId={behandlingId}


### PR DESCRIPTION
### Behov / Bakgrunn
Viser feilaktig avslag på opptjening når man har valgt § 8-47 bokstav a eller b

