### PR TITLE
Fix: legger til støtte for æøå i variabelnavn for sourcemaps

### DIFF
--- a/ung.vite.config.js
+++ b/ung.vite.config.js
@@ -132,6 +132,9 @@ export default ({ mode }) => {
         },
       }),
     ],
+    esbuild: {
+      charset: 'utf8',
+    },
     build: {
       // Relative to the root
       outDir: './dist/ung/web',

--- a/vite.config.js
+++ b/vite.config.js
@@ -127,6 +127,9 @@ export default ({ mode }) => {
         },
       }),
     ],
+    esbuild: {
+      charset: 'utf8',
+    },
     build: {
       // Relative to the root
       outDir: './dist/k9/web',


### PR DESCRIPTION
### Behov / Bakgrunn
Får ikke inspisert variabler med æøå i sourcemaps i feks Chrome. Virker som det bare treffer variabelnavn med æøå i seg.

### Løsning
Prøver å løse dette ved å tvinge UTF-8 i transpiler output.

### Andre endringer

