### PR TITLE
Ny ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ måten får vi gjort en gradvis overgang til bedre kontrollert typescript.
 Mer info om dette i [v2/README](./packages/v2/README.md)
 
 ## Bygg og utrulling
-Ved merge av **PR til master** branch blir koden bygd inn i et Docker image og rulla ut til testmiljø på https://k9.dev.intern.nav.no.
+Ved merge av **PR til master** branch blir koden bygd inn i et Docker image og rulla ut til testmiljø på https://k9.intern.dev.nav.no.
 Etter godkjenning i pipeline blir samme Docker image rulla ut i produksjon på https://k9.intern.nav.no/.
 
 Vi har også støtte for å rulle ut mer eksperimentelle endringer for test til https://k9-next1.dev.intern.nav.no. Dette

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Mer info om dette i [v2/README](./packages/v2/README.md)
 Ved merge av **PR til master** branch blir koden bygd inn i et Docker image og rulla ut til testmiljø på https://k9.intern.dev.nav.no.
 Etter godkjenning i pipeline blir samme Docker image rulla ut i produksjon på https://k9.intern.nav.no/.
 
-Vi har også støtte for å rulle ut mer eksperimentelle endringer for test til https://k9-next1.dev.intern.nav.no. Dette
+Vi har også støtte for å rulle ut mer eksperimentelle endringer for test til https://k9-next1.intern.dev.nav.no. Dette
 skjer automatisk ved merge av **PR til dev-next1** branch. Denne utrulling lever i 10 dager. Hvis det går lenger tid mellom
 hver nye utrulling her stenges servicen ned inntil det skjer en ny utrulling.
 

--- a/deploy/dev.yaml
+++ b/deploy/dev.yaml
@@ -1,6 +1,6 @@
 # Verdier for dev-fss.k9saksbehandling.yml ved utrulling frå master til Q
 name: k9-sak-web
-ingress: "https://k9.dev.intern.nav.no/"
+ingress: "https://k9.intern.dev.nav.no/"
 replicas:
   min: 2
   max: 3

--- a/deploy/ung/dev-aktivitetspenger.yaml
+++ b/deploy/ung/dev-aktivitetspenger.yaml
@@ -1,4 +1,4 @@
-# Verdier for dev-fss.k9saksbehandling.yml ved utrulling frå dev-next1 branch til k9-next1.dev.intern.nav.no
+# Verdier for dev-fss.k9saksbehandling.yml ved utrulling frå dev-next1 branch til k9-next1.intern.dev.nav.no
 name: aktivitetspenger-sak-web
 ingress: "https://aktivitetspenger.intern.dev.nav.no/"
 replicas:

--- a/packages/sak-app/src/app/paths.ts
+++ b/packages/sak-app/src/app/paths.ts
@@ -45,7 +45,7 @@ export const getPathToK9Los = v2GetPathToK9Los;
 
 export const getPathToK9Punsj = (): string | null => {
   const { host } = window.location;
-  if (host === 'app-q1.adeo.no' || host === 'k9.dev.intern.nav.no') {
+  if (host === 'k9.intern.dev.nav.no') {
     return 'https://k9-punsj-frontend.intern.dev.nav.no/';
   }
   if (host === 'app.adeo.no' || host === 'k9.intern.nav.no') {

--- a/packages/sak-app/src/configureStore.ts
+++ b/packages/sak-app/src/configureStore.ts
@@ -7,7 +7,7 @@ const isDevelopment = IS_DEV;
 
 const configureStore = () => {
   let enhancer;
-  if (isDevelopment || window.location.href.includes('dev.intern.nav.no')) {
+  if (isDevelopment || window.location.href.includes('intern.dev.nav.no')) {
     /* eslint-disable-next-line no-underscore-dangle */
     const composeEnhancers = (window && (window as any).__REDUX_DEVTOOLS_EXTENSION_COMPOSE__) || compose;
     enhancer = composeEnhancers(applyMiddleware(thunk));

--- a/packages/v2/gui/src/sak/dekoratør/HeaderPanel.tsx
+++ b/packages/v2/gui/src/sak/dekoratør/HeaderPanel.tsx
@@ -9,7 +9,7 @@ import styles from './headerPanel.module.css';
 const isRunningOnLocalhost = () => window.location.hostname === 'localhost';
 const isInDevelopmentModeOrTestEnvironment = () =>
   isRunningOnLocalhost() ||
-  window.location.hostname === 'k9.dev.intern.nav.no' ||
+  window.location.hostname === 'k9.intern.dev.nav.no' ||
   window.location.hostname === 'ung.intern.dev.nav.no' ||
   window.location.hostname === 'aktivitetspenger.intern.dev.nav.no';
 

--- a/packages/v2/gui/src/sak/dokumenter/components/DocumentList.tsx
+++ b/packages/v2/gui/src/sak/dokumenter/components/DocumentList.tsx
@@ -59,7 +59,7 @@ const getDirectionText = (document: Document): string => {
 
 const getModiaPath = (fødselsnummer?: string) => {
   const { host } = window.location;
-  if (host === 'app-q1.adeo.no' || host === 'k9.dev.intern.nav.no' || host === 'ung.intern.dev.nav.no') {
+  if (host === 'k9.intern.dev.nav.no' || host === 'ung.intern.dev.nav.no') {
     return `https://app-q1.adeo.no/modiapersonoversikt/person/${fødselsnummer}/meldinger/`;
   }
   if (host === 'app.adeo.no' || host === 'k9.intern.nav.no' || host === 'ung.intern.nav.no') {

--- a/packages/v2/lib/src/paths/paths.ts
+++ b/packages/v2/lib/src/paths/paths.ts
@@ -1,7 +1,7 @@
 const { DEV: IS_DEV } = import.meta.env;
 export const AINNTEKT_URL = 'https://arbeid-og-inntekt.nais.adeo.no';
 
-const devHosts = ['k9.dev.intern.nav.no', 'ung.intern.dev.nav.no'];
+const devHosts = ['k9.intern.dev.nav.no', 'ung.intern.dev.nav.no'];
 const prodHosts = ['k9.intern.nav.no', 'ung.intern.nav.no'];
 
 export const getPathToK9Los = (): string | null => {

--- a/packages/v2/lib/src/paths/paths.ts
+++ b/packages/v2/lib/src/paths/paths.ts
@@ -49,9 +49,7 @@ export const goToSearch = () => {
 
 export const isDev = () => IS_DEV;
 
-export const isQ = (): boolean =>
-  window.location.hostname.toLowerCase().endsWith('.dev.intern.nav.no') ||
-  window.location.hostname.toLowerCase().endsWith('.intern.dev.nav.no');
+export const isQ = (): boolean => window.location.hostname.toLowerCase().endsWith('.intern.dev.nav.no');
 
 export const isProd = () => {
   const { host } = window.location;


### PR DESCRIPTION
### Behov / Bakgrunn
nais APM fungerer ikke i Q på grunn av at vi bruker en eldgammel ingress (dev.intern) som ikke telemetry-serveren tillater trafikk fra.

### Løsning
Gå over til intern.dev. Dette skulle vært gjort for flere år siden

### Andre endringer
app-q1.adeo.no var det man gikk over til dev.intern fra. Så den er mega deprecated
