### PR TITLE
fix: venter til aksjonspunkter er lastet for valg av prosesspanel utl…

### DIFF
--- a/packages/behandling-pleiepenger/src/components/PleiepengerProsessV2.tsx
+++ b/packages/behandling-pleiepenger/src/components/PleiepengerProsessV2.tsx
@@ -108,7 +108,7 @@ export const PleiepengerProsessV2 = ({
 
   const k9SakProsessApi = useMemo(() => new K9SakProsessBackendClient(), []);
   const prosessteg = useProsessmotor({ api: k9SakProsessApi, behandling });
-  const { isPending: aksjonspunkterIkkeLastet } = useQuery(aksjonspunkterQueryOptions(k9SakProsessApi, behandling));
+  const { isFetching: aksjonspunkterIkkeLastet } = useQuery(aksjonspunkterQueryOptions(k9SakProsessApi, behandling));
 
   const bekreftAksjonspunktCallback = useBekreftAksjonspunkt({
     fagsak,

--- a/packages/behandling-pleiepenger/src/components/PleiepengerProsessV2.tsx
+++ b/packages/behandling-pleiepenger/src/components/PleiepengerProsessV2.tsx
@@ -14,9 +14,11 @@ import { ProsessMeny } from '@k9-sak-web/gui/behandling/prosess/ProsessMeny.js';
 import { Behandling, Fagsak, FagsakPerson } from '@k9-sak-web/types';
 import { Bleed, Box } from '@navikt/ds-react';
 import { k9_sak_kontrakt_aksjonspunkt_AksjonspunktDto } from '@navikt/k9-sak-typescript-client/types';
+import { useQuery } from '@tanstack/react-query';
 import { useBekreftAksjonspunkt } from '../hooks/useBekreftAksjonspunkt';
 import prosessStegPanelDefinisjoner from '../panelDefinisjoner/prosessStegPleiepengerPanelDefinisjoner';
 import { K9SakProsessBackendClient } from '../prosess/api/K9SakProsessBackendClient';
+import { aksjonspunkterQueryOptions } from '../prosess/api/k9SakQueryOptions';
 import { useProsessmotor } from '../prosess/api/Prosessmotor';
 import {
   BeregningsgrunnlagProsessStegInitPanel,
@@ -106,6 +108,7 @@ export const PleiepengerProsessV2 = ({
 
   const k9SakProsessApi = useMemo(() => new K9SakProsessBackendClient(), []);
   const prosessteg = useProsessmotor({ api: k9SakProsessApi, behandling });
+  const { isPending: aksjonspunkterIkkeLastet } = useQuery(aksjonspunkterQueryOptions(k9SakProsessApi, behandling));
 
   const bekreftAksjonspunktCallback = useBekreftAksjonspunkt({
     fagsak,
@@ -165,7 +168,7 @@ export const PleiepengerProsessV2 = ({
         tekstkode="FatterVedtakStatusModal.ModalDescriptionPleiepenger"
       />
 
-      <ProsessMeny steg={prosessteg}>
+      <ProsessMeny steg={prosessteg} erKlar={!aksjonspunkterIkkeLastet}>
         <Bleed marginInline="space-24">
           <Box padding="space-16" className={styles.prosessmenyWrapper}>
             {prosessStegPanelDefinisjoner.map(panelDef => {

--- a/packages/behandling-pleiepenger/src/components/PleiepengerProsessV2.tsx
+++ b/packages/behandling-pleiepenger/src/components/PleiepengerProsessV2.tsx
@@ -108,7 +108,7 @@ export const PleiepengerProsessV2 = ({
 
   const k9SakProsessApi = useMemo(() => new K9SakProsessBackendClient(), []);
   const prosessteg = useProsessmotor({ api: k9SakProsessApi, behandling });
-  const { isFetching: aksjonspunkterIkkeLastet } = useQuery(aksjonspunkterQueryOptions(k9SakProsessApi, behandling));
+  const { isFetching: aksjonspunkterLaster } = useQuery(aksjonspunkterQueryOptions(k9SakProsessApi, behandling));
 
   const bekreftAksjonspunktCallback = useBekreftAksjonspunkt({
     fagsak,
@@ -168,7 +168,7 @@ export const PleiepengerProsessV2 = ({
         tekstkode="FatterVedtakStatusModal.ModalDescriptionPleiepenger"
       />
 
-      <ProsessMeny steg={prosessteg} erKlar={!aksjonspunkterIkkeLastet}>
+      <ProsessMeny steg={prosessteg} erKlar={!aksjonspunkterLaster}>
         <Bleed marginInline="space-24">
           <Box padding="space-16" className={styles.prosessmenyWrapper}>
             {prosessStegPanelDefinisjoner.map(panelDef => {

--- a/packages/v2/gui/src/behandling/prosess/ProsessMeny.tsx
+++ b/packages/v2/gui/src/behandling/prosess/ProsessMeny.tsx
@@ -36,6 +36,8 @@ interface ProsessMenyProps {
    */
   children: React.ReactElement<ProsessPanelProps> | Array<React.ReactElement<ProsessPanelProps>>;
   steg: ProsessSteg[];
+  /** Om prosessmotor-data (f.eks. aksjonspunkter) er ferdig hentet. Når false hoppes URL-synkroniseringen over. */
+  erKlar?: boolean;
 }
 
 /**
@@ -59,7 +61,7 @@ interface ProsessMenyProps {
  * </ProsessMeny>
  * ```
  */
-export const ProsessMeny = ({ children, steg: prosessmotorSteg }: ProsessMenyProps) => {
+export const ProsessMeny = ({ children, steg: prosessmotorSteg, erKlar = true }: ProsessMenyProps) => {
   const [searchParams, setSearchParams] = useSearchParams();
   const [valgtPanelId, setValgtPanelId] = useState<string | null>(null);
   const sisteAktivtValgtePanelIdRef = useRef<string | null>(null);
@@ -94,6 +96,12 @@ export const ProsessMeny = ({ children, steg: prosessmotorSteg }: ProsessMenyPro
    * render-output direkte. Mutasjon av den skal ikke utløse en ekstra render-syklus.
    */
   useEffect(() => {
+    // Ikke velg panel før prosessmotor-data er ferdig hentet — ellers kan et midlertidig tomt
+    // datasett føre til at feil panel (f.eks. prosessmotorSteg[0]) blir valgt som default
+    if (!erKlar) {
+      return;
+    }
+
     const gyldigePanelIds = prosessmotorSteg.map(s => s.id);
     // Ekskluder aktivt panel — ved stale data kan det fremdeles vises som warning selv om det akkurat ble løst
     const panelMedAksjonspunkt = prosessmotorSteg.find(
@@ -152,7 +160,7 @@ export const ProsessMeny = ({ children, steg: prosessmotorSteg }: ProsessMenyPro
         return neste;
       });
     }
-  }, [urlPanelId, prosessmotorSteg, setSearchParams]);
+  }, [urlPanelId, prosessmotorSteg, setSearchParams, erKlar]);
 
   // Konverter panelregistreringer til ProcessMenu steps-format
   const steg = useMemo(() => {


### PR DESCRIPTION
…edes

### Behov / Bakgrunn
Det hender at utleding av hvilket prosesspanel som skal velges skjer før aksjonspunktdata er lastet ferdig. Dermed kan  "feil panel" settes som valgt.

### Løsning
Ønsker å vente til aksjonspunkt er lastet før man utleder hvilket panel som skal settes som aktivt.

### Andre endringer

