### PR TITLE
Skru av console echo når man ikke har faro collector url

### DIFF
--- a/packages/sak-app/src/bootstrap.tsx
+++ b/packages/sak-app/src/bootstrap.tsx
@@ -27,7 +27,7 @@ initSentry({
   release: VITE_SENTRY_RELEASE || 'unknown',
 });
 
-initApm({ namespace: 'k9saksbehandling', app: 'k9-sak-web', tracing: true });
+initApm({ namespace: 'k9saksbehandling', app: 'k9-sak-web', tracing: true, devConsoleEcho: false });
 
 const featureToggles = resolveK9FeatureToggles({ useQVersion: IS_DEV || isQ() });
 

--- a/packages/ung/sak-app/bootstrapUng.tsx
+++ b/packages/ung/sak-app/bootstrapUng.tsx
@@ -29,6 +29,7 @@ initApm({
   namespace: 'k9saksbehandling',
   app: 'ung-sak-web',
   tracing: true,
+  devConsoleEcho: false,
 });
 
 const featureToggles = resolveUngFeatureToggles({ useQVersion: IS_DEV || isQ() });


### PR DESCRIPTION
### Behov / Bakgrunn
Når man kjører appen lokalt blir alle events synlig i nettleser-konsollet som default. 

### Løsning
Vi skrur av dette slik at eventene ikke dukker opp i konsollet

