### PR TITLE
Minimer TopErrorPanel i utgangspunktet.

### DIFF
--- a/packages/v2/gui/src/app/errorhandling/ui/TopErrorPanel.tsx
+++ b/packages/v2/gui/src/app/errorhandling/ui/TopErrorPanel.tsx
@@ -19,7 +19,11 @@ interface TopErrorPanelUIProps {
 }
 
 /** Eksponert her kun for testing/storybook. Bruk TopErrorPanel direkte i app */
-export const TopErrorPanelUI = ({ errors: allErrors, aktivFagsakId, defaultExpanded = true }: TopErrorPanelUIProps) => {
+export const TopErrorPanelUI = ({
+  errors: allErrors,
+  aktivFagsakId,
+  defaultExpanded = false,
+}: TopErrorPanelUIProps) => {
   const [expanded, setExpanded] = useState(defaultExpanded);
 
   // Fjern påfølgjande duplikatfeil slik at brukar berre ser den siste i kvar gruppe av like feil.


### PR DESCRIPTION
### Behov / Bakgrunn

"Globale feil" i toppen av sida viste i utvida tilstand i utgangspunktet. Det var ønskelig at feilmeldinger ikkje skulle ta så mykje plass på sida.

### Løsning

Endre til å vise feilmeldingspanelet på toppen av sida i minimert tilstand i utgangspunktet.

Bestemt i slack tråd https://nav-it.slack.com/archives/C02M0NEFHNZ/p1785919729348579

