### PR TITLE
Tsff 2854

### DIFF
--- a/packages/fakta-medisinsk-vilkår/src/ui/components/diagnosekodeoversikt/Diagnosekodeoversikt.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/diagnosekodeoversikt/Diagnosekodeoversikt.tsx
@@ -5,10 +5,9 @@ import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Erro
 import { initDiagnosekodeSearcher } from '@k9-sak-web/gui/shared/diagnosekodeVelger/diagnosekodeSearcher.js';
 import WriteAccessBoundContent from '@k9-sak-web/gui/shared/write-access-bound-content/WriteAccessBoundContent.js';
 import { Alert, Box, Heading, HStack, Loader } from '@navikt/ds-react';
-import { useMutation, useQueries, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import React, { type JSX } from 'react';
 import LinkRel from '../../../constants/LinkRel';
-import Diagnosekode from '../../../types/Diagnosekode';
 import { DiagnosekodeResponse } from '../../../types/DiagnosekodeResponse';
 import { findLinkByRel } from '../../../util/linkUtils';
 import { toLegacyDiagnosekode } from '../../../util/toLegacyDiagnosekode.js';
@@ -20,20 +19,6 @@ import Diagnosekodeliste from '../diagnosekodeliste/Diagnosekodeliste';
 // initialize diagnosekode searcher instance, with pagesize 8, so that it can be used both here and in the DiagnosekodeModal.
 // This reuse is possible since we don't use the paging functionality in the instance anyways.
 const diagnosekodeSearcher = initDiagnosekodeSearcher(8);
-
-const fetchDiagnosekoderByQuery = (queryString: string): Diagnosekode => {
-  const searchResult = diagnosekodeSearcher.search(queryString, 1);
-  // This function only returns the found diagnosecode if there is exactly one diagnosecode found.
-  if (searchResult.diagnosekoder.length === 1 && !searchResult.hasMore) {
-    return toLegacyDiagnosekode(searchResult.diagnosekoder[0]);
-  }
-  // If there are multiple diagnosecodes found, we check if there is a exact match for the queryString, and return that if it exists.
-  const exactMatch = searchResult.diagnosekoder.find(d => d.code === queryString);
-  if (exactMatch) {
-    return toLegacyDiagnosekode(exactMatch);
-  }
-  return { kode: queryString, beskrivelse: '' };
-};
 
 interface DiagnosekodeoversiktProps {
   onDiagnosekoderUpdated: () => void;
@@ -54,26 +39,33 @@ const Diagnosekodeoversikt = ({ onDiagnosekoderUpdated }: DiagnosekodeoversiktPr
     queryKey: ['diagnosekodeResponse'],
     throwOnError: ignore404Errors,
     queryFn: hentDiagnosekoder,
-    placeholderData: { diagnosekoder: [], links: [], behandlingUuid: '', versjon: null },
+    placeholderData: { diagnosekoder: [], links: [], behandlingUuid: '', versjon: '' },
     staleTime: 10000,
   });
 
-  const { diagnosekoder, links, behandlingUuid, versjon } = data;
+  const {
+    diagnosekoder,
+    links = [],
+    behandlingUuid,
+    versjon,
+  } = data || {
+    diagnosekoder: [],
+    links: [],
+    behandlingUuid: '',
+    versjon: '',
+  };
   const endreDiagnosekoderLink = findLinkByRel(LinkRel.ENDRE_DIAGNOSEKODER, links);
 
-  const { diagnosekodeObjekter, diagnosekodeObjekterLaster } = useQueries({
-    queries: diagnosekoder.map(diagnosekode => ({
-      queryKey: ['diagnosekode', diagnosekode],
-      queryFn: () => fetchDiagnosekoderByQuery(diagnosekode),
-      refetchOnWindowFocus: false,
-    })),
-    combine: results => {
-      return {
-        diagnosekodeObjekter: results.map(r => r.data).filter(d => d != null),
-        diagnosekodeObjekterLaster: results.some(r => r.isPending),
-      };
-    },
-  });
+  const diagnosekodeObjekter = React.useMemo(
+    () =>
+      diagnosekoder.map(kode => {
+        const match = diagnosekodeSearcher.diagnosekoderAndUppercased.find(
+          dk => dk.uppercased.code === kode.trim().toUpperCase(),
+        );
+        return match ? toLegacyDiagnosekode(match.diagnosekode) : { kode, beskrivelse: '' };
+      }),
+    [diagnosekoder],
+  );
 
   const focusAddButton = () => {
     if (addButtonRef.current) {
@@ -154,7 +146,7 @@ const Diagnosekodeoversikt = ({ onDiagnosekoderUpdated }: DiagnosekodeoversiktPr
               Ingen diagnosekode registrert.
             </Alert>
           )}
-          {diagnosekoder.length >= 1 && !diagnosekodeObjekterLaster && (
+          {diagnosekoder.length >= 1 && (
             <Diagnosekodeliste diagnosekoder={diagnosekodeObjekter} onDeleteClick={slettDiagnosekodeMutation.mutate} />
           )}
         </Box>

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/diagnosekodeoversikt/Diagnosekodeoversikt.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/diagnosekodeoversikt/Diagnosekodeoversikt.tsx
@@ -27,10 +27,10 @@ const fetchDiagnosekoderByQuery = (queryString: string): Diagnosekode => {
   if (searchResult.diagnosekoder.length === 1 && !searchResult.hasMore) {
     return toLegacyDiagnosekode(searchResult.diagnosekoder[0]);
   }
-  // If there are multiple diagnosecodes found, we check if there is a perfect match for the queryString, and return that if it exists.
-  const perfectMatch = searchResult.diagnosekoder.find(d => d.code === queryString);
-  if (perfectMatch) {
-    return toLegacyDiagnosekode(perfectMatch);
+  // If there are multiple diagnosecodes found, we check if there is a exact match for the queryString, and return that if it exists.
+  const exactMatch = searchResult.diagnosekoder.find(d => d.code === queryString);
+  if (exactMatch) {
+    return toLegacyDiagnosekode(exactMatch);
   }
   return { kode: queryString, beskrivelse: '' };
 };

--- a/packages/fakta-medisinsk-vilkår/src/ui/components/diagnosekodeoversikt/Diagnosekodeoversikt.tsx
+++ b/packages/fakta-medisinsk-vilkår/src/ui/components/diagnosekodeoversikt/Diagnosekodeoversikt.tsx
@@ -1,11 +1,11 @@
 import { httpUtils } from '@fpsak-frontend/utils';
 import useRefetchBehandlingVedSykdomsendring from '../../hooks/useRefetchBehandlingVedSykdomsendring';
 
+import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 import { initDiagnosekodeSearcher } from '@k9-sak-web/gui/shared/diagnosekodeVelger/diagnosekodeSearcher.js';
 import WriteAccessBoundContent from '@k9-sak-web/gui/shared/write-access-bound-content/WriteAccessBoundContent.js';
 import { Alert, Box, Heading, HStack, Loader } from '@navikt/ds-react';
 import { useMutation, useQueries, useQuery } from '@tanstack/react-query';
-import { ignore404Errors } from '@k9-sak-web/gui/app/errorhandling/ignore404Errors.js';
 import React, { type JSX } from 'react';
 import LinkRel from '../../../constants/LinkRel';
 import Diagnosekode from '../../../types/Diagnosekode';
@@ -21,11 +21,16 @@ import Diagnosekodeliste from '../diagnosekodeliste/Diagnosekodeliste';
 // This reuse is possible since we don't use the paging functionality in the instance anyways.
 const diagnosekodeSearcher = initDiagnosekodeSearcher(8);
 
-const fetchDiagnosekoderByQuery = async (queryString: string): Promise<Diagnosekode> => {
+const fetchDiagnosekoderByQuery = (queryString: string): Diagnosekode => {
   const searchResult = diagnosekodeSearcher.search(queryString, 1);
   // This function only returns the found diagnosecode if there is exactly one diagnosecode found.
   if (searchResult.diagnosekoder.length === 1 && !searchResult.hasMore) {
     return toLegacyDiagnosekode(searchResult.diagnosekoder[0]);
+  }
+  // If there are multiple diagnosecodes found, we check if there is a perfect match for the queryString, and return that if it exists.
+  const perfectMatch = searchResult.diagnosekoder.find(d => d.code === queryString);
+  if (perfectMatch) {
+    return toLegacyDiagnosekode(perfectMatch);
   }
   return { kode: queryString, beskrivelse: '' };
 };


### PR DESCRIPTION
### Behov / Bakgrunn
Når komponenten skal hente ut navn på diagnosekode og koden er feks F321 får man tre treff: F321, F3210 og F3211. Med gammel logikk returneres bare F321 og man får ikke med navnet på diagnosen.

### Løsning
Dersom eksakt diagnosekode finnes bør man returnere den.

### Andre endringer

