### PR TITLE
Fix: retter visningsbugs i prosessmeny v2

### DIFF
--- a/packages/behandling-pleiepenger/src/prosess/api/Prosessmotor.spec.tsx
+++ b/packages/behandling-pleiepenger/src/prosess/api/Prosessmotor.spec.tsx
@@ -2,6 +2,7 @@ import { aksjonspunktStatus, AksjonspunktStatus } from '@k9-sak-web/backend/k9sa
 import { AksjonspunktDefinisjon } from '@k9-sak-web/backend/k9sak/kodeverk/behandling/aksjonspunkt/AksjonspunktDefinisjon.js';
 import { vilkårStatus } from '@k9-sak-web/backend/k9sak/kodeverk/behandling/VilkårStatus.js';
 import { vilkarType } from '@k9-sak-web/backend/k9sak/kodeverk/behandling/VilkårType.js';
+import { createQueryClient } from '@k9-sak-web/gui/shared/query/queryClient.js';
 import { FakeK9SakProsessApi } from '@k9-sak-web/gui/storybook/mocks/FakeK9SakProsessApi.js';
 import { ProcessMenuStepType } from '@navikt/ft-plattform-komponenter';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -15,7 +16,6 @@ import {
   beregnVedtakType,
   useProsessmotor,
 } from './Prosessmotor';
-import { createQueryClient } from '@k9-sak-web/gui/shared/query/queryClient.js';
 
 const createWrapper =
   (queryClient: QueryClient) =>
@@ -38,11 +38,11 @@ const lagAksjonspunkt = (
 describe('useProsessmotor', () => {
   let queryClient: QueryClient;
 
-    beforeEach(() => {
-      queryClient = createQueryClient({
-        queries: { retry: false },
-      });
+  beforeEach(() => {
+    queryClient = createQueryClient({
+      queries: { retry: false },
     });
+  });
 
   test('returnerer alle 8 paneler med korrekte id-er', async () => {
     const api = new FakeK9SakProsessApi();
@@ -196,6 +196,116 @@ describe('useProsessmotor', () => {
     await waitFor(() => {
       expect(result.current[4].type).toBe(ProcessMenuStepType.danger);
       expect(result.current[6].type).toBe(ProcessMenuStepType.warning);
+    });
+  });
+
+  test('setter opptjening til danger når vilkår er delvis oppfylt', async () => {
+    const api = new FakeK9SakProsessApi({
+      vilkår: [
+        {
+          vilkarType: vilkarType.SØKNADSFRIST,
+          perioder: [
+            { vilkarStatus: vilkårStatus.OPPFYLT, periode: { fom: '', tom: '' }, vurderesIBehandlingen: true },
+          ],
+          relevanteInnvilgetMerknader: [],
+        },
+        {
+          vilkarType: vilkarType.ALDERSVILKÅR,
+          perioder: [
+            { vilkarStatus: vilkårStatus.OPPFYLT, periode: { fom: '', tom: '' }, vurderesIBehandlingen: true },
+          ],
+          relevanteInnvilgetMerknader: [],
+        },
+        {
+          vilkarType: vilkarType.OMSORGEN_FOR,
+          perioder: [
+            { vilkarStatus: vilkårStatus.OPPFYLT, periode: { fom: '', tom: '' }, vurderesIBehandlingen: true },
+          ],
+          relevanteInnvilgetMerknader: [],
+        },
+        {
+          vilkarType: vilkarType.MEDISINSKEVILKÅR_UNDER_18_ÅR,
+          perioder: [
+            { vilkarStatus: vilkårStatus.OPPFYLT, periode: { fom: '', tom: '' }, vurderesIBehandlingen: true },
+          ],
+          relevanteInnvilgetMerknader: [],
+        },
+        {
+          vilkarType: vilkarType.MEDLEMSKAPSVILKÅRET,
+          perioder: [
+            { vilkarStatus: vilkårStatus.OPPFYLT, periode: { fom: '', tom: '' }, vurderesIBehandlingen: true },
+            { vilkarStatus: vilkårStatus.IKKE_OPPFYLT, periode: { fom: '', tom: '' }, vurderesIBehandlingen: true },
+          ],
+          relevanteInnvilgetMerknader: [],
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useProsessmotor({ api, behandling: createMockBehandling() }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current[2].id).toBe('opptjening');
+      expect(result.current[2].type).toBe(ProcessMenuStepType.danger);
+      expect(result.current[2]).toHaveProperty('erVurdert', true);
+      expect(result.current[2].usePartialStatus).toBe(false);
+    });
+  });
+
+  test('skjuler simulering når tilkjent ytelse ikke er vurdert og uttak ikke er avslått', async () => {
+    const api = new FakeK9SakProsessApi({
+      uttak: {
+        uttaksplan: {
+          perioder: {
+            '2024-01-01/2024-01-31': { utfall: vilkårStatus.OPPFYLT },
+          },
+        },
+        simulertUttaksplan: {},
+      },
+      simuleringResultat: {
+        simuleringResultat: { periode: { fom: '', tom: '' } },
+        simuleringResultatUtenInntrekk: { periode: { fom: '', tom: '' } },
+        slåttAvInntrekk: false,
+      },
+    });
+
+    const { result } = renderHook(() => useProsessmotor({ api, behandling: createMockBehandling() }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current[4].type).toBe(ProcessMenuStepType.success);
+      expect(result.current[5].type).toBe(ProcessMenuStepType.default);
+      expect(result.current[5]).toHaveProperty('erVurdert', false);
+      expect(result.current[6].type).toBe(ProcessMenuStepType.default);
+    });
+  });
+
+  test('viser delvis vedtak-status når resultat er innvilget og vilkår er både oppfylt og ikke oppfylt', async () => {
+    const api = new FakeK9SakProsessApi({
+      vilkår: [
+        {
+          vilkarType: vilkarType.SØKNADSFRIST,
+          perioder: [{ vilkarStatus: vilkårStatus.OPPFYLT, periode: { fom: '', tom: '' } }],
+          relevanteInnvilgetMerknader: [],
+        },
+        {
+          vilkarType: vilkarType.ALDERSVILKÅR,
+          perioder: [{ vilkarStatus: vilkårStatus.IKKE_OPPFYLT, periode: { fom: '', tom: '' } }],
+          relevanteInnvilgetMerknader: [],
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useProsessmotor({ api, behandling: createMockBehandling() }), {
+      wrapper: createWrapper(queryClient),
+    });
+
+    await waitFor(() => {
+      expect(result.current[7].id).toBe('vedtak');
+      expect(result.current[7].type).toBe(ProcessMenuStepType.success);
+      expect(result.current[7].usePartialStatus).toBe(true);
     });
   });
 });
@@ -474,6 +584,17 @@ describe('beregnVedtakType', () => {
   test('returnerer default når behandlingsresultat mangler type', () => {
     expect(
       beregnVedtakType([lagVilkår(vilkårStatus.OPPFYLT)] as any, [], lagBehandling() as any, vedtakAksjonspunkter),
+    ).toBe(ProcessMenuStepType.default);
+  });
+
+  test('returnerer default når overstyring av beregning er åpent', () => {
+    expect(
+      beregnVedtakType(
+        [lagVilkår(vilkårStatus.OPPFYLT)] as any,
+        [lagAksjonspunkt(AksjonspunktDefinisjon.OVERSTYRING_AV_BEREGNING)],
+        lagBehandling('INNVILGET') as any,
+        vedtakAksjonspunkter,
+      ),
     ).toBe(ProcessMenuStepType.default);
   });
 });

--- a/packages/behandling-pleiepenger/src/prosess/api/Prosessmotor.ts
+++ b/packages/behandling-pleiepenger/src/prosess/api/Prosessmotor.ts
@@ -155,6 +155,18 @@ const byggVilkårPanel = (
   };
 };
 
+const byggInngangsvilkårFortsetterPanel = (
+  skalVisePanel: boolean | undefined,
+  vilkår: VilkårMedPerioderDto[],
+  aksjonspunkter: AksjonspunktDto[],
+): ProcessMenuStep => {
+  const panel = byggVilkårPanel(skalVisePanel, vilkår, PANEL_KONFIG.opptjening, aksjonspunkter);
+  if (panel.usePartialStatus) {
+    return { ...panel, type: ProcessMenuStepType.danger, erVurdert: true };
+  }
+  return panel;
+};
+
 // Hjelpefunksjon for å beregne uttak-status
 export const beregnUttakType = (
   aksjonspunkter: AksjonspunktDto[],
@@ -315,15 +327,14 @@ export const useProsessmotor = ({ api, behandling }: ProsessmotorProps) => {
 
     const sykdomPanel = byggVilkårPanel(inngangsvilkårPanel.erVurdert, vilkår, PANEL_KONFIG.sykdom, aksjonspunkter);
 
-    const inngangsvilkårFortsetterPanel = byggVilkårPanel(
+    const inngangsvilkårFortsetterPanel = byggInngangsvilkårFortsetterPanel(
       sykdomPanel.erVurdert,
       vilkår,
-      PANEL_KONFIG.opptjening,
       aksjonspunkter,
     );
 
     const beregningPanel = byggVilkårPanel(
-      inngangsvilkårFortsetterPanel.erVurdert,
+      inngangsvilkårFortsetterPanel.type === ProcessMenuStepType.success,
       vilkår,
       PANEL_KONFIG.beregning,
       aksjonspunkter,
@@ -338,7 +349,7 @@ export const useProsessmotor = ({ api, behandling }: ProsessmotorProps) => {
     );
 
     const tilkjentYtelsePanel = byggPanelUtenVilkår(
-      uttakPanel.erVurdert && uttakPanel.type !== ProcessMenuStepType.danger,
+      beregningsresultatUtbetaling != null && uttakPanel.erVurdert && uttakPanel.type !== ProcessMenuStepType.danger,
       beregnTilkjentYtelseType(beregningsresultatUtbetaling, PANEL_KONFIG.tilkjentYtelse, aksjonspunkter),
       PANEL_KONFIG.tilkjentYtelse.label,
       PANEL_KONFIG.tilkjentYtelse.id,
@@ -356,7 +367,8 @@ export const useProsessmotor = ({ api, behandling }: ProsessmotorProps) => {
       id: PANEL_KONFIG.vedtak.id,
       label: PANEL_KONFIG.vedtak.label,
       type: vedtakType,
-      usePartialStatus: skalViseDelvisVedtakStatus(vedtakType, vilkår),
+      usePartialStatus:
+        vedtakType === ProcessMenuStepType.success ? skalViseDelvisVedtakStatus(vedtakType, vilkår) : false,
     };
 
     return [

--- a/packages/behandling-pleiepenger/src/prosess/api/Prosessmotor.ts
+++ b/packages/behandling-pleiepenger/src/prosess/api/Prosessmotor.ts
@@ -162,7 +162,7 @@ const byggInngangsvilkårFortsetterPanel = (
 ): ProcessMenuStep => {
   const panel = byggVilkårPanel(skalVisePanel, vilkår, PANEL_KONFIG.opptjening, aksjonspunkter);
   if (panel.usePartialStatus) {
-    return { ...panel, type: ProcessMenuStepType.danger, erVurdert: true };
+    return { ...panel, type: ProcessMenuStepType.danger, usePartialStatus: false };
   }
   return panel;
 };

--- a/packages/behandling-pleiepenger/src/prosess/inngangsvilkårFortsetterPaneler/OpptjeningProsessStegInitPanel.tsx
+++ b/packages/behandling-pleiepenger/src/prosess/inngangsvilkårFortsetterPaneler/OpptjeningProsessStegInitPanel.tsx
@@ -47,20 +47,24 @@ export function OpptjeningProsessStegInitPanel(props: Props) {
 
   const skalVisePanel = vilkårForSteg.length > 0;
 
-  const erAlleVilkårVurdert = vilkårForSteg.every(vilkar =>
-    vilkar.perioder?.every(periode => periode.vilkarStatus !== 'IKKE_VURDERT'),
-  );
-
-  const relevanteAksjonspunkter = props.aksjonspunkter?.filter(
+  const relevanteVurderingsAksjonspunkter = props.aksjonspunkter?.filter(
     ap => ap.definisjon === AksjonspunktDefinisjon.VURDER_OPPTJENINGSVILKÅRET,
   );
 
-  const isAksjonspunktOpen = relevanteAksjonspunkter.some(
+  const relevanteOverstyringsAksjonspunkter = props.aksjonspunkter?.filter(
+    ap => ap.definisjon === AksjonspunktDefinisjon.OVERSTYRING_AV_OPPTJENINGSVILKÅRET,
+  );
+
+  const isAksjonspunktOpen = relevanteVurderingsAksjonspunkter.some(
     ap => ap.status === k9_kodeverk_behandling_aksjonspunkt_AksjonspunktStatus.OPPRETTET,
   );
 
-  const handleSubmit = async (data: any) => {
-    return props.submitCallback(data, relevanteAksjonspunkter);
+  const handleSubmitVurdering = async (data: any) => {
+    return props.submitCallback(data, relevanteVurderingsAksjonspunkter);
+  };
+
+  const handleSubmitOverstyring = async (data: any) => {
+    return props.submitCallback(data, relevanteOverstyringsAksjonspunkter);
   };
 
   // Ikke vis panelet hvis det ikke finnes relevante vilkår
@@ -72,17 +76,19 @@ export function OpptjeningProsessStegInitPanel(props: Props) {
     kode => kode === AksjonspunktDefinisjon.OVERSTYRING_AV_OPPTJENINGSVILKÅRET,
   );
 
-  if (erAlleVilkårVurdert && !isAksjonspunktOpen) {
+  const skalViseOverstyringspanel = relevanteVurderingsAksjonspunkter.length === 0;
+
+  if (skalViseOverstyringspanel) {
     return (
       <VilkarresultatMedOverstyringProsessIndex
-        aksjonspunkter={[]}
+        aksjonspunkter={relevanteOverstyringsAksjonspunkter}
         behandling={{ type: props.behandling.type.kode as k9_kodeverk_behandling_BehandlingType }}
         panelTittelKode="Opptjening"
         vilkar={vilkårForSteg}
         erOverstyrt={erOverstyrt}
         overstyringApKode={AksjonspunktDefinisjon.OVERSTYRING_AV_OPPTJENINGSVILKÅRET}
         erMedlemskapsPanel={false}
-        submitCallback={handleSubmit}
+        submitCallback={handleSubmitOverstyring}
         overrideReadOnly={props.overrideReadOnly}
         kanOverstyreAccess={props.kanOverstyreAccess}
         toggleOverstyring={props.toggleOverstyring}
@@ -94,10 +100,10 @@ export function OpptjeningProsessStegInitPanel(props: Props) {
   if (opptjeningV2) {
     return (
       <OpptjeningVilkarProsessIndex
-        submitCallback={handleSubmit}
+        submitCallback={handleSubmitVurdering}
         isReadOnly={props.isReadOnly}
         behandling={props.behandling}
-        aksjonspunkter={relevanteAksjonspunkter}
+        aksjonspunkter={relevanteVurderingsAksjonspunkter}
         opptjening={opptjeningV2}
         visAllePerioder={props.visAllePerioder}
         vilkar={vilkårForSteg}


### PR DESCRIPTION
### Behov / Bakgrunn
Feil visning av panelstatus for flere paneler.
Opptjening viser ikke mulighet for å redigere aksjonspunkt.

### Løsning
Endrer i logikk for prosessmotor.
Endrer logikk for visning av overstyringspanel i Opptjening.

### Andre endringer

