### PR TITLE
fix: Retter visning av feil status for ti dager prosess

### DIFF
--- a/packages/v2/backend/src/k9sak/kontrakt/vilkår/VilkårPeriodeDto.ts
+++ b/packages/v2/backend/src/k9sak/kontrakt/vilkår/VilkårPeriodeDto.ts
@@ -1,0 +1,1 @@
+export type { k9_sak_kontrakt_vilkår_VilkårPeriodeDto as VilkårPeriodeDto } from '@k9-sak-web/backend/k9sak/generated/types.js';

--- a/packages/v2/gui/src/prosess/ti-dager/TiDagerProsessIndex.spec.tsx
+++ b/packages/v2/gui/src/prosess/ti-dager/TiDagerProsessIndex.spec.tsx
@@ -1,0 +1,112 @@
+import { vilkårStatus } from '@k9-sak-web/backend/k9sak/kodeverk/behandling/VilkårStatus.js';
+import type { VilkårMedPerioderDto } from '@k9-sak-web/backend/k9sak/kontrakt/vilkår/VilkårMedPerioderDto.js';
+import type { VilkårPeriodeDto } from '@k9-sak-web/backend/k9sak/kontrakt/vilkår/VilkårPeriodeDto.js';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import type { TiDagerBackendApiType } from './TiDagerBackendApiType.js';
+import { TiDagerBackendClientContext } from './TiDagerBackendClientContext.js';
+import { TiDagerProsessIndex } from './TiDagerProsessIndex.js';
+
+vi.mock('./TiDagerProsess.js', () => ({
+  TiDagerProsess: ({
+    vilkårErFerdigVurdert,
+    vilkårErOppfylt,
+  }: {
+    vilkårErFerdigVurdert: boolean;
+    vilkårErOppfylt: boolean;
+  }) => (
+    <div data-testid="TiDagerProsess">
+      <span data-testid="vilkårErFerdigVurdert">{String(vilkårErFerdigVurdert)}</span>
+      <span data-testid="vilkårErOppfylt">{String(vilkårErOppfylt)}</span>
+    </div>
+  ),
+}));
+
+const ingenJournalposter: TiDagerBackendApiType = {
+  hentRettFraDagEnOpplysninger: async () => ({ journalposter: [] }),
+};
+
+const createQueryClient = () => new QueryClient({ defaultOptions: { queries: { retry: false } } });
+
+const lagVilkår = (periodeStatuser: VilkårPeriodeDto['vilkarStatus'][]): VilkårMedPerioderDto[] => [
+  {
+    vilkarType: 'K9_VK_9_8',
+    relevanteInnvilgetMerknader: [],
+    perioder: periodeStatuser.map((status, i) => ({
+      vilkarStatus: status,
+      periode: { fom: `2026-04-0${i + 1}`, tom: `2026-04-0${i + 1}` },
+      vurderesIBehandlingen: true,
+      merknadParametere: {},
+    })),
+  },
+];
+
+const defaultProps = {
+  aksjonspunkter: [],
+  isReadOnly: false,
+  behandlingUUID: 'test-uuid',
+  saksnummer: '123',
+  submitCallback: vi.fn(),
+};
+
+const renderComponent = (vilkar: VilkårMedPerioderDto[], api = ingenJournalposter) =>
+  render(
+    <QueryClientProvider client={createQueryClient()}>
+      <TiDagerBackendClientContext value={api}>
+        <TiDagerProsessIndex {...defaultProps} vilkar={vilkar} />
+      </TiDagerBackendClientContext>
+    </QueryClientProvider>,
+  );
+
+describe('TiDagerProsessIndex', () => {
+  it('viser "10 dager har blitt dekket" når alle perioder er oppfylt og det ikke er journalposter', async () => {
+    renderComponent(lagVilkår([vilkårStatus.OPPFYLT, vilkårStatus.OPPFYLT]));
+
+    expect(await screen.findByText('10 dager har blitt dekket')).toBeInTheDocument();
+    expect(screen.queryByTestId('TiDagerProsess')).not.toBeInTheDocument();
+  });
+
+  it('viser TiDagerProsess når én periode er OPPFYLT og én er IKKE_VURDERT', async () => {
+    renderComponent(lagVilkår([vilkårStatus.OPPFYLT, vilkårStatus.IKKE_VURDERT]));
+
+    const prosess = await screen.findByTestId('TiDagerProsess');
+    expect(screen.queryByText('10 dager har blitt dekket')).not.toBeInTheDocument();
+    expect(prosess.querySelector('[data-testid="vilkårErFerdigVurdert"]')?.textContent).toBe('false');
+    expect(prosess.querySelector('[data-testid="vilkårErOppfylt"]')?.textContent).toBe('true');
+  });
+
+  it('vilkårErFerdigVurdert er true når alle perioder er vurdert', async () => {
+    renderComponent(lagVilkår([vilkårStatus.OPPFYLT, vilkårStatus.IKKE_OPPFYLT]));
+
+    const prosess = await screen.findByTestId('TiDagerProsess');
+    expect(prosess.querySelector('[data-testid="vilkårErFerdigVurdert"]')?.textContent).toBe('true');
+  });
+
+  it('vilkårErOppfylt er false når ingen perioder er oppfylt', async () => {
+    renderComponent(lagVilkår([vilkårStatus.IKKE_OPPFYLT, vilkårStatus.IKKE_OPPFYLT]));
+
+    const prosess = await screen.findByTestId('TiDagerProsess');
+    expect(prosess.querySelector('[data-testid="vilkårErOppfylt"]')?.textContent).toBe('false');
+  });
+
+  it('viser TiDagerProsess selv om alle perioder er oppfylt når det finnes journalposter', async () => {
+    const apiMedJournalpost: TiDagerBackendApiType = {
+      hentRettFraDagEnOpplysninger: async () => ({
+        journalposter: [
+          {
+            journalpostId: 'JP-001',
+            dokumentId: 'DOK-001',
+            arbeidsgiver: { arbeidsgiverOrgnr: '910909088' },
+            foersteOppgitteFravaersdag: '2026-04-01',
+          },
+        ],
+      }),
+    };
+
+    renderComponent(lagVilkår([vilkårStatus.OPPFYLT, vilkårStatus.OPPFYLT]), apiMedJournalpost);
+
+    expect(await screen.findByTestId('TiDagerProsess')).toBeInTheDocument();
+    expect(screen.queryByText('10 dager har blitt dekket')).not.toBeInTheDocument();
+  });
+});

--- a/packages/v2/gui/src/prosess/ti-dager/TiDagerProsessIndex.tsx
+++ b/packages/v2/gui/src/prosess/ti-dager/TiDagerProsessIndex.tsx
@@ -2,12 +2,12 @@ import { aksjonspunktStatus } from '@k9-sak-web/backend/k9sak/kodeverk/Aksjonspu
 import { vilkårStatus } from '@k9-sak-web/backend/k9sak/kodeverk/behandling/VilkårStatus.js';
 import type { AksjonspunktDto } from '@k9-sak-web/backend/k9sak/kontrakt/aksjonspunkt/AksjonspunktDto.js';
 import type { VilkårMedPerioderDto } from '@k9-sak-web/backend/k9sak/kontrakt/vilkår/VilkårMedPerioderDto.js';
+import type { VilkårPeriodeDto } from '@k9-sak-web/backend/k9sak/kontrakt/vilkår/VilkårPeriodeDto.js';
 import { formatDate } from '@k9-sak-web/gui/utils/formatters.js';
 import { CheckmarkCircleFillIcon, XMarkOctagonFillIcon } from '@navikt/aksel-icons';
 import { BodyShort, Box, Detail, Heading, HStack, Loader } from '@navikt/ds-react';
 import { SideMenu } from '@navikt/ft-plattform-komponenter';
 import { queryOptions, useQuery } from '@tanstack/react-query';
-
 import AksjonspunktIkon from '../../shared/aksjonspunkt-ikon/AksjonspunktIkon.js';
 import { Lovreferanse } from '../../shared/lovreferanse/Lovreferanse.js';
 import { hentAktivePerioderFraVilkar } from '../../utils/hentAktivePerioderFraVilkar.js';
@@ -15,14 +15,16 @@ import { useTiDagerBackendClient } from './TiDagerBackendClientContext.js';
 import { TiDagerProsess, type TiDagerSubmitModel } from './TiDagerProsess.js';
 import styles from './tiDagerProsessIndex.module.css';
 
-const getIconForPeriode = (vilkarStatus: string, erOverstyrt: boolean, harÅpentUløstAksjonspunkt: boolean) => {
+const getIconForPeriode = (perioder: VilkårPeriodeDto[], erOverstyrt: boolean, harÅpentUløstAksjonspunkt: boolean) => {
+  const harOppfyltPeriode = perioder.some(p => p.vilkarStatus === vilkårStatus.OPPFYLT);
+  const harBareAvslåttePerioder = perioder.every(p => p.vilkarStatus === vilkårStatus.IKKE_OPPFYLT);
   if (erOverstyrt || harÅpentUløstAksjonspunkt) {
     return <AksjonspunktIkon size="small" />;
   }
-  if (vilkarStatus === vilkårStatus.OPPFYLT) {
+  if (harOppfyltPeriode) {
     return <CheckmarkCircleFillIcon style={{ color: 'var(--ax-bg-success-strong)' }} />;
   }
-  if (vilkarStatus === vilkårStatus.IKKE_OPPFYLT) {
+  if (harBareAvslåttePerioder) {
     return <XMarkOctagonFillIcon style={{ color: 'var(--ax-bg-danger-strong)' }} />;
   }
   return null;
@@ -98,7 +100,7 @@ export const TiDagerProsessIndex = ({
 
   const activePeriodeStatus = perioder[0]!.vilkarStatus;
   const vilkårErFerdigVurdert = activePeriodeStatus !== vilkårStatus.IKKE_VURDERT;
-  const vilkårErOppfylt = activePeriodeStatus === vilkårStatus.OPPFYLT;
+  const vilkårErOppfylt = perioder.some(p => p.vilkarStatus === vilkårStatus.OPPFYLT);
 
   return (
     <div className={styles.mainContainerWithSideMenu}>
@@ -107,7 +109,7 @@ export const TiDagerProsessIndex = ({
           links={perioder.map((p, i) => ({
             active: true,
             label: `${formatDate(p.periode.fom)} - ${formatDate(p.periode.tom)}${i < perioder.length - 1 ? ',' : ''}`,
-            icon: i === perioder.length - 1 ? getIconForPeriode(p.vilkarStatus, false, isAksjonspunktOpen) : undefined,
+            icon: i === perioder.length - 1 ? getIconForPeriode(perioder, false, isAksjonspunktOpen) : undefined,
           }))}
           onClick={() => {
             return;

--- a/packages/v2/gui/src/prosess/ti-dager/TiDagerProsessIndex.tsx
+++ b/packages/v2/gui/src/prosess/ti-dager/TiDagerProsessIndex.tsx
@@ -15,7 +15,7 @@ import { useTiDagerBackendClient } from './TiDagerBackendClientContext.js';
 import { TiDagerProsess, type TiDagerSubmitModel } from './TiDagerProsess.js';
 import styles from './tiDagerProsessIndex.module.css';
 
-const getIconForPeriode = (perioder: VilkårPeriodeDto[], erOverstyrt: boolean, harÅpentUløstAksjonspunkt: boolean) => {
+const getIconForPerioder = (perioder: VilkårPeriodeDto[], erOverstyrt: boolean, harÅpentUløstAksjonspunkt: boolean) => {
   const harOppfyltPeriode = perioder.some(p => p.vilkarStatus === vilkårStatus.OPPFYLT);
   const harBareAvslåttePerioder = perioder.every(p => p.vilkarStatus === vilkårStatus.IKKE_OPPFYLT);
   if (erOverstyrt || harÅpentUløstAksjonspunkt) {
@@ -98,8 +98,7 @@ export const TiDagerProsessIndex = ({
     vilkår.perioder.every(p => p.vilkarStatus === vilkårStatus.OPPFYLT) &&
     !harJournalposter;
 
-  const activePeriodeStatus = perioder[0]!.vilkarStatus;
-  const vilkårErFerdigVurdert = activePeriodeStatus !== vilkårStatus.IKKE_VURDERT;
+  const vilkårErFerdigVurdert = perioder.every(p => p.vilkarStatus !== vilkårStatus.IKKE_VURDERT);
   const vilkårErOppfylt = perioder.some(p => p.vilkarStatus === vilkårStatus.OPPFYLT);
 
   return (
@@ -109,7 +108,7 @@ export const TiDagerProsessIndex = ({
           links={perioder.map((p, i) => ({
             active: true,
             label: `${formatDate(p.periode.fom)} - ${formatDate(p.periode.tom)}${i < perioder.length - 1 ? ',' : ''}`,
-            icon: i === perioder.length - 1 ? getIconForPeriode(perioder, false, isAksjonspunktOpen) : undefined,
+            icon: i === perioder.length - 1 ? getIconForPerioder(perioder, false, isAksjonspunktOpen) : undefined,
           }))}
           onClick={() => {
             return;


### PR DESCRIPTION
### Behov / Bakgrunn
Ved flere inntektsmeldinger blir det feil visning av status i prosessteget.

### Løsning
Endrer logikk på hvordan status utledes.

### Andre endringer

